### PR TITLE
Update AttributeGraph from OpenAttributeGraph feature/wasModified

### DIFF
--- a/AG/2021/AttributeGraph.xcframework/ios-arm64-arm64e/AttributeGraph.framework/Headers/AGAttribute.h
+++ b/AG/2021/AttributeGraph.xcframework/ios-arm64-arm64e/AttributeGraph.framework/Headers/AGAttribute.h
@@ -31,7 +31,7 @@ AGAttribute AGGraphGetCurrentAttribute(void);
 
 AG_EXPORT
 AG_REFINED_FOR_SWIFT
-bool AGGraphCurrentAttributeWasModified(void);
+bool AGGraphCurrentAttributeWasModified(void) AG_SWIFT_NAME(getter:AGAttribute.currentWasModified());
 
 AG_EXPORT
 AG_REFINED_FOR_SWIFT

--- a/AG/2021/AttributeGraph.xcframework/ios-arm64-x86_64-simulator/AttributeGraph.framework/Headers/AGAttribute.h
+++ b/AG/2021/AttributeGraph.xcframework/ios-arm64-x86_64-simulator/AttributeGraph.framework/Headers/AGAttribute.h
@@ -31,7 +31,7 @@ AGAttribute AGGraphGetCurrentAttribute(void);
 
 AG_EXPORT
 AG_REFINED_FOR_SWIFT
-bool AGGraphCurrentAttributeWasModified(void);
+bool AGGraphCurrentAttributeWasModified(void) AG_SWIFT_NAME(getter:AGAttribute.currentWasModified());
 
 AG_EXPORT
 AG_REFINED_FOR_SWIFT

--- a/AG/2021/AttributeGraph.xcframework/macos-arm64e-arm64-x86_64/AttributeGraph.framework/Headers/AGAttribute.h
+++ b/AG/2021/AttributeGraph.xcframework/macos-arm64e-arm64-x86_64/AttributeGraph.framework/Headers/AGAttribute.h
@@ -31,7 +31,7 @@ AGAttribute AGGraphGetCurrentAttribute(void);
 
 AG_EXPORT
 AG_REFINED_FOR_SWIFT
-bool AGGraphCurrentAttributeWasModified(void);
+bool AGGraphCurrentAttributeWasModified(void) AG_SWIFT_NAME(getter:AGAttribute.currentWasModified());
 
 AG_EXPORT
 AG_REFINED_FOR_SWIFT

--- a/AG/2024/AttributeGraph.xcframework/ios-arm64-arm64e/AttributeGraph.framework/Headers/AGAttribute.h
+++ b/AG/2024/AttributeGraph.xcframework/ios-arm64-arm64e/AttributeGraph.framework/Headers/AGAttribute.h
@@ -31,7 +31,7 @@ AGAttribute AGGraphGetCurrentAttribute(void);
 
 AG_EXPORT
 AG_REFINED_FOR_SWIFT
-bool AGGraphCurrentAttributeWasModified(void);
+bool AGGraphCurrentAttributeWasModified(void) AG_SWIFT_NAME(getter:AGAttribute.currentWasModified());
 
 AG_EXPORT
 AG_REFINED_FOR_SWIFT

--- a/AG/2024/AttributeGraph.xcframework/ios-arm64-x86_64-simulator/AttributeGraph.framework/Headers/AGAttribute.h
+++ b/AG/2024/AttributeGraph.xcframework/ios-arm64-x86_64-simulator/AttributeGraph.framework/Headers/AGAttribute.h
@@ -31,7 +31,7 @@ AGAttribute AGGraphGetCurrentAttribute(void);
 
 AG_EXPORT
 AG_REFINED_FOR_SWIFT
-bool AGGraphCurrentAttributeWasModified(void);
+bool AGGraphCurrentAttributeWasModified(void) AG_SWIFT_NAME(getter:AGAttribute.currentWasModified());
 
 AG_EXPORT
 AG_REFINED_FOR_SWIFT

--- a/AG/2024/AttributeGraph.xcframework/macos-arm64e-arm64-x86_64/AttributeGraph.framework/Headers/AGAttribute.h
+++ b/AG/2024/AttributeGraph.xcframework/macos-arm64e-arm64-x86_64/AttributeGraph.framework/Headers/AGAttribute.h
@@ -31,7 +31,7 @@ AGAttribute AGGraphGetCurrentAttribute(void);
 
 AG_EXPORT
 AG_REFINED_FOR_SWIFT
-bool AGGraphCurrentAttributeWasModified(void);
+bool AGGraphCurrentAttributeWasModified(void) AG_SWIFT_NAME(getter:AGAttribute.currentWasModified());
 
 AG_EXPORT
 AG_REFINED_FOR_SWIFT

--- a/AG/2024/Sources/Headers/AGAttribute.h
+++ b/AG/2024/Sources/Headers/AGAttribute.h
@@ -31,7 +31,7 @@ AGAttribute AGGraphGetCurrentAttribute(void);
 
 AG_EXPORT
 AG_REFINED_FOR_SWIFT
-bool AGGraphCurrentAttributeWasModified(void);
+bool AGGraphCurrentAttributeWasModified(void) AG_SWIFT_NAME(getter:AGAttribute.currentWasModified());
 
 AG_EXPORT
 AG_REFINED_FOR_SWIFT


### PR DESCRIPTION
Automated update of AttributeGraph framework from OpenAttributeGraph.

**Changes:**
- Updated headers from OpenAttributeGraph sources
- Updated Swift interface template
- Updated xcframework binaries

**Source Branch:** feature/wasModified
**Generated by:** OpenAttributeGraph bump script