### PR TITLE
Update AttributeGraph from OpenGraph optimize/flags

### DIFF
--- a/AG/2021/AttributeGraph.xcframework/ios-arm64-x86_64-simulator/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/arm64-apple-ios-simulator.swiftinterface
+++ b/AG/2021/AttributeGraph.xcframework/ios-arm64-x86_64-simulator/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/arm64-apple-ios-simulator.swiftinterface
@@ -15,7 +15,7 @@ extension AnyAttribute {
     get
   }
   public func unsafeOffset(at offset: Swift.Int) -> AnyAttribute
-  public func setFlags(_ newFlags: Subgraph.Flags, mask: Subgraph.Flags)
+  public func setFlags(_ newFlags: AnyAttribute.Flags, mask: AnyAttribute.Flags)
   public func addInput(_ attribute: AnyAttribute, options: AGInputOptions = [], token: Swift.Int)
   public func addInput<Value>(_ attribute: AttributeGraph.Attribute<Value>, options: AGInputOptions = [], token: Swift.Int)
   public func visitBody<Body>(_ visitor: inout Body) where Body : AttributeGraph.AttributeBodyVisitor
@@ -96,11 +96,12 @@ public typealias AttributeUpdateBlock = () -> (Swift.UnsafeMutableRawPointer, An
   public func validate()
   public func addInput(_ attribute: AnyAttribute, options: AGInputOptions = [], token: Swift.Int)
   public func addInput<V>(_ attribute: AttributeGraph.Attribute<V>, options: AGInputOptions = [], token: Swift.Int)
-  public var flags: Subgraph.Flags {
+  public typealias Flags = AnyAttribute.Flags
+  public var flags: AttributeGraph.Attribute<Value>.Flags {
     get
     nonmutating set
   }
-  public func setFlags(_ newFlags: Subgraph.Flags, mask: Subgraph.Flags)
+  public func setFlags(_ newFlags: AttributeGraph.Attribute<Value>.Flags, mask: AttributeGraph.Attribute<Value>.Flags)
 }
 extension AttributeGraph.Attribute : Swift.Hashable {
   public static func == (a: AttributeGraph.Attribute<Value>, b: AttributeGraph.Attribute<Value>) -> Swift.Bool

--- a/AG/2021/AttributeGraph.xcframework/ios-arm64-x86_64-simulator/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/x86_64-apple-ios-simulator.swiftinterface
+++ b/AG/2021/AttributeGraph.xcframework/ios-arm64-x86_64-simulator/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/x86_64-apple-ios-simulator.swiftinterface
@@ -15,7 +15,7 @@ extension AnyAttribute {
     get
   }
   public func unsafeOffset(at offset: Swift.Int) -> AnyAttribute
-  public func setFlags(_ newFlags: Subgraph.Flags, mask: Subgraph.Flags)
+  public func setFlags(_ newFlags: AnyAttribute.Flags, mask: AnyAttribute.Flags)
   public func addInput(_ attribute: AnyAttribute, options: AGInputOptions = [], token: Swift.Int)
   public func addInput<Value>(_ attribute: AttributeGraph.Attribute<Value>, options: AGInputOptions = [], token: Swift.Int)
   public func visitBody<Body>(_ visitor: inout Body) where Body : AttributeGraph.AttributeBodyVisitor
@@ -96,11 +96,12 @@ public typealias AttributeUpdateBlock = () -> (Swift.UnsafeMutableRawPointer, An
   public func validate()
   public func addInput(_ attribute: AnyAttribute, options: AGInputOptions = [], token: Swift.Int)
   public func addInput<V>(_ attribute: AttributeGraph.Attribute<V>, options: AGInputOptions = [], token: Swift.Int)
-  public var flags: Subgraph.Flags {
+  public typealias Flags = AnyAttribute.Flags
+  public var flags: AttributeGraph.Attribute<Value>.Flags {
     get
     nonmutating set
   }
-  public func setFlags(_ newFlags: Subgraph.Flags, mask: Subgraph.Flags)
+  public func setFlags(_ newFlags: AttributeGraph.Attribute<Value>.Flags, mask: AttributeGraph.Attribute<Value>.Flags)
 }
 extension AttributeGraph.Attribute : Swift.Hashable {
   public static func == (a: AttributeGraph.Attribute<Value>, b: AttributeGraph.Attribute<Value>) -> Swift.Bool

--- a/AG/2021/AttributeGraph.xcframework/macos-arm64e-arm64-x86_64/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/arm64-apple-macos.swiftinterface
+++ b/AG/2021/AttributeGraph.xcframework/macos-arm64e-arm64-x86_64/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/arm64-apple-macos.swiftinterface
@@ -15,7 +15,7 @@ extension AnyAttribute {
     get
   }
   public func unsafeOffset(at offset: Swift.Int) -> AnyAttribute
-  public func setFlags(_ newFlags: Subgraph.Flags, mask: Subgraph.Flags)
+  public func setFlags(_ newFlags: AnyAttribute.Flags, mask: AnyAttribute.Flags)
   public func addInput(_ attribute: AnyAttribute, options: AGInputOptions = [], token: Swift.Int)
   public func addInput<Value>(_ attribute: AttributeGraph.Attribute<Value>, options: AGInputOptions = [], token: Swift.Int)
   public func visitBody<Body>(_ visitor: inout Body) where Body : AttributeGraph.AttributeBodyVisitor
@@ -96,11 +96,12 @@ public typealias AttributeUpdateBlock = () -> (Swift.UnsafeMutableRawPointer, An
   public func validate()
   public func addInput(_ attribute: AnyAttribute, options: AGInputOptions = [], token: Swift.Int)
   public func addInput<V>(_ attribute: AttributeGraph.Attribute<V>, options: AGInputOptions = [], token: Swift.Int)
-  public var flags: Subgraph.Flags {
+  public typealias Flags = AnyAttribute.Flags
+  public var flags: AttributeGraph.Attribute<Value>.Flags {
     get
     nonmutating set
   }
-  public func setFlags(_ newFlags: Subgraph.Flags, mask: Subgraph.Flags)
+  public func setFlags(_ newFlags: AttributeGraph.Attribute<Value>.Flags, mask: AttributeGraph.Attribute<Value>.Flags)
 }
 extension AttributeGraph.Attribute : Swift.Hashable {
   public static func == (a: AttributeGraph.Attribute<Value>, b: AttributeGraph.Attribute<Value>) -> Swift.Bool

--- a/AG/2021/AttributeGraph.xcframework/macos-arm64e-arm64-x86_64/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/arm64e-apple-macos.swiftinterface
+++ b/AG/2021/AttributeGraph.xcframework/macos-arm64e-arm64-x86_64/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/arm64e-apple-macos.swiftinterface
@@ -15,7 +15,7 @@ extension AnyAttribute {
     get
   }
   public func unsafeOffset(at offset: Swift.Int) -> AnyAttribute
-  public func setFlags(_ newFlags: Subgraph.Flags, mask: Subgraph.Flags)
+  public func setFlags(_ newFlags: AnyAttribute.Flags, mask: AnyAttribute.Flags)
   public func addInput(_ attribute: AnyAttribute, options: AGInputOptions = [], token: Swift.Int)
   public func addInput<Value>(_ attribute: AttributeGraph.Attribute<Value>, options: AGInputOptions = [], token: Swift.Int)
   public func visitBody<Body>(_ visitor: inout Body) where Body : AttributeGraph.AttributeBodyVisitor
@@ -96,11 +96,12 @@ public typealias AttributeUpdateBlock = () -> (Swift.UnsafeMutableRawPointer, An
   public func validate()
   public func addInput(_ attribute: AnyAttribute, options: AGInputOptions = [], token: Swift.Int)
   public func addInput<V>(_ attribute: AttributeGraph.Attribute<V>, options: AGInputOptions = [], token: Swift.Int)
-  public var flags: Subgraph.Flags {
+  public typealias Flags = AnyAttribute.Flags
+  public var flags: AttributeGraph.Attribute<Value>.Flags {
     get
     nonmutating set
   }
-  public func setFlags(_ newFlags: Subgraph.Flags, mask: Subgraph.Flags)
+  public func setFlags(_ newFlags: AttributeGraph.Attribute<Value>.Flags, mask: AttributeGraph.Attribute<Value>.Flags)
 }
 extension AttributeGraph.Attribute : Swift.Hashable {
   public static func == (a: AttributeGraph.Attribute<Value>, b: AttributeGraph.Attribute<Value>) -> Swift.Bool

--- a/AG/2021/AttributeGraph.xcframework/macos-arm64e-arm64-x86_64/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/x86_64-apple-macos.swiftinterface
+++ b/AG/2021/AttributeGraph.xcframework/macos-arm64e-arm64-x86_64/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/x86_64-apple-macos.swiftinterface
@@ -15,7 +15,7 @@ extension AnyAttribute {
     get
   }
   public func unsafeOffset(at offset: Swift.Int) -> AnyAttribute
-  public func setFlags(_ newFlags: Subgraph.Flags, mask: Subgraph.Flags)
+  public func setFlags(_ newFlags: AnyAttribute.Flags, mask: AnyAttribute.Flags)
   public func addInput(_ attribute: AnyAttribute, options: AGInputOptions = [], token: Swift.Int)
   public func addInput<Value>(_ attribute: AttributeGraph.Attribute<Value>, options: AGInputOptions = [], token: Swift.Int)
   public func visitBody<Body>(_ visitor: inout Body) where Body : AttributeGraph.AttributeBodyVisitor
@@ -96,11 +96,12 @@ public typealias AttributeUpdateBlock = () -> (Swift.UnsafeMutableRawPointer, An
   public func validate()
   public func addInput(_ attribute: AnyAttribute, options: AGInputOptions = [], token: Swift.Int)
   public func addInput<V>(_ attribute: AttributeGraph.Attribute<V>, options: AGInputOptions = [], token: Swift.Int)
-  public var flags: Subgraph.Flags {
+  public typealias Flags = AnyAttribute.Flags
+  public var flags: AttributeGraph.Attribute<Value>.Flags {
     get
     nonmutating set
   }
-  public func setFlags(_ newFlags: Subgraph.Flags, mask: Subgraph.Flags)
+  public func setFlags(_ newFlags: AttributeGraph.Attribute<Value>.Flags, mask: AttributeGraph.Attribute<Value>.Flags)
 }
 extension AttributeGraph.Attribute : Swift.Hashable {
   public static func == (a: AttributeGraph.Attribute<Value>, b: AttributeGraph.Attribute<Value>) -> Swift.Bool

--- a/AG/2024/AttributeGraph.xcframework/ios-arm64-x86_64-simulator/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/arm64-apple-ios-simulator.swiftinterface
+++ b/AG/2024/AttributeGraph.xcframework/ios-arm64-x86_64-simulator/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/arm64-apple-ios-simulator.swiftinterface
@@ -15,7 +15,7 @@ extension AnyAttribute {
     get
   }
   public func unsafeOffset(at offset: Swift.Int) -> AnyAttribute
-  public func setFlags(_ newFlags: Subgraph.Flags, mask: Subgraph.Flags)
+  public func setFlags(_ newFlags: AnyAttribute.Flags, mask: AnyAttribute.Flags)
   public func addInput(_ attribute: AnyAttribute, options: AGInputOptions = [], token: Swift.Int)
   public func addInput<Value>(_ attribute: AttributeGraph.Attribute<Value>, options: AGInputOptions = [], token: Swift.Int)
   public func visitBody<Body>(_ visitor: inout Body) where Body : AttributeGraph.AttributeBodyVisitor
@@ -96,11 +96,12 @@ public typealias AttributeUpdateBlock = () -> (Swift.UnsafeMutableRawPointer, An
   public func validate()
   public func addInput(_ attribute: AnyAttribute, options: AGInputOptions = [], token: Swift.Int)
   public func addInput<V>(_ attribute: AttributeGraph.Attribute<V>, options: AGInputOptions = [], token: Swift.Int)
-  public var flags: Subgraph.Flags {
+  public typealias Flags = AnyAttribute.Flags
+  public var flags: AttributeGraph.Attribute<Value>.Flags {
     get
     nonmutating set
   }
-  public func setFlags(_ newFlags: Subgraph.Flags, mask: Subgraph.Flags)
+  public func setFlags(_ newFlags: AttributeGraph.Attribute<Value>.Flags, mask: AttributeGraph.Attribute<Value>.Flags)
 }
 extension AttributeGraph.Attribute : Swift.Hashable {
   public static func == (a: AttributeGraph.Attribute<Value>, b: AttributeGraph.Attribute<Value>) -> Swift.Bool

--- a/AG/2024/AttributeGraph.xcframework/ios-arm64-x86_64-simulator/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/x86_64-apple-ios-simulator.swiftinterface
+++ b/AG/2024/AttributeGraph.xcframework/ios-arm64-x86_64-simulator/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/x86_64-apple-ios-simulator.swiftinterface
@@ -15,7 +15,7 @@ extension AnyAttribute {
     get
   }
   public func unsafeOffset(at offset: Swift.Int) -> AnyAttribute
-  public func setFlags(_ newFlags: Subgraph.Flags, mask: Subgraph.Flags)
+  public func setFlags(_ newFlags: AnyAttribute.Flags, mask: AnyAttribute.Flags)
   public func addInput(_ attribute: AnyAttribute, options: AGInputOptions = [], token: Swift.Int)
   public func addInput<Value>(_ attribute: AttributeGraph.Attribute<Value>, options: AGInputOptions = [], token: Swift.Int)
   public func visitBody<Body>(_ visitor: inout Body) where Body : AttributeGraph.AttributeBodyVisitor
@@ -96,11 +96,12 @@ public typealias AttributeUpdateBlock = () -> (Swift.UnsafeMutableRawPointer, An
   public func validate()
   public func addInput(_ attribute: AnyAttribute, options: AGInputOptions = [], token: Swift.Int)
   public func addInput<V>(_ attribute: AttributeGraph.Attribute<V>, options: AGInputOptions = [], token: Swift.Int)
-  public var flags: Subgraph.Flags {
+  public typealias Flags = AnyAttribute.Flags
+  public var flags: AttributeGraph.Attribute<Value>.Flags {
     get
     nonmutating set
   }
-  public func setFlags(_ newFlags: Subgraph.Flags, mask: Subgraph.Flags)
+  public func setFlags(_ newFlags: AttributeGraph.Attribute<Value>.Flags, mask: AttributeGraph.Attribute<Value>.Flags)
 }
 extension AttributeGraph.Attribute : Swift.Hashable {
   public static func == (a: AttributeGraph.Attribute<Value>, b: AttributeGraph.Attribute<Value>) -> Swift.Bool

--- a/AG/2024/AttributeGraph.xcframework/macos-arm64e-arm64-x86_64/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/arm64-apple-macos.swiftinterface
+++ b/AG/2024/AttributeGraph.xcframework/macos-arm64e-arm64-x86_64/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/arm64-apple-macos.swiftinterface
@@ -15,7 +15,7 @@ extension AnyAttribute {
     get
   }
   public func unsafeOffset(at offset: Swift.Int) -> AnyAttribute
-  public func setFlags(_ newFlags: Subgraph.Flags, mask: Subgraph.Flags)
+  public func setFlags(_ newFlags: AnyAttribute.Flags, mask: AnyAttribute.Flags)
   public func addInput(_ attribute: AnyAttribute, options: AGInputOptions = [], token: Swift.Int)
   public func addInput<Value>(_ attribute: AttributeGraph.Attribute<Value>, options: AGInputOptions = [], token: Swift.Int)
   public func visitBody<Body>(_ visitor: inout Body) where Body : AttributeGraph.AttributeBodyVisitor
@@ -96,11 +96,12 @@ public typealias AttributeUpdateBlock = () -> (Swift.UnsafeMutableRawPointer, An
   public func validate()
   public func addInput(_ attribute: AnyAttribute, options: AGInputOptions = [], token: Swift.Int)
   public func addInput<V>(_ attribute: AttributeGraph.Attribute<V>, options: AGInputOptions = [], token: Swift.Int)
-  public var flags: Subgraph.Flags {
+  public typealias Flags = AnyAttribute.Flags
+  public var flags: AttributeGraph.Attribute<Value>.Flags {
     get
     nonmutating set
   }
-  public func setFlags(_ newFlags: Subgraph.Flags, mask: Subgraph.Flags)
+  public func setFlags(_ newFlags: AttributeGraph.Attribute<Value>.Flags, mask: AttributeGraph.Attribute<Value>.Flags)
 }
 extension AttributeGraph.Attribute : Swift.Hashable {
   public static func == (a: AttributeGraph.Attribute<Value>, b: AttributeGraph.Attribute<Value>) -> Swift.Bool

--- a/AG/2024/AttributeGraph.xcframework/macos-arm64e-arm64-x86_64/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/arm64e-apple-macos.swiftinterface
+++ b/AG/2024/AttributeGraph.xcframework/macos-arm64e-arm64-x86_64/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/arm64e-apple-macos.swiftinterface
@@ -15,7 +15,7 @@ extension AnyAttribute {
     get
   }
   public func unsafeOffset(at offset: Swift.Int) -> AnyAttribute
-  public func setFlags(_ newFlags: Subgraph.Flags, mask: Subgraph.Flags)
+  public func setFlags(_ newFlags: AnyAttribute.Flags, mask: AnyAttribute.Flags)
   public func addInput(_ attribute: AnyAttribute, options: AGInputOptions = [], token: Swift.Int)
   public func addInput<Value>(_ attribute: AttributeGraph.Attribute<Value>, options: AGInputOptions = [], token: Swift.Int)
   public func visitBody<Body>(_ visitor: inout Body) where Body : AttributeGraph.AttributeBodyVisitor
@@ -96,11 +96,12 @@ public typealias AttributeUpdateBlock = () -> (Swift.UnsafeMutableRawPointer, An
   public func validate()
   public func addInput(_ attribute: AnyAttribute, options: AGInputOptions = [], token: Swift.Int)
   public func addInput<V>(_ attribute: AttributeGraph.Attribute<V>, options: AGInputOptions = [], token: Swift.Int)
-  public var flags: Subgraph.Flags {
+  public typealias Flags = AnyAttribute.Flags
+  public var flags: AttributeGraph.Attribute<Value>.Flags {
     get
     nonmutating set
   }
-  public func setFlags(_ newFlags: Subgraph.Flags, mask: Subgraph.Flags)
+  public func setFlags(_ newFlags: AttributeGraph.Attribute<Value>.Flags, mask: AttributeGraph.Attribute<Value>.Flags)
 }
 extension AttributeGraph.Attribute : Swift.Hashable {
   public static func == (a: AttributeGraph.Attribute<Value>, b: AttributeGraph.Attribute<Value>) -> Swift.Bool

--- a/AG/2024/AttributeGraph.xcframework/macos-arm64e-arm64-x86_64/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/x86_64-apple-macos.swiftinterface
+++ b/AG/2024/AttributeGraph.xcframework/macos-arm64e-arm64-x86_64/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/x86_64-apple-macos.swiftinterface
@@ -15,7 +15,7 @@ extension AnyAttribute {
     get
   }
   public func unsafeOffset(at offset: Swift.Int) -> AnyAttribute
-  public func setFlags(_ newFlags: Subgraph.Flags, mask: Subgraph.Flags)
+  public func setFlags(_ newFlags: AnyAttribute.Flags, mask: AnyAttribute.Flags)
   public func addInput(_ attribute: AnyAttribute, options: AGInputOptions = [], token: Swift.Int)
   public func addInput<Value>(_ attribute: AttributeGraph.Attribute<Value>, options: AGInputOptions = [], token: Swift.Int)
   public func visitBody<Body>(_ visitor: inout Body) where Body : AttributeGraph.AttributeBodyVisitor
@@ -96,11 +96,12 @@ public typealias AttributeUpdateBlock = () -> (Swift.UnsafeMutableRawPointer, An
   public func validate()
   public func addInput(_ attribute: AnyAttribute, options: AGInputOptions = [], token: Swift.Int)
   public func addInput<V>(_ attribute: AttributeGraph.Attribute<V>, options: AGInputOptions = [], token: Swift.Int)
-  public var flags: Subgraph.Flags {
+  public typealias Flags = AnyAttribute.Flags
+  public var flags: AttributeGraph.Attribute<Value>.Flags {
     get
     nonmutating set
   }
-  public func setFlags(_ newFlags: Subgraph.Flags, mask: Subgraph.Flags)
+  public func setFlags(_ newFlags: AttributeGraph.Attribute<Value>.Flags, mask: AttributeGraph.Attribute<Value>.Flags)
 }
 extension AttributeGraph.Attribute : Swift.Hashable {
   public static func == (a: AttributeGraph.Attribute<Value>, b: AttributeGraph.Attribute<Value>) -> Swift.Bool

--- a/AG/2024/Sources/Modules/AttributeGraph.swiftmodule/template.swiftinterface
+++ b/AG/2024/Sources/Modules/AttributeGraph.swiftmodule/template.swiftinterface
@@ -11,7 +11,7 @@ extension AnyAttribute {
     get
   }
   public func unsafeOffset(at offset: Swift.Int) -> AnyAttribute
-  public func setFlags(_ newFlags: Subgraph.Flags, mask: Subgraph.Flags)
+  public func setFlags(_ newFlags: AnyAttribute.Flags, mask: AnyAttribute.Flags)
   public func addInput(_ attribute: AnyAttribute, options: AGInputOptions = [], token: Swift.Int)
   public func addInput<Value>(_ attribute: AttributeGraph.Attribute<Value>, options: AGInputOptions = [], token: Swift.Int)
   public func visitBody<Body>(_ visitor: inout Body) where Body : AttributeGraph.AttributeBodyVisitor
@@ -92,11 +92,12 @@ public typealias AttributeUpdateBlock = () -> (Swift.UnsafeMutableRawPointer, An
   public func validate()
   public func addInput(_ attribute: AnyAttribute, options: AGInputOptions = [], token: Swift.Int)
   public func addInput<V>(_ attribute: AttributeGraph.Attribute<V>, options: AGInputOptions = [], token: Swift.Int)
-  public var flags: Subgraph.Flags {
+  public typealias Flags = AnyAttribute.Flags
+  public var flags: AttributeGraph.Attribute<Value>.Flags {
     get
     nonmutating set
   }
-  public func setFlags(_ newFlags: Subgraph.Flags, mask: Subgraph.Flags)
+  public func setFlags(_ newFlags: AttributeGraph.Attribute<Value>.Flags, mask: AttributeGraph.Attribute<Value>.Flags)
 }
 extension AttributeGraph.Attribute : Swift.Hashable {
   public static func == (a: AttributeGraph.Attribute<Value>, b: AttributeGraph.Attribute<Value>) -> Swift.Bool


### PR DESCRIPTION
Automated update of AttributeGraph framework from OpenGraph.

**Changes:**
- Updated headers from OpenGraph sources
- Updated Swift interface template
- Updated xcframework binaries

**Source Branch:** optimize/flags
**Generated by:** OpenGraph bump script