### PR TITLE
Update AttributeGraph from OpenAttributeGraph subgraph-interface

### DIFF
--- a/AG/2021/AttributeGraph.xcframework/ios-arm64-arm64e/AttributeGraph.framework/Headers/AGGraph.h
+++ b/AG/2021/AttributeGraph.xcframework/ios-arm64-arm64e/AttributeGraph.framework/Headers/AGGraph.h
@@ -114,6 +114,14 @@ AG_REFINED_FOR_SWIFT
 bool AGGraphAnyInputsChanged(const AGAttribute *excluded_inputs, size_t count);
 #endif
 
+AG_EXPORT
+AG_REFINED_FOR_SWIFT
+bool AGGraphBeginDeferringSubgraphInvalidation(AGGraphRef graph) AG_SWIFT_NAME(AGGraphRef.beginDeferringSubgraphInvalidation(self:));
+
+AG_EXPORT
+AG_REFINED_FOR_SWIFT
+void AGGraphEndDeferringSubgraphInvalidation(AGGraphRef graph, bool was_deferring) AG_SWIFT_NAME(AGGraphRef.endDeferringSubgraphInvalidation(self:wasDeferring:));
+
 AG_EXTERN_C_END
 
 AG_IMPLICIT_BRIDGING_DISABLED

--- a/AG/2021/AttributeGraph.xcframework/ios-arm64-arm64e/AttributeGraph.framework/Headers/AGSubgraph.h
+++ b/AG/2021/AttributeGraph.xcframework/ios-arm64-arm64e/AttributeGraph.framework/Headers/AGSubgraph.h
@@ -22,7 +22,7 @@ AG_EXTERN_C_BEGIN
 
 AG_EXPORT
 AG_REFINED_FOR_SWIFT
-CFTypeID AGSubgraphGetTypeID();
+CFTypeID AGSubgraphGetTypeID(void) AG_SWIFT_NAME(getter:AGSubgraphRef.typeID());
 
 AG_EXPORT
 AG_REFINED_FOR_SWIFT
@@ -67,6 +67,26 @@ void AGSubgraphAddChild2(AGSubgraphRef parent, AGSubgraphRef child, uint8_t tag)
 AG_EXPORT
 AG_REFINED_FOR_SWIFT
 void AGSubgraphRemoveChild(AGSubgraphRef parent, AGSubgraphRef child) AG_SWIFT_NAME(AGSubgraphRef.removeChild(self:_:));
+
+AG_EXPORT
+AG_REFINED_FOR_SWIFT
+AGSubgraphRef AGSubgraphGetChild(AGSubgraphRef cf_subgraph, uint32_t index, uint8_t *_Nullable tag_out) AG_SWIFT_NAME(AGSubgraphRef.child(self:at:tag:));
+
+AG_EXPORT
+AG_REFINED_FOR_SWIFT
+uint32_t AGSubgraphGetChildCount(AGSubgraphRef cf_subgraph) AG_SWIFT_NAME(getter:AGSubgraphRef.childCount(self:));
+
+AG_EXPORT
+AG_REFINED_FOR_SWIFT
+AGSubgraphRef AGSubgraphGetParent(AGSubgraphRef cf_subgraph, int64_t index) AG_SWIFT_NAME(AGSubgraphRef.parent(self:at:));
+
+AG_EXPORT
+AG_REFINED_FOR_SWIFT
+uint64_t AGSubgraphGetParentCount(AGSubgraphRef cf_subgraph) AG_SWIFT_NAME(getter:AGSubgraphRef.parentCount(self:));
+
+AG_EXPORT
+AG_REFINED_FOR_SWIFT
+bool AGSubgraphIsAncestor(AGSubgraphRef cf_subgraph, AGSubgraphRef other) AG_SWIFT_NAME(AGSubgraphRef.isAncestor(self:of:));
 
 AG_EXPORT
 AG_REFINED_FOR_SWIFT

--- a/AG/2021/AttributeGraph.xcframework/ios-arm64-x86_64-simulator/AttributeGraph.framework/Headers/AGGraph.h
+++ b/AG/2021/AttributeGraph.xcframework/ios-arm64-x86_64-simulator/AttributeGraph.framework/Headers/AGGraph.h
@@ -114,6 +114,14 @@ AG_REFINED_FOR_SWIFT
 bool AGGraphAnyInputsChanged(const AGAttribute *excluded_inputs, size_t count);
 #endif
 
+AG_EXPORT
+AG_REFINED_FOR_SWIFT
+bool AGGraphBeginDeferringSubgraphInvalidation(AGGraphRef graph) AG_SWIFT_NAME(AGGraphRef.beginDeferringSubgraphInvalidation(self:));
+
+AG_EXPORT
+AG_REFINED_FOR_SWIFT
+void AGGraphEndDeferringSubgraphInvalidation(AGGraphRef graph, bool was_deferring) AG_SWIFT_NAME(AGGraphRef.endDeferringSubgraphInvalidation(self:wasDeferring:));
+
 AG_EXTERN_C_END
 
 AG_IMPLICIT_BRIDGING_DISABLED

--- a/AG/2021/AttributeGraph.xcframework/ios-arm64-x86_64-simulator/AttributeGraph.framework/Headers/AGSubgraph.h
+++ b/AG/2021/AttributeGraph.xcframework/ios-arm64-x86_64-simulator/AttributeGraph.framework/Headers/AGSubgraph.h
@@ -22,7 +22,7 @@ AG_EXTERN_C_BEGIN
 
 AG_EXPORT
 AG_REFINED_FOR_SWIFT
-CFTypeID AGSubgraphGetTypeID();
+CFTypeID AGSubgraphGetTypeID(void) AG_SWIFT_NAME(getter:AGSubgraphRef.typeID());
 
 AG_EXPORT
 AG_REFINED_FOR_SWIFT
@@ -67,6 +67,26 @@ void AGSubgraphAddChild2(AGSubgraphRef parent, AGSubgraphRef child, uint8_t tag)
 AG_EXPORT
 AG_REFINED_FOR_SWIFT
 void AGSubgraphRemoveChild(AGSubgraphRef parent, AGSubgraphRef child) AG_SWIFT_NAME(AGSubgraphRef.removeChild(self:_:));
+
+AG_EXPORT
+AG_REFINED_FOR_SWIFT
+AGSubgraphRef AGSubgraphGetChild(AGSubgraphRef cf_subgraph, uint32_t index, uint8_t *_Nullable tag_out) AG_SWIFT_NAME(AGSubgraphRef.child(self:at:tag:));
+
+AG_EXPORT
+AG_REFINED_FOR_SWIFT
+uint32_t AGSubgraphGetChildCount(AGSubgraphRef cf_subgraph) AG_SWIFT_NAME(getter:AGSubgraphRef.childCount(self:));
+
+AG_EXPORT
+AG_REFINED_FOR_SWIFT
+AGSubgraphRef AGSubgraphGetParent(AGSubgraphRef cf_subgraph, int64_t index) AG_SWIFT_NAME(AGSubgraphRef.parent(self:at:));
+
+AG_EXPORT
+AG_REFINED_FOR_SWIFT
+uint64_t AGSubgraphGetParentCount(AGSubgraphRef cf_subgraph) AG_SWIFT_NAME(getter:AGSubgraphRef.parentCount(self:));
+
+AG_EXPORT
+AG_REFINED_FOR_SWIFT
+bool AGSubgraphIsAncestor(AGSubgraphRef cf_subgraph, AGSubgraphRef other) AG_SWIFT_NAME(AGSubgraphRef.isAncestor(self:of:));
 
 AG_EXPORT
 AG_REFINED_FOR_SWIFT

--- a/AG/2021/AttributeGraph.xcframework/macos-arm64e-arm64-x86_64/AttributeGraph.framework/Headers/AGGraph.h
+++ b/AG/2021/AttributeGraph.xcframework/macos-arm64e-arm64-x86_64/AttributeGraph.framework/Headers/AGGraph.h
@@ -114,6 +114,14 @@ AG_REFINED_FOR_SWIFT
 bool AGGraphAnyInputsChanged(const AGAttribute *excluded_inputs, size_t count);
 #endif
 
+AG_EXPORT
+AG_REFINED_FOR_SWIFT
+bool AGGraphBeginDeferringSubgraphInvalidation(AGGraphRef graph) AG_SWIFT_NAME(AGGraphRef.beginDeferringSubgraphInvalidation(self:));
+
+AG_EXPORT
+AG_REFINED_FOR_SWIFT
+void AGGraphEndDeferringSubgraphInvalidation(AGGraphRef graph, bool was_deferring) AG_SWIFT_NAME(AGGraphRef.endDeferringSubgraphInvalidation(self:wasDeferring:));
+
 AG_EXTERN_C_END
 
 AG_IMPLICIT_BRIDGING_DISABLED

--- a/AG/2021/AttributeGraph.xcframework/macos-arm64e-arm64-x86_64/AttributeGraph.framework/Headers/AGSubgraph.h
+++ b/AG/2021/AttributeGraph.xcframework/macos-arm64e-arm64-x86_64/AttributeGraph.framework/Headers/AGSubgraph.h
@@ -22,7 +22,7 @@ AG_EXTERN_C_BEGIN
 
 AG_EXPORT
 AG_REFINED_FOR_SWIFT
-CFTypeID AGSubgraphGetTypeID();
+CFTypeID AGSubgraphGetTypeID(void) AG_SWIFT_NAME(getter:AGSubgraphRef.typeID());
 
 AG_EXPORT
 AG_REFINED_FOR_SWIFT
@@ -67,6 +67,26 @@ void AGSubgraphAddChild2(AGSubgraphRef parent, AGSubgraphRef child, uint8_t tag)
 AG_EXPORT
 AG_REFINED_FOR_SWIFT
 void AGSubgraphRemoveChild(AGSubgraphRef parent, AGSubgraphRef child) AG_SWIFT_NAME(AGSubgraphRef.removeChild(self:_:));
+
+AG_EXPORT
+AG_REFINED_FOR_SWIFT
+AGSubgraphRef AGSubgraphGetChild(AGSubgraphRef cf_subgraph, uint32_t index, uint8_t *_Nullable tag_out) AG_SWIFT_NAME(AGSubgraphRef.child(self:at:tag:));
+
+AG_EXPORT
+AG_REFINED_FOR_SWIFT
+uint32_t AGSubgraphGetChildCount(AGSubgraphRef cf_subgraph) AG_SWIFT_NAME(getter:AGSubgraphRef.childCount(self:));
+
+AG_EXPORT
+AG_REFINED_FOR_SWIFT
+AGSubgraphRef AGSubgraphGetParent(AGSubgraphRef cf_subgraph, int64_t index) AG_SWIFT_NAME(AGSubgraphRef.parent(self:at:));
+
+AG_EXPORT
+AG_REFINED_FOR_SWIFT
+uint64_t AGSubgraphGetParentCount(AGSubgraphRef cf_subgraph) AG_SWIFT_NAME(getter:AGSubgraphRef.parentCount(self:));
+
+AG_EXPORT
+AG_REFINED_FOR_SWIFT
+bool AGSubgraphIsAncestor(AGSubgraphRef cf_subgraph, AGSubgraphRef other) AG_SWIFT_NAME(AGSubgraphRef.isAncestor(self:of:));
 
 AG_EXPORT
 AG_REFINED_FOR_SWIFT

--- a/AG/2024/AttributeGraph.xcframework/ios-arm64-arm64e/AttributeGraph.framework/Headers/AGGraph.h
+++ b/AG/2024/AttributeGraph.xcframework/ios-arm64-arm64e/AttributeGraph.framework/Headers/AGGraph.h
@@ -114,6 +114,14 @@ AG_REFINED_FOR_SWIFT
 bool AGGraphAnyInputsChanged(const AGAttribute *excluded_inputs, size_t count);
 #endif
 
+AG_EXPORT
+AG_REFINED_FOR_SWIFT
+bool AGGraphBeginDeferringSubgraphInvalidation(AGGraphRef graph) AG_SWIFT_NAME(AGGraphRef.beginDeferringSubgraphInvalidation(self:));
+
+AG_EXPORT
+AG_REFINED_FOR_SWIFT
+void AGGraphEndDeferringSubgraphInvalidation(AGGraphRef graph, bool was_deferring) AG_SWIFT_NAME(AGGraphRef.endDeferringSubgraphInvalidation(self:wasDeferring:));
+
 AG_EXTERN_C_END
 
 AG_IMPLICIT_BRIDGING_DISABLED

--- a/AG/2024/AttributeGraph.xcframework/ios-arm64-arm64e/AttributeGraph.framework/Headers/AGSubgraph.h
+++ b/AG/2024/AttributeGraph.xcframework/ios-arm64-arm64e/AttributeGraph.framework/Headers/AGSubgraph.h
@@ -22,7 +22,7 @@ AG_EXTERN_C_BEGIN
 
 AG_EXPORT
 AG_REFINED_FOR_SWIFT
-CFTypeID AGSubgraphGetTypeID();
+CFTypeID AGSubgraphGetTypeID(void) AG_SWIFT_NAME(getter:AGSubgraphRef.typeID());
 
 AG_EXPORT
 AG_REFINED_FOR_SWIFT
@@ -67,6 +67,26 @@ void AGSubgraphAddChild2(AGSubgraphRef parent, AGSubgraphRef child, uint8_t tag)
 AG_EXPORT
 AG_REFINED_FOR_SWIFT
 void AGSubgraphRemoveChild(AGSubgraphRef parent, AGSubgraphRef child) AG_SWIFT_NAME(AGSubgraphRef.removeChild(self:_:));
+
+AG_EXPORT
+AG_REFINED_FOR_SWIFT
+AGSubgraphRef AGSubgraphGetChild(AGSubgraphRef cf_subgraph, uint32_t index, uint8_t *_Nullable tag_out) AG_SWIFT_NAME(AGSubgraphRef.child(self:at:tag:));
+
+AG_EXPORT
+AG_REFINED_FOR_SWIFT
+uint32_t AGSubgraphGetChildCount(AGSubgraphRef cf_subgraph) AG_SWIFT_NAME(getter:AGSubgraphRef.childCount(self:));
+
+AG_EXPORT
+AG_REFINED_FOR_SWIFT
+AGSubgraphRef AGSubgraphGetParent(AGSubgraphRef cf_subgraph, int64_t index) AG_SWIFT_NAME(AGSubgraphRef.parent(self:at:));
+
+AG_EXPORT
+AG_REFINED_FOR_SWIFT
+uint64_t AGSubgraphGetParentCount(AGSubgraphRef cf_subgraph) AG_SWIFT_NAME(getter:AGSubgraphRef.parentCount(self:));
+
+AG_EXPORT
+AG_REFINED_FOR_SWIFT
+bool AGSubgraphIsAncestor(AGSubgraphRef cf_subgraph, AGSubgraphRef other) AG_SWIFT_NAME(AGSubgraphRef.isAncestor(self:of:));
 
 AG_EXPORT
 AG_REFINED_FOR_SWIFT

--- a/AG/2024/AttributeGraph.xcframework/ios-arm64-x86_64-simulator/AttributeGraph.framework/Headers/AGGraph.h
+++ b/AG/2024/AttributeGraph.xcframework/ios-arm64-x86_64-simulator/AttributeGraph.framework/Headers/AGGraph.h
@@ -114,6 +114,14 @@ AG_REFINED_FOR_SWIFT
 bool AGGraphAnyInputsChanged(const AGAttribute *excluded_inputs, size_t count);
 #endif
 
+AG_EXPORT
+AG_REFINED_FOR_SWIFT
+bool AGGraphBeginDeferringSubgraphInvalidation(AGGraphRef graph) AG_SWIFT_NAME(AGGraphRef.beginDeferringSubgraphInvalidation(self:));
+
+AG_EXPORT
+AG_REFINED_FOR_SWIFT
+void AGGraphEndDeferringSubgraphInvalidation(AGGraphRef graph, bool was_deferring) AG_SWIFT_NAME(AGGraphRef.endDeferringSubgraphInvalidation(self:wasDeferring:));
+
 AG_EXTERN_C_END
 
 AG_IMPLICIT_BRIDGING_DISABLED

--- a/AG/2024/AttributeGraph.xcframework/ios-arm64-x86_64-simulator/AttributeGraph.framework/Headers/AGSubgraph.h
+++ b/AG/2024/AttributeGraph.xcframework/ios-arm64-x86_64-simulator/AttributeGraph.framework/Headers/AGSubgraph.h
@@ -22,7 +22,7 @@ AG_EXTERN_C_BEGIN
 
 AG_EXPORT
 AG_REFINED_FOR_SWIFT
-CFTypeID AGSubgraphGetTypeID();
+CFTypeID AGSubgraphGetTypeID(void) AG_SWIFT_NAME(getter:AGSubgraphRef.typeID());
 
 AG_EXPORT
 AG_REFINED_FOR_SWIFT
@@ -67,6 +67,26 @@ void AGSubgraphAddChild2(AGSubgraphRef parent, AGSubgraphRef child, uint8_t tag)
 AG_EXPORT
 AG_REFINED_FOR_SWIFT
 void AGSubgraphRemoveChild(AGSubgraphRef parent, AGSubgraphRef child) AG_SWIFT_NAME(AGSubgraphRef.removeChild(self:_:));
+
+AG_EXPORT
+AG_REFINED_FOR_SWIFT
+AGSubgraphRef AGSubgraphGetChild(AGSubgraphRef cf_subgraph, uint32_t index, uint8_t *_Nullable tag_out) AG_SWIFT_NAME(AGSubgraphRef.child(self:at:tag:));
+
+AG_EXPORT
+AG_REFINED_FOR_SWIFT
+uint32_t AGSubgraphGetChildCount(AGSubgraphRef cf_subgraph) AG_SWIFT_NAME(getter:AGSubgraphRef.childCount(self:));
+
+AG_EXPORT
+AG_REFINED_FOR_SWIFT
+AGSubgraphRef AGSubgraphGetParent(AGSubgraphRef cf_subgraph, int64_t index) AG_SWIFT_NAME(AGSubgraphRef.parent(self:at:));
+
+AG_EXPORT
+AG_REFINED_FOR_SWIFT
+uint64_t AGSubgraphGetParentCount(AGSubgraphRef cf_subgraph) AG_SWIFT_NAME(getter:AGSubgraphRef.parentCount(self:));
+
+AG_EXPORT
+AG_REFINED_FOR_SWIFT
+bool AGSubgraphIsAncestor(AGSubgraphRef cf_subgraph, AGSubgraphRef other) AG_SWIFT_NAME(AGSubgraphRef.isAncestor(self:of:));
 
 AG_EXPORT
 AG_REFINED_FOR_SWIFT

--- a/AG/2024/AttributeGraph.xcframework/macos-arm64e-arm64-x86_64/AttributeGraph.framework/Headers/AGGraph.h
+++ b/AG/2024/AttributeGraph.xcframework/macos-arm64e-arm64-x86_64/AttributeGraph.framework/Headers/AGGraph.h
@@ -114,6 +114,14 @@ AG_REFINED_FOR_SWIFT
 bool AGGraphAnyInputsChanged(const AGAttribute *excluded_inputs, size_t count);
 #endif
 
+AG_EXPORT
+AG_REFINED_FOR_SWIFT
+bool AGGraphBeginDeferringSubgraphInvalidation(AGGraphRef graph) AG_SWIFT_NAME(AGGraphRef.beginDeferringSubgraphInvalidation(self:));
+
+AG_EXPORT
+AG_REFINED_FOR_SWIFT
+void AGGraphEndDeferringSubgraphInvalidation(AGGraphRef graph, bool was_deferring) AG_SWIFT_NAME(AGGraphRef.endDeferringSubgraphInvalidation(self:wasDeferring:));
+
 AG_EXTERN_C_END
 
 AG_IMPLICIT_BRIDGING_DISABLED

--- a/AG/2024/AttributeGraph.xcframework/macos-arm64e-arm64-x86_64/AttributeGraph.framework/Headers/AGSubgraph.h
+++ b/AG/2024/AttributeGraph.xcframework/macos-arm64e-arm64-x86_64/AttributeGraph.framework/Headers/AGSubgraph.h
@@ -22,7 +22,7 @@ AG_EXTERN_C_BEGIN
 
 AG_EXPORT
 AG_REFINED_FOR_SWIFT
-CFTypeID AGSubgraphGetTypeID();
+CFTypeID AGSubgraphGetTypeID(void) AG_SWIFT_NAME(getter:AGSubgraphRef.typeID());
 
 AG_EXPORT
 AG_REFINED_FOR_SWIFT
@@ -67,6 +67,26 @@ void AGSubgraphAddChild2(AGSubgraphRef parent, AGSubgraphRef child, uint8_t tag)
 AG_EXPORT
 AG_REFINED_FOR_SWIFT
 void AGSubgraphRemoveChild(AGSubgraphRef parent, AGSubgraphRef child) AG_SWIFT_NAME(AGSubgraphRef.removeChild(self:_:));
+
+AG_EXPORT
+AG_REFINED_FOR_SWIFT
+AGSubgraphRef AGSubgraphGetChild(AGSubgraphRef cf_subgraph, uint32_t index, uint8_t *_Nullable tag_out) AG_SWIFT_NAME(AGSubgraphRef.child(self:at:tag:));
+
+AG_EXPORT
+AG_REFINED_FOR_SWIFT
+uint32_t AGSubgraphGetChildCount(AGSubgraphRef cf_subgraph) AG_SWIFT_NAME(getter:AGSubgraphRef.childCount(self:));
+
+AG_EXPORT
+AG_REFINED_FOR_SWIFT
+AGSubgraphRef AGSubgraphGetParent(AGSubgraphRef cf_subgraph, int64_t index) AG_SWIFT_NAME(AGSubgraphRef.parent(self:at:));
+
+AG_EXPORT
+AG_REFINED_FOR_SWIFT
+uint64_t AGSubgraphGetParentCount(AGSubgraphRef cf_subgraph) AG_SWIFT_NAME(getter:AGSubgraphRef.parentCount(self:));
+
+AG_EXPORT
+AG_REFINED_FOR_SWIFT
+bool AGSubgraphIsAncestor(AGSubgraphRef cf_subgraph, AGSubgraphRef other) AG_SWIFT_NAME(AGSubgraphRef.isAncestor(self:of:));
 
 AG_EXPORT
 AG_REFINED_FOR_SWIFT

--- a/AG/2024/Sources/Headers/AGGraph.h
+++ b/AG/2024/Sources/Headers/AGGraph.h
@@ -114,6 +114,14 @@ AG_REFINED_FOR_SWIFT
 bool AGGraphAnyInputsChanged(const AGAttribute *excluded_inputs, size_t count);
 #endif
 
+AG_EXPORT
+AG_REFINED_FOR_SWIFT
+bool AGGraphBeginDeferringSubgraphInvalidation(AGGraphRef graph) AG_SWIFT_NAME(AGGraphRef.beginDeferringSubgraphInvalidation(self:));
+
+AG_EXPORT
+AG_REFINED_FOR_SWIFT
+void AGGraphEndDeferringSubgraphInvalidation(AGGraphRef graph, bool was_deferring) AG_SWIFT_NAME(AGGraphRef.endDeferringSubgraphInvalidation(self:wasDeferring:));
+
 AG_EXTERN_C_END
 
 AG_IMPLICIT_BRIDGING_DISABLED

--- a/AG/2024/Sources/Headers/AGSubgraph.h
+++ b/AG/2024/Sources/Headers/AGSubgraph.h
@@ -22,7 +22,7 @@ AG_EXTERN_C_BEGIN
 
 AG_EXPORT
 AG_REFINED_FOR_SWIFT
-CFTypeID AGSubgraphGetTypeID();
+CFTypeID AGSubgraphGetTypeID(void) AG_SWIFT_NAME(getter:AGSubgraphRef.typeID());
 
 AG_EXPORT
 AG_REFINED_FOR_SWIFT
@@ -67,6 +67,26 @@ void AGSubgraphAddChild2(AGSubgraphRef parent, AGSubgraphRef child, uint8_t tag)
 AG_EXPORT
 AG_REFINED_FOR_SWIFT
 void AGSubgraphRemoveChild(AGSubgraphRef parent, AGSubgraphRef child) AG_SWIFT_NAME(AGSubgraphRef.removeChild(self:_:));
+
+AG_EXPORT
+AG_REFINED_FOR_SWIFT
+AGSubgraphRef AGSubgraphGetChild(AGSubgraphRef cf_subgraph, uint32_t index, uint8_t *_Nullable tag_out) AG_SWIFT_NAME(AGSubgraphRef.child(self:at:tag:));
+
+AG_EXPORT
+AG_REFINED_FOR_SWIFT
+uint32_t AGSubgraphGetChildCount(AGSubgraphRef cf_subgraph) AG_SWIFT_NAME(getter:AGSubgraphRef.childCount(self:));
+
+AG_EXPORT
+AG_REFINED_FOR_SWIFT
+AGSubgraphRef AGSubgraphGetParent(AGSubgraphRef cf_subgraph, int64_t index) AG_SWIFT_NAME(AGSubgraphRef.parent(self:at:));
+
+AG_EXPORT
+AG_REFINED_FOR_SWIFT
+uint64_t AGSubgraphGetParentCount(AGSubgraphRef cf_subgraph) AG_SWIFT_NAME(getter:AGSubgraphRef.parentCount(self:));
+
+AG_EXPORT
+AG_REFINED_FOR_SWIFT
+bool AGSubgraphIsAncestor(AGSubgraphRef cf_subgraph, AGSubgraphRef other) AG_SWIFT_NAME(AGSubgraphRef.isAncestor(self:of:));
 
 AG_EXPORT
 AG_REFINED_FOR_SWIFT


### PR DESCRIPTION
Automated update of AttributeGraph framework from OpenAttributeGraph.

**Changes:**
- Updated headers from OpenAttributeGraph sources
- Updated Swift interface template
- Updated xcframework binaries

**Source Branch:** subgraph-interface
**Generated by:** OpenAttributeGraph bump script