### PR TITLE
Add generate_swiftinterface.sh scripts for GF and AG frameworks

### DIFF
--- a/AG/2024/AttributeGraph.xcframework/ios-arm64-x86_64-simulator/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/arm64-apple-ios-simulator.swiftinterface
+++ b/AG/2024/AttributeGraph.xcframework/ios-arm64-x86_64-simulator/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/arm64-apple-ios-simulator.swiftinterface
@@ -7,19 +7,21 @@ public import Swift
 public import _Concurrency
 public import _StringProcessing
 public import _SwiftConcurrencyShims
-extension AnyAttribute {
+extension AttributeGraph.AnyAttribute {
   public init<Value>(_ attribute: AttributeGraph.Attribute<Value>)
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.Attribute<Value>
-  public static var current: AnyAttribute? {
+  #if compiler(>=5.3) && $NonescapableTypes
+  public static var current: AttributeGraph.AnyAttribute? {
     get
   }
-  public func unsafeOffset(at offset: Swift.Int) -> AnyAttribute
-  public func setFlags(_ newFlags: AnyAttribute.Flags, mask: AnyAttribute.Flags)
-  public func addInput(_ attribute: AnyAttribute, options: AGInputOptions = [], token: Swift.Int)
-  public func addInput<Value>(_ attribute: AttributeGraph.Attribute<Value>, options: AGInputOptions = [], token: Swift.Int)
+  #endif
+  public func unsafeOffset(at offset: Swift.Int) -> AttributeGraph.AnyAttribute
+  public func setFlags(_ newFlags: AttributeGraph.AnyAttribute.Flags, mask: AttributeGraph.AnyAttribute.Flags)
+  public func addInput(_ attribute: AttributeGraph.AnyAttribute, options: AttributeGraph.AGInputOptions = [], token: Swift.Int)
+  public func addInput<Value>(_ attribute: AttributeGraph.Attribute<Value>, options: AttributeGraph.AGInputOptions = [], token: Swift.Int)
   public func visitBody<Body>(_ visitor: inout Body) where Body : AttributeGraph.AttributeBodyVisitor
   public func mutateBody<Value>(as type: Value.Type, invalidating: Swift.Bool, _ body: (inout Value) -> Swift.Void)
-  public func breadthFirstSearch(options _: SearchOptions = [], _: (AnyAttribute) -> Swift.Bool) -> Swift.Bool
+  public func breadthFirstSearch(options _: AttributeGraph.SearchOptions = [], _: (AttributeGraph.AnyAttribute) -> Swift.Bool) -> Swift.Bool
   public var _bodyType: any Any.Type {
     get
   }
@@ -29,118 +31,19 @@ extension AnyAttribute {
   public var valueType: any Any.Type {
     get
   }
-  public var indirectDependency: AnyAttribute? {
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var indirectDependency: AttributeGraph.AnyAttribute? {
     get
     nonmutating set
   }
+  #endif
 }
-extension AnyAttribute : Swift.CustomStringConvertible {
+extension AttributeGraph.AnyAttribute : Swift.CustomStringConvertible {
   @inlinable public var description: Swift.String {
     get { "#\(rawValue)" }
   }
 }
-public typealias AttributeUpdateBlock = () -> (Swift.UnsafeMutableRawPointer, AnyAttribute) -> Swift.Void
-@frozen @propertyWrapper @dynamicMemberLookup public struct Attribute<Value> {
-  public var identifier: AnyAttribute
-  public init(identifier: AnyAttribute)
-  public init(_ attribute: AttributeGraph.Attribute<Value>)
-  public init(value: Value)
-  public init(type _: Value.Type)
-  public init<Body>(body: Swift.UnsafePointer<Body>, value: Swift.UnsafePointer<Value>?, flags: _AttributeType.Flags = [], update: () -> (Swift.UnsafeMutableRawPointer, AnyAttribute) -> Swift.Void) where Body : AttributeGraph._AttributeBody
-  public var wrappedValue: Value {
-    unsafeAddress
-    nonmutating set
-  }
-  public var projectedValue: AttributeGraph.Attribute<Value> {
-    get
-    set
-  }
-  public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member> {
-    get
-  }
-  public subscript<Member>(keyPath keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member> {
-    get
-  }
-  public subscript<Member>(offset body: (inout Value) -> AttributeGraph.PointerOffset<Value, Member>) -> AttributeGraph.Attribute<Member> {
-    get
-  }
-  public func unsafeCast<V>(to type: V.Type) -> AttributeGraph.Attribute<V>
-  public func unsafeOffset<Member>(at offset: Swift.Int, as _: Member.Type) -> AttributeGraph.Attribute<Member>
-  public func applying<Member>(offset: AttributeGraph.PointerOffset<Value, Member>) -> AttributeGraph.Attribute<Member>
-  public func visitBody<Body>(_ visitor: inout Body) where Body : AttributeGraph.AttributeBodyVisitor
-  public func mutateBody<V>(as type: V.Type, invalidating: Swift.Bool, _ body: (inout V) -> Swift.Void)
-  public func breadthFirstSearch(options: SearchOptions = [], _ body: (AnyAttribute) -> Swift.Bool) -> Swift.Bool
-  public var graph: Graph {
-    get
-  }
-  public var subgraph: Subgraph {
-    get
-  }
-  public var value: Value {
-    unsafeAddress
-    nonmutating set
-  }
-  public var valueState: ValueState {
-    get
-  }
-  public func valueAndFlags(options: AGValueOptions = []) -> (value: Value, flags: AGChangedValueFlags)
-  public func changedValue(options: AGValueOptions = []) -> (value: Value, changed: Swift.Bool)
-  public func setValue(_ value: Value) -> Swift.Bool
-  public var hasValue: Swift.Bool {
-    get
-  }
-  public func updateValue()
-  public func prefetchValue()
-  public func invalidateValue()
-  public func validate()
-  public func addInput(_ attribute: AnyAttribute, options: AGInputOptions = [], token: Swift.Int)
-  public func addInput<V>(_ attribute: AttributeGraph.Attribute<V>, options: AGInputOptions = [], token: Swift.Int)
-  public typealias Flags = AnyAttribute.Flags
-  public var flags: AttributeGraph.Attribute<Value>.Flags {
-    get
-    nonmutating set
-  }
-  public func setFlags(_ newFlags: AttributeGraph.Attribute<Value>.Flags, mask: AttributeGraph.Attribute<Value>.Flags)
-}
-extension AttributeGraph.Attribute : Swift.Hashable {
-  public static func == (a: AttributeGraph.Attribute<Value>, b: AttributeGraph.Attribute<Value>) -> Swift.Bool
-  public func hash(into hasher: inout Swift.Hasher)
-  public var hashValue: Swift.Int {
-    get
-  }
-}
-extension AttributeGraph.Attribute : Swift.CustomStringConvertible {
-  public var description: Swift.String {
-    get
-  }
-}
-extension AttributeGraph.Attribute {
-  public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.Rule
-  public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.StatefulRule
-}
-@_silgen_name("AGGraphCreateAttribute")
-@inline(__always) @inlinable internal func AGGraphCreateAttribute(index: Swift.Int, body: Swift.UnsafeRawPointer, value: Swift.UnsafeRawPointer?) -> AnyAttribute
-@_silgen_name("AGGraphGetValue")
-@inline(__always) @inlinable internal func AGGraphGetValue<Value>(_ attribute: AnyAttribute, options: AGValueOptions = [], type: Value.Type = Value.self) -> AGValue
-@_silgen_name("AGGraphSetValue")
-@inline(__always) @inlinable internal func AGGraphSetValue<Value>(_ attribute: AnyAttribute, valuePointer: Swift.UnsafePointer<Value>) -> Swift.Bool
-@frozen public struct External<Value> {
-  public init()
-}
-extension AttributeGraph.External : AttributeGraph._AttributeBody {
-  public static var comparisonMode: ComparisonMode {
-    get
-  }
-  public static var flags: AttributeGraph.External<Value>.Flags {
-    get
-  }
-  public static func _update(_: Swift.UnsafeMutableRawPointer, attribute _: AnyAttribute)
-}
-extension AttributeGraph.External : Swift.CustomStringConvertible {
-  public var description: Swift.String {
-    get
-  }
-}
+public typealias AttributeUpdateBlock = () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void
 @frozen public struct PointerOffset<Base, Member> {
   public var byteOffset: Swift.Int
   public init(byteOffset: Swift.Int)
@@ -169,27 +72,111 @@ extension Swift.UnsafeMutablePointer {
   }
   public static func + <Member>(lhs: Swift.UnsafeMutablePointer<Pointee>, rhs: AttributeGraph.PointerOffset<Pointee, Member>) -> Swift.UnsafeMutablePointer<Member>
 }
-public protocol _AttributeBody {
-  static func _destroySelf(_ pointer: Swift.UnsafeMutableRawPointer)
-  static var _hasDestroySelf: Swift.Bool { get }
-  static func _updateDefault(_ pointer: Swift.UnsafeMutableRawPointer)
-  static var comparisonMode: ComparisonMode { get }
-  typealias Flags = _AttributeType.Flags
-  static var flags: Self.Flags { get }
+@frozen public struct External<Value> {
+  public init()
 }
-extension AttributeGraph._AttributeBody {
-  public static func _destroySelf(_ pointer: Swift.UnsafeMutableRawPointer)
-  public static var _hasDestroySelf: Swift.Bool {
+extension AttributeGraph.External : AttributeGraph._AttributeBody {
+  public static var comparisonMode: AttributeGraph.ComparisonMode {
     get
   }
-  public static func _updateDefault(_ pointer: Swift.UnsafeMutableRawPointer)
-  public static var comparisonMode: ComparisonMode {
+  public static var flags: AttributeGraph.External<Value>.Flags {
     get
   }
-  public static var flags: Self.Flags {
+  public static func _update(_: Swift.UnsafeMutableRawPointer, attribute _: AttributeGraph.AnyAttribute)
+}
+extension AttributeGraph.External : Swift.CustomStringConvertible {
+  public var description: Swift.String {
     get
   }
 }
+@frozen @propertyWrapper @dynamicMemberLookup public struct Attribute<Value> {
+  public var identifier: AttributeGraph.AnyAttribute
+  public init(identifier: AttributeGraph.AnyAttribute)
+  public init(_ attribute: AttributeGraph.Attribute<Value>)
+  public init(value: Value)
+  public init(type _: Value.Type)
+  #if compiler(>=5.3) && $NonescapableTypes
+  public init<Body>(body: Swift.UnsafePointer<Body>, value: Swift.UnsafePointer<Value>?, flags: AttributeGraph._AttributeType.Flags = [], update: () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void) where Body : AttributeGraph._AttributeBody
+  #endif
+  public var wrappedValue: Value {
+    unsafeAddress
+    nonmutating set
+  }
+  public var projectedValue: AttributeGraph.Attribute<Value> {
+    get
+    set
+  }
+  public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member> {
+    get
+  }
+  public subscript<Member>(keyPath keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member> {
+    get
+  }
+  public subscript<Member>(offset body: (inout Value) -> AttributeGraph.PointerOffset<Value, Member>) -> AttributeGraph.Attribute<Member> {
+    get
+  }
+  public func unsafeCast<V>(to type: V.Type) -> AttributeGraph.Attribute<V>
+  public func unsafeOffset<Member>(at offset: Swift.Int, as _: Member.Type) -> AttributeGraph.Attribute<Member>
+  public func applying<Member>(offset: AttributeGraph.PointerOffset<Value, Member>) -> AttributeGraph.Attribute<Member>
+  public func visitBody<Body>(_ visitor: inout Body) where Body : AttributeGraph.AttributeBodyVisitor
+  public func mutateBody<V>(as type: V.Type, invalidating: Swift.Bool, _ body: (inout V) -> Swift.Void)
+  public func breadthFirstSearch(options: AttributeGraph.SearchOptions = [], _ body: (AttributeGraph.AnyAttribute) -> Swift.Bool) -> Swift.Bool
+  public var graph: AttributeGraph.Graph {
+    get
+  }
+  public var subgraph: AttributeGraph.Subgraph {
+    get
+  }
+  public var value: Value {
+    unsafeAddress
+    nonmutating set
+  }
+  public var valueState: AttributeGraph.ValueState {
+    get
+  }
+  public func valueAndFlags(options: AttributeGraph.AGValueOptions = []) -> (value: Value, flags: AttributeGraph.AGChangedValueFlags)
+  public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)
+  public func setValue(_ value: Value) -> Swift.Bool
+  public var hasValue: Swift.Bool {
+    get
+  }
+  public func updateValue()
+  public func prefetchValue()
+  public func invalidateValue()
+  public func validate()
+  public func addInput(_ attribute: AttributeGraph.AnyAttribute, options: AttributeGraph.AGInputOptions = [], token: Swift.Int)
+  public func addInput<V>(_ attribute: AttributeGraph.Attribute<V>, options: AttributeGraph.AGInputOptions = [], token: Swift.Int)
+  public typealias Flags = AttributeGraph.AnyAttribute.Flags
+  public var flags: AttributeGraph.Attribute<Value>.Flags {
+    get
+    nonmutating set
+  }
+  public func setFlags(_ newFlags: AttributeGraph.Attribute<Value>.Flags, mask: AttributeGraph.Attribute<Value>.Flags)
+}
+extension AttributeGraph.Attribute : Swift.Hashable {
+  public static func == (a: AttributeGraph.Attribute<Value>, b: AttributeGraph.Attribute<Value>) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+extension AttributeGraph.Attribute : Swift.CustomStringConvertible {
+  public var description: Swift.String {
+    get
+  }
+}
+extension AttributeGraph.Attribute {
+  public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.Rule
+  public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.StatefulRule
+}
+#if compiler(>=5.3) && $NonescapableTypes
+@_silgen_name("AGGraphCreateAttribute")
+@inline(__always) @inlinable internal func AGGraphCreateAttribute(index: Swift.Int, body: Swift.UnsafeRawPointer, value: Swift.UnsafeRawPointer?) -> AttributeGraph.AnyAttribute
+#endif
+@_silgen_name("AGGraphGetValue")
+@inline(__always) @inlinable internal func AGGraphGetValue<Value>(_ attribute: AttributeGraph.AnyAttribute, options: AttributeGraph.AGValueOptions = [], type: Value.Type = Value.self) -> AttributeGraph.AGValue
+@_silgen_name("AGGraphSetValue")
+@inline(__always) @inlinable internal func AGGraphSetValue<Value>(_ attribute: AttributeGraph.AnyAttribute, valuePointer: Swift.UnsafePointer<Value>) -> Swift.Bool
 public protocol AttributeBodyVisitor {
   func visit<Body>(body: Swift.UnsafePointer<Body>) where Body : AttributeGraph._AttributeBody
 }
@@ -202,23 +189,307 @@ extension AttributeGraph.ObservedAttribute {
     get
   }
 }
+public protocol _AttributeBody {
+  static func _destroySelf(_ pointer: Swift.UnsafeMutableRawPointer)
+  static var _hasDestroySelf: Swift.Bool { get }
+  static func _updateDefault(_ pointer: Swift.UnsafeMutableRawPointer)
+  static var comparisonMode: AttributeGraph.ComparisonMode { get }
+  typealias Flags = AttributeGraph._AttributeType.Flags
+  static var flags: Self.Flags { get }
+}
+extension AttributeGraph._AttributeBody {
+  public static func _destroySelf(_ pointer: Swift.UnsafeMutableRawPointer)
+  public static var _hasDestroySelf: Swift.Bool {
+    get
+  }
+  public static func _updateDefault(_ pointer: Swift.UnsafeMutableRawPointer)
+  public static var comparisonMode: AttributeGraph.ComparisonMode {
+    get
+  }
+  public static var flags: Self.Flags {
+    get
+  }
+}
+@frozen @propertyWrapper @dynamicMemberLookup public struct WeakAttribute<Value> {
+  internal var base: AttributeGraph.AnyWeakAttribute
+  public init(base: AttributeGraph.AnyWeakAttribute)
+  public init()
+  public init(_ attribute: AttributeGraph.Attribute<Value>)
+  #if compiler(>=5.3) && $NonescapableTypes
+  public init(_ attribute: AttributeGraph.Attribute<Value>?)
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var wrappedValue: Value? {
+    get
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var projectedValue: AttributeGraph.Attribute<Value>? {
+    get
+    set
+    _modify
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
+    get
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var attribute: AttributeGraph.Attribute<Value>? {
+    get
+    set
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var value: Value? {
+    get
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
+  #endif
+}
+extension AttributeGraph.WeakAttribute : Swift.Hashable {
+  public static func == (a: AttributeGraph.WeakAttribute<Value>, b: AttributeGraph.WeakAttribute<Value>) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+extension AttributeGraph.WeakAttribute : Swift.CustomStringConvertible {
+  public var description: Swift.String {
+    get
+  }
+}
+extension AttributeGraph.AnyWeakAttribute {
+  #if compiler(>=5.3) && $NonescapableTypes
+  public init(_ attribute: AttributeGraph.AnyAttribute?)
+  #endif
+  public init<Value>(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
+  public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.WeakAttribute<Value>
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var attribute: AttributeGraph.AnyAttribute? {
+    get
+    set
+  }
+  #endif
+}
+extension AttributeGraph.AnyWeakAttribute : Swift.Hashable {
+  public static func == (lhs: AttributeGraph.AnyWeakAttribute, rhs: AttributeGraph.AnyWeakAttribute) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+extension AttributeGraph.AnyWeakAttribute : Swift.CustomStringConvertible {
+  @_alwaysEmitIntoClient public var description: Swift.String {
+    get { attribute?.description ?? "nil" }
+  }
+}
+public protocol Rule : AttributeGraph._AttributeBody {
+  associatedtype Value
+  #if compiler(>=5.3) && $NonescapableTypes
+  static var initialValue: Self.Value? { get }
+  #endif
+  var value: Self.Value { get }
+}
+extension AttributeGraph.Rule {
+  #if compiler(>=5.3) && $NonescapableTypes
+  public static var initialValue: Self.Value? {
+    get
+  }
+  #endif
+  public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AttributeGraph.AnyAttribute)
+  public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
+}
+extension AttributeGraph.Rule {
+  public var attribute: AttributeGraph.Attribute<Self.Value> {
+    get
+  }
+  public var context: AttributeGraph.RuleContext<Self.Value> {
+    get
+  }
+}
+extension AttributeGraph.Rule where Self : Swift.Hashable {
+  #if compiler(>=5.3) && $NonescapableTypes
+  public func cachedValue(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?) -> Self.Value
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public func cachedValueIfExists(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?) -> Self.Value?
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public static func _cachedValue(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?, hashValue: Swift.Int, bodyPtr: Swift.UnsafeRawPointer, update: () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void) -> Swift.UnsafePointer<Self.Value>
+  #endif
+}
+@frozen public struct Map<Source, Value> : AttributeGraph.Rule, Swift.CustomStringConvertible {
+  public var arg: AttributeGraph.Attribute<Source>
+  public let body: (Source) -> Value
+  public init(_ arg: AttributeGraph.Attribute<Source>, _ body: @escaping (Source) -> Value)
+  public var value: Value {
+    get
+  }
+  public static var flags: AttributeGraph.Map<Source, Value>.Flags {
+    get
+  }
+  public var description: Swift.String {
+    get
+  }
+}
+public protocol StatefulRule : AttributeGraph._AttributeBody {
+  associatedtype Value
+  #if compiler(>=5.3) && $NonescapableTypes
+  static var initialValue: Self.Value? { get }
+  #endif
+  mutating func updateValue()
+}
+extension AttributeGraph.StatefulRule {
+  #if compiler(>=5.3) && $NonescapableTypes
+  public static var initialValue: Self.Value? {
+    get
+  }
+  #endif
+  public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AttributeGraph.AnyAttribute)
+  public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
+}
+extension AttributeGraph.StatefulRule {
+  public var attribute: AttributeGraph.Attribute<Self.Value> {
+    get
+  }
+  public var context: AttributeGraph.RuleContext<Self.Value> {
+    get
+  }
+  public var value: Self.Value {
+    unsafeAddress
+    nonmutating set
+  }
+  public var hasValue: Swift.Bool {
+    get
+  }
+}
+@frozen public struct Focus<Root, Value> : AttributeGraph.Rule, Swift.CustomStringConvertible {
+  public var root: AttributeGraph.Attribute<Root>
+  public var keyPath: Swift.KeyPath<Root, Value>
+  public init(root: AttributeGraph.Attribute<Root>, keyPath: Swift.KeyPath<Root, Value>)
+  public var value: Value {
+    get
+  }
+  public static var flags: AttributeGraph.Focus<Root, Value>.Flags {
+    get
+  }
+  public var description: Swift.String {
+    get
+  }
+}
+@frozen @propertyWrapper @dynamicMemberLookup public struct OptionalAttribute<Value> {
+  public var base: AttributeGraph.AnyOptionalAttribute
+  public init()
+  public init(base: AttributeGraph.AnyOptionalAttribute)
+  public init(_ attribute: AttributeGraph.Attribute<Value>)
+  #if compiler(>=5.3) && $NonescapableTypes
+  public init(_ attribute: AttributeGraph.Attribute<Value>?)
+  #endif
+  public init(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var attribute: AttributeGraph.Attribute<Value>? {
+    get
+    set
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var value: Value? {
+    get
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public func map<V>(_ body: (AttributeGraph.Attribute<Value>) -> V) -> V?
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var wrappedValue: Value? {
+    get
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var projectedValue: AttributeGraph.Attribute<Value>? {
+    get
+    set
+    _modify
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
+    get
+  }
+  #endif
+}
+extension AttributeGraph.OptionalAttribute : Swift.Hashable {
+  public static func == (a: AttributeGraph.OptionalAttribute<Value>, b: AttributeGraph.OptionalAttribute<Value>) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+extension AttributeGraph.OptionalAttribute : Swift.CustomStringConvertible {
+  public var description: Swift.String {
+    get
+  }
+}
+@frozen public struct AnyOptionalAttribute {
+  public var identifier: AttributeGraph.AnyAttribute
+  public init()
+  public init(_ attribute: AttributeGraph.AnyAttribute)
+  #if compiler(>=5.3) && $NonescapableTypes
+  public init(_ attribute: AttributeGraph.AnyAttribute?)
+  #endif
+  public init<Value>(_ attribute: AttributeGraph.OptionalAttribute<Value>)
+  public static var current: AttributeGraph.AnyOptionalAttribute {
+    get
+  }
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var attribute: AttributeGraph.AnyAttribute? {
+    get
+    set
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public func map<Value>(_ body: (AttributeGraph.AnyAttribute) -> Value) -> Value?
+  #endif
+  public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.OptionalAttribute<Value>
+}
+extension AttributeGraph.AnyOptionalAttribute : Swift.Hashable {
+  public static func == (a: AttributeGraph.AnyOptionalAttribute, b: AttributeGraph.AnyOptionalAttribute) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+extension AttributeGraph.AnyOptionalAttribute : Swift.CustomStringConvertible {
+  public var description: Swift.String {
+    get
+  }
+}
 @frozen @propertyWrapper @dynamicMemberLookup public struct IndirectAttribute<Value> {
-  public let identifier: AnyAttribute
+  public let identifier: AttributeGraph.AnyAttribute
   public init(source: AttributeGraph.Attribute<Value>)
   public var source: AttributeGraph.Attribute<Value> {
     get
     nonmutating set
   }
-  public var dependency: AnyAttribute? {
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var dependency: AttributeGraph.AnyAttribute? {
     get
     nonmutating set
   }
+  #endif
   public var value: Value {
     get
     nonmutating set
     nonmutating _modify
   }
-  public func changedValue(options: AGValueOptions = []) -> (value: Value, changed: Swift.Bool)
+  public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)
   public var wrappedValue: Value {
     get
     nonmutating set
@@ -238,169 +509,25 @@ extension AttributeGraph.IndirectAttribute : Swift.Hashable {
     get
   }
 }
-@frozen public struct AnyOptionalAttribute {
-  public var identifier: AnyAttribute
-  public init()
-  public init(_ attribute: AnyAttribute)
-  public init(_ attribute: AnyAttribute?)
-  public init<Value>(_ attribute: AttributeGraph.OptionalAttribute<Value>)
-  public static var current: AttributeGraph.AnyOptionalAttribute {
-    get
-  }
-  public var attribute: AnyAttribute? {
-    get
-    set
-  }
-  public func map<Value>(_ body: (AnyAttribute) -> Value) -> Value?
-  public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.OptionalAttribute<Value>
-}
-extension AttributeGraph.AnyOptionalAttribute : Swift.Hashable {
-  public static func == (a: AttributeGraph.AnyOptionalAttribute, b: AttributeGraph.AnyOptionalAttribute) -> Swift.Bool
-  public func hash(into hasher: inout Swift.Hasher)
-  public var hashValue: Swift.Int {
-    get
-  }
-}
-extension AttributeGraph.AnyOptionalAttribute : Swift.CustomStringConvertible {
-  public var description: Swift.String {
-    get
-  }
-}
-@frozen @propertyWrapper @dynamicMemberLookup public struct OptionalAttribute<Value> {
-  public var base: AttributeGraph.AnyOptionalAttribute
-  public init()
-  public init(base: AttributeGraph.AnyOptionalAttribute)
-  public init(_ attribute: AttributeGraph.Attribute<Value>)
-  public init(_ attribute: AttributeGraph.Attribute<Value>?)
-  public init(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
-  public var attribute: AttributeGraph.Attribute<Value>? {
-    get
-    set
-  }
-  public var value: Value? {
-    get
-  }
-  public func changedValue(options: AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
-  public func map<V>(_ body: (AttributeGraph.Attribute<Value>) -> V) -> V?
-  public var wrappedValue: Value? {
-    get
-  }
-  public var projectedValue: AttributeGraph.Attribute<Value>? {
-    get
-    set
-    _modify
-  }
-  public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
-    get
-  }
-}
-extension AttributeGraph.OptionalAttribute : Swift.Hashable {
-  public static func == (a: AttributeGraph.OptionalAttribute<Value>, b: AttributeGraph.OptionalAttribute<Value>) -> Swift.Bool
-  public func hash(into hasher: inout Swift.Hasher)
-  public var hashValue: Swift.Int {
-    get
-  }
-}
-extension AttributeGraph.OptionalAttribute : Swift.CustomStringConvertible {
-  public var description: Swift.String {
-    get
-  }
-}
-@frozen public struct Focus<Root, Value> : AttributeGraph.Rule, Swift.CustomStringConvertible {
-  public var root: AttributeGraph.Attribute<Root>
-  public var keyPath: Swift.KeyPath<Root, Value>
-  public init(root: AttributeGraph.Attribute<Root>, keyPath: Swift.KeyPath<Root, Value>)
-  public var value: Value {
-    get
-  }
-  public static var flags: AttributeGraph.Focus<Root, Value>.Flags {
-    get
-  }
-  public var description: Swift.String {
-    get
-  }
-}
-@frozen public struct Map<Source, Value> : AttributeGraph.Rule, Swift.CustomStringConvertible {
-  public var arg: AttributeGraph.Attribute<Source>
-  public let body: (Source) -> Value
-  public init(_ arg: AttributeGraph.Attribute<Source>, _ body: @escaping (Source) -> Value)
-  public var value: Value {
-    get
-  }
-  public static var flags: AttributeGraph.Map<Source, Value>.Flags {
-    get
-  }
-  public var description: Swift.String {
-    get
-  }
-}
-public protocol Rule : AttributeGraph._AttributeBody {
-  associatedtype Value
-  static var initialValue: Self.Value? { get }
-  var value: Self.Value { get }
-}
-extension AttributeGraph.Rule {
-  public static var initialValue: Self.Value? {
-    get
-  }
-  public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AnyAttribute)
-  public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
-}
-extension AttributeGraph.Rule {
-  public var attribute: AttributeGraph.Attribute<Self.Value> {
-    get
-  }
-  public var context: AttributeGraph.RuleContext<Self.Value> {
-    get
-  }
-}
-extension AttributeGraph.Rule where Self : Swift.Hashable {
-  public func cachedValue(options: AGCachedValueOptions = [], owner: AnyAttribute?) -> Self.Value
-  public func cachedValueIfExists(options: AGCachedValueOptions = [], owner: AnyAttribute?) -> Self.Value?
-  public static func _cachedValue(options: AGCachedValueOptions = [], owner: AnyAttribute?, hashValue: Swift.Int, bodyPtr: Swift.UnsafeRawPointer, update: () -> (Swift.UnsafeMutableRawPointer, AnyAttribute) -> Swift.Void) -> Swift.UnsafePointer<Self.Value>
-}
-public protocol StatefulRule : AttributeGraph._AttributeBody {
-  associatedtype Value
-  static var initialValue: Self.Value? { get }
-  mutating func updateValue()
-}
-extension AttributeGraph.StatefulRule {
-  public static var initialValue: Self.Value? {
-    get
-  }
-  public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AnyAttribute)
-  public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
-}
-extension AttributeGraph.StatefulRule {
-  public var attribute: AttributeGraph.Attribute<Self.Value> {
-    get
-  }
-  public var context: AttributeGraph.RuleContext<Self.Value> {
-    get
-  }
-  public var value: Self.Value {
-    unsafeAddress
-    nonmutating set
-  }
-  public var hasValue: Swift.Bool {
-    get
-  }
-}
 @frozen public struct AnyRuleContext : Swift.Equatable {
-  public var attribute: AnyAttribute
-  public init(attribute: AnyAttribute)
+  public var attribute: AttributeGraph.AnyAttribute
+  public init(attribute: AttributeGraph.AnyAttribute)
   public init<V>(_ context: AttributeGraph.RuleContext<V>)
   public subscript<V>(attribute: AttributeGraph.Attribute<V>) -> V {
     unsafeAddress
   }
+  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(weakAttribute: AttributeGraph.WeakAttribute<V>) -> V? {
     get
   }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(optionalAttribute: AttributeGraph.OptionalAttribute<V>) -> V? {
     get
   }
-  public func valueAndFlags<V>(of input: AttributeGraph.Attribute<V>, options: AGValueOptions = []) -> (value: V, flags: AGChangedValueFlags)
-  public func changedValue<V>(of input: AttributeGraph.Attribute<V>, options: AGValueOptions = []) -> (value: V, changed: Swift.Bool)
+  #endif
+  public func valueAndFlags<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, flags: AttributeGraph.AGChangedValueFlags)
+  public func changedValue<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, changed: Swift.Bool)
   public func update(body: () -> Swift.Void)
   public func unsafeCast<V>(to _: V.Type) -> AttributeGraph.RuleContext<V>
   public static func == (a: AttributeGraph.AnyRuleContext, b: AttributeGraph.AnyRuleContext) -> Swift.Bool
@@ -411,12 +538,16 @@ extension AttributeGraph.StatefulRule {
   public subscript<V>(attribute: AttributeGraph.Attribute<V>) -> V {
     unsafeAddress
   }
+  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(weakAttribute: AttributeGraph.WeakAttribute<V>) -> V? {
     get
   }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(optionalAttribute: AttributeGraph.OptionalAttribute<V>) -> V? {
     get
   }
+  #endif
   public var value: Value {
     unsafeAddress
     nonmutating set
@@ -424,86 +555,41 @@ extension AttributeGraph.StatefulRule {
   public var hasValue: Swift.Bool {
     get
   }
-  public func valueAndFlags<V>(of input: AttributeGraph.Attribute<V>, options: AGValueOptions = []) -> (value: V, flags: AGChangedValueFlags)
-  public func changedValue<V>(of input: AttributeGraph.Attribute<V>, options: AGValueOptions = []) -> (value: V, changed: Swift.Bool)
+  public func valueAndFlags<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, flags: AttributeGraph.AGChangedValueFlags)
+  public func changedValue<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, changed: Swift.Bool)
   public func update(body: () -> Swift.Void)
   public static func == (a: AttributeGraph.RuleContext<Value>, b: AttributeGraph.RuleContext<Value>) -> Swift.Bool
 }
 @_silgen_name("AGGraphGetInputValue")
-@inline(__always) @inlinable internal func AGGraphGetInputValue<Value>(_ attribute: AnyAttribute, input: AnyAttribute, options: AGValueOptions = [], type: Value.Type = Value.self) -> AGValue
+@inline(__always) @inlinable internal func AGGraphGetInputValue<Value>(_ attribute: AttributeGraph.AnyAttribute, input: AttributeGraph.AnyAttribute, options: AttributeGraph.AGValueOptions = [], type: Value.Type = Value.self) -> AttributeGraph.AGValue
 @_silgen_name("AGGraphWithUpdate")
-@inline(__always) @inlinable internal func AGGraphWithUpdate(_ attribute: AnyAttribute, body: () -> Swift.Void)
-extension AnyWeakAttribute {
-  public init(_ attribute: AnyAttribute?)
-  public init<Value>(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
-  public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.WeakAttribute<Value>
-  public var attribute: AnyAttribute? {
-    get
-    set
-  }
+@inline(__always) @inlinable internal func AGGraphWithUpdate(_ attribute: AttributeGraph.AnyAttribute, body: () -> Swift.Void)
+extension AttributeGraph.Subgraph {
+  public typealias Flags = AttributeGraph.AnyAttribute.Flags
+  public typealias ChildFlags = AttributeGraph.AnyAttribute.Flags
 }
-extension AnyWeakAttribute : Swift.Hashable {
-  public static func == (lhs: AnyWeakAttribute, rhs: AnyWeakAttribute) -> Swift.Bool
-  public func hash(into hasher: inout Swift.Hasher)
-  public var hashValue: Swift.Int {
-    get
-  }
+extension AttributeGraph.Subgraph {
+  public func addObserver(_ observer: @escaping () -> Swift.Void) -> Swift.Int
+  public func apply<Value>(_ body: () -> Value) -> Value
+  public func forEach(_ flags: AttributeGraph.Subgraph.Flags, _ callback: (AttributeGraph.AnyAttribute) -> Swift.Void)
 }
-extension AnyWeakAttribute : Swift.CustomStringConvertible {
-  @_alwaysEmitIntoClient public var description: Swift.String {
-    get { attribute?.description ?? "nil" }
-  }
+extension AttributeGraph.Subgraph {
+  public static func beginTreeElement<Value>(value: AttributeGraph.Attribute<Value>, flags: Swift.UInt32)
+  public static func addTreeValue<Value>(_ value: AttributeGraph.Attribute<Value>, forKey key: Swift.UnsafePointer<Swift.Int8>, flags: Swift.UInt32)
+  public static func endTreeElement<Value>(value: AttributeGraph.Attribute<Value>)
 }
-@frozen @propertyWrapper @dynamicMemberLookup public struct WeakAttribute<Value> {
-  internal var base: AnyWeakAttribute
-  public init(base: AnyWeakAttribute)
-  public init()
-  public init(_ attribute: AttributeGraph.Attribute<Value>)
-  public init(_ attribute: AttributeGraph.Attribute<Value>?)
-  public var wrappedValue: Value? {
-    get
-  }
-  public var projectedValue: AttributeGraph.Attribute<Value>? {
-    get
-    set
-    _modify
-  }
-  public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
-    get
-  }
-  public var attribute: AttributeGraph.Attribute<Value>? {
-    get
-    set
-  }
-  public var value: Value? {
-    get
-  }
-  public func changedValue(options: AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
+extension AttributeGraph.Graph {
+  public static func typeIndex(ctx: AttributeGraph.GraphContext, body: any AttributeGraph._AttributeBody.Type, valueType: AttributeGraph.Metadata, flags: AttributeGraph._AttributeType.Flags, update: () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void) -> Swift.Int
 }
-extension AttributeGraph.WeakAttribute : Swift.Hashable {
-  public static func == (a: AttributeGraph.WeakAttribute<Value>, b: AttributeGraph.WeakAttribute<Value>) -> Swift.Bool
-  public func hash(into hasher: inout Swift.Hasher)
-  public var hashValue: Swift.Int {
-    get
-  }
-}
-extension AttributeGraph.WeakAttribute : Swift.CustomStringConvertible {
-  public var description: Swift.String {
-    get
-  }
-}
-extension Graph {
-  public static func typeIndex(ctx: GraphContext, body: any AttributeGraph._AttributeBody.Type, valueType: Metadata, flags: _AttributeType.Flags, update: () -> (Swift.UnsafeMutableRawPointer, AnyAttribute) -> Swift.Void) -> Swift.Int
-}
-extension Graph {
+extension AttributeGraph.Graph {
   public static func withoutUpdate<V>(_ body: () -> V) -> V
   public func withoutSubgraphInvalidation<V>(_ body: () -> V) -> V
   public func withDeadline<V>(_: Swift.UInt64, _: () -> V) -> V
-  public func onInvalidation(_ callback: @escaping (AnyAttribute) -> Swift.Void)
+  public func onInvalidation(_ callback: @escaping (AttributeGraph.AnyAttribute) -> Swift.Void)
   public func onUpdate(_ callback: @escaping () -> Swift.Void)
   public func withMainThreadHandler(_: (() -> Swift.Void) -> Swift.Void, do: () -> Swift.Void)
 }
-extension Graph {
+extension AttributeGraph.Graph {
   @_transparent public func startProfiling() {
         __AGGraphStartProfiling(self)
     }
@@ -517,46 +603,31 @@ extension Graph {
   public static func stopProfiling()
   public static func resetProfile()
 }
-extension Graph {
+extension AttributeGraph.Graph {
   @_transparent public var mainUpdates: Swift.Int {
     @_transparent get { numericCast(counter(for: .mainThreadUpdates)) }
   }
 }
-extension Graph {
+extension AttributeGraph.Graph {
+  #if compiler(>=5.3) && $NonescapableTypes
   @_silgen_name("AGGraphGetOutputValue")
   @inline(__always) @inlinable public static func outputValue<Value>() -> Swift.UnsafePointer<Value>?
+  #endif
   @_silgen_name("AGGraphSetOutputValue")
   @inline(__always) @inlinable public static func setOutputValue<Value>(_ value: Swift.UnsafePointer<Value>)
 }
-extension Graph {
-  @_transparent public static func anyInputsChanged(excluding excludedInputs: [AnyAttribute]) -> Swift.Bool {
+extension AttributeGraph.Graph {
+  @_transparent public static func anyInputsChanged(excluding excludedInputs: [AttributeGraph.AnyAttribute]) -> Swift.Bool {
         return __AGGraphAnyInputsChanged(excludedInputs, excludedInputs.count)
     }
 }
-extension Graph {
+extension AttributeGraph.Graph {
+  #if compiler(>=5.3) && $NonescapableTypes
   public func archiveJSON(name: Swift.String?)
-}
-extension Subgraph {
-  public typealias Flags = AnyAttribute.Flags
-  public typealias ChildFlags = AnyAttribute.Flags
-}
-extension Subgraph {
-  public func addObserver(_ observer: @escaping () -> Swift.Void) -> Swift.Int
-  public func apply<Value>(_ body: () -> Value) -> Value
-  public func forEach(_ flags: Subgraph.Flags, _ callback: (AnyAttribute) -> Swift.Void)
-}
-extension Subgraph {
-  public static func beginTreeElement<Value>(value: AttributeGraph.Attribute<Value>, flags: Swift.UInt32)
-  public static func addTreeValue<Value>(_ value: AttributeGraph.Attribute<Value>, forKey key: Swift.UnsafePointer<Swift.Int8>, flags: Swift.UInt32)
-  public static func endTreeElement<Value>(value: AttributeGraph.Attribute<Value>)
-}
-public func compareValues<Value>(_ lhs: Value, _ rhs: Value, mode: ComparisonMode = .equatableAlways) -> Swift.Bool
-public func compareValues<Value>(_ lhs: Value, _ rhs: Value, options: ComparisonOptions) -> Swift.Bool
-extension ComparisonOptions {
-  public init(mode: ComparisonMode)
+  #endif
 }
 public func forEachField(of type: any Any.Type, do body: (Swift.UnsafePointer<Swift.Int8>, Swift.Int, any Any.Type) -> Swift.Void)
-extension Metadata : Swift.Hashable, Swift.CustomStringConvertible {
+extension AttributeGraph.Metadata : Swift.Hashable, Swift.CustomStringConvertible {
   public init(_ type: any Any.Type)
   public var type: any Any.Type {
     get
@@ -564,16 +635,12 @@ extension Metadata : Swift.Hashable, Swift.CustomStringConvertible {
   public var description: Swift.String {
     get
   }
-  public func forEachField(options: Metadata.ApplyOptions, do body: (Swift.UnsafePointer<Swift.Int8>, Swift.Int, any Any.Type) -> Swift.Bool) -> Swift.Bool
+  public func forEachField(options: AttributeGraph.Metadata.ApplyOptions, do body: (Swift.UnsafePointer<Swift.Int8>, Swift.Int, any Any.Type) -> Swift.Bool) -> Swift.Bool
 }
-extension Signature : Swift.Equatable {
-  public static func == (lhs: Signature, rhs: Signature) -> Swift.Bool
+extension AttributeGraph.Signature : Swift.Equatable {
+  public static func == (lhs: AttributeGraph.Signature, rhs: AttributeGraph.Signature) -> Swift.Bool
 }
-@discardableResult
-public func withUnsafePointerToEnumCase<T>(of value: Swift.UnsafeMutablePointer<T>, do body: (Swift.Int, any Any.Type, Swift.UnsafeRawPointer) -> ()) -> Swift.Bool
-@discardableResult
-public func withUnsafeMutablePointerToEnumCase<T>(of value: Swift.UnsafeMutablePointer<T>, do body: (Swift.Int, any Any.Type, Swift.UnsafeMutableRawPointer) -> ()) -> Swift.Bool
-extension TupleType {
+extension AttributeGraph.TupleType {
   @_transparent public init(_ types: [any Any.Type]) {
         self.init(count: types.count, elements: types.map(Metadata.init))
     }
@@ -597,16 +664,16 @@ extension TupleType {
   @_transparent public func offset<T>(at index: Swift.Int, as type: T.Type) -> Swift.Int {
         elementOffset(at: index, type: Metadata(type))
     }
-  @_transparent public func setElement<T>(in tupleValue: Swift.UnsafeMutableRawPointer, at index: Swift.Int, from srcValue: Swift.UnsafePointer<T>, options: TupleType.CopyOptions) {
+  @_transparent public func setElement<T>(in tupleValue: Swift.UnsafeMutableRawPointer, at index: Swift.Int, from srcValue: Swift.UnsafePointer<T>, options: AttributeGraph.TupleType.CopyOptions) {
         __AGTupleSetElement(self, tupleValue, index, srcValue, Metadata(T.self), options)
     }
-  @_transparent public func getElement<T>(in tupleValue: Swift.UnsafeMutableRawPointer, at index: Swift.Int, to dstValue: Swift.UnsafeMutablePointer<T>, options: TupleType.CopyOptions) {
+  @_transparent public func getElement<T>(in tupleValue: Swift.UnsafeMutableRawPointer, at index: Swift.Int, to dstValue: Swift.UnsafeMutablePointer<T>, options: AttributeGraph.TupleType.CopyOptions) {
         __AGTupleGetElement(self, tupleValue, index, dstValue, Metadata(T.self), options)
     }
 }
 @_silgen_name("AGTupleWithBuffer")
-public func withUnsafeTuple(of type: TupleType, count: Swift.Int, _ body: (UnsafeMutableTuple) -> Swift.Void)
-extension UnsafeTuple {
+public func withUnsafeTuple(of type: AttributeGraph.TupleType, count: Swift.Int, _ body: (AttributeGraph.UnsafeMutableTuple) -> Swift.Void)
+extension AttributeGraph.UnsafeTuple {
   @_transparent public var count: Swift.Int {
     @_transparent get { type.count }
   }
@@ -633,8 +700,8 @@ extension UnsafeTuple {
     @_transparent unsafeAddress { address(of: index, as: T.self) }
   }
 }
-extension UnsafeMutableTuple {
-  @_transparent public init(with tupleType: TupleType) {
+extension AttributeGraph.UnsafeMutableTuple {
+  @_transparent public init(with tupleType: AttributeGraph.TupleType) {
         self.init(
             type: tupleType,
             value: UnsafeMutableRawPointer.allocate(
@@ -688,21 +755,30 @@ extension UnsafeMutableTuple {
     @_transparent nonmutating unsafeMutableAddress { address(of: index, as: T.self) }
   }
 }
-extension AttributeGraph.Attribute : Swift.Sendable {}
-extension AttributeGraph.Attribute : Swift.BitwiseCopyable {}
-extension AttributeGraph.External : Swift.Sendable {}
-extension AttributeGraph.External : Swift.BitwiseCopyable {}
+@discardableResult
+public func withUnsafePointerToEnumCase<T>(of value: Swift.UnsafeMutablePointer<T>, do body: (Swift.Int, any Any.Type, Swift.UnsafeRawPointer) -> ()) -> Swift.Bool
+@discardableResult
+public func withUnsafeMutablePointerToEnumCase<T>(of value: Swift.UnsafeMutablePointer<T>, do body: (Swift.Int, any Any.Type, Swift.UnsafeMutableRawPointer) -> ()) -> Swift.Bool
+public func compareValues<Value>(_ lhs: Value, _ rhs: Value, mode: AttributeGraph.ComparisonMode = .equatableAlways) -> Swift.Bool
+public func compareValues<Value>(_ lhs: Value, _ rhs: Value, options: AttributeGraph.ComparisonOptions) -> Swift.Bool
+extension AttributeGraph.ComparisonOptions {
+  public init(mode: AttributeGraph.ComparisonMode)
+}
 extension AttributeGraph.PointerOffset : Swift.Sendable {}
 extension AttributeGraph.PointerOffset : Swift.BitwiseCopyable {}
-extension AttributeGraph.IndirectAttribute : Swift.Sendable {}
-extension AttributeGraph.IndirectAttribute : Swift.BitwiseCopyable {}
-extension AttributeGraph.AnyOptionalAttribute : Swift.Sendable {}
-extension AttributeGraph.AnyOptionalAttribute : Swift.BitwiseCopyable {}
+extension AttributeGraph.External : Swift.Sendable {}
+extension AttributeGraph.External : Swift.BitwiseCopyable {}
+extension AttributeGraph.Attribute : Swift.Sendable {}
+extension AttributeGraph.Attribute : Swift.BitwiseCopyable {}
+extension AttributeGraph.WeakAttribute : Swift.Sendable {}
+extension AttributeGraph.WeakAttribute : Swift.BitwiseCopyable {}
 extension AttributeGraph.OptionalAttribute : Swift.Sendable {}
 extension AttributeGraph.OptionalAttribute : Swift.BitwiseCopyable {}
+extension AttributeGraph.AnyOptionalAttribute : Swift.Sendable {}
+extension AttributeGraph.AnyOptionalAttribute : Swift.BitwiseCopyable {}
+extension AttributeGraph.IndirectAttribute : Swift.Sendable {}
+extension AttributeGraph.IndirectAttribute : Swift.BitwiseCopyable {}
 extension AttributeGraph.AnyRuleContext : Swift.Sendable {}
 extension AttributeGraph.AnyRuleContext : Swift.BitwiseCopyable {}
 extension AttributeGraph.RuleContext : Swift.Sendable {}
 extension AttributeGraph.RuleContext : Swift.BitwiseCopyable {}
-extension AttributeGraph.WeakAttribute : Swift.Sendable {}
-extension AttributeGraph.WeakAttribute : Swift.BitwiseCopyable {}

--- a/AG/2024/AttributeGraph.xcframework/ios-arm64-x86_64-simulator/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/arm64-apple-ios-simulator.swiftinterface
+++ b/AG/2024/AttributeGraph.xcframework/ios-arm64-x86_64-simulator/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/arm64-apple-ios-simulator.swiftinterface
@@ -10,11 +10,9 @@ public import _SwiftConcurrencyShims
 extension AttributeGraph.AnyAttribute {
   public init<Value>(_ attribute: AttributeGraph.Attribute<Value>)
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.Attribute<Value>
-  #if compiler(>=5.3) && $NonescapableTypes
   public static var current: AttributeGraph.AnyAttribute? {
     get
   }
-  #endif
   public func unsafeOffset(at offset: Swift.Int) -> AttributeGraph.AnyAttribute
   public func setFlags(_ newFlags: AttributeGraph.AnyAttribute.Flags, mask: AttributeGraph.AnyAttribute.Flags)
   public func addInput(_ attribute: AttributeGraph.AnyAttribute, options: AttributeGraph.AGInputOptions = [], token: Swift.Int)
@@ -31,12 +29,10 @@ extension AttributeGraph.AnyAttribute {
   public var valueType: any Any.Type {
     get
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public var indirectDependency: AttributeGraph.AnyAttribute? {
     get
     nonmutating set
   }
-  #endif
 }
 extension AttributeGraph.AnyAttribute : Swift.CustomStringConvertible {
   @inlinable public var description: Swift.String {
@@ -95,9 +91,7 @@ extension AttributeGraph.External : Swift.CustomStringConvertible {
   public init(_ attribute: AttributeGraph.Attribute<Value>)
   public init(value: Value)
   public init(type _: Value.Type)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init<Body>(body: Swift.UnsafePointer<Body>, value: Swift.UnsafePointer<Value>?, flags: AttributeGraph._AttributeType.Flags = [], update: () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void) where Body : AttributeGraph._AttributeBody
-  #endif
   public var wrappedValue: Value {
     unsafeAddress
     nonmutating set
@@ -169,10 +163,8 @@ extension AttributeGraph.Attribute {
   public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.Rule
   public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.StatefulRule
 }
-#if compiler(>=5.3) && $NonescapableTypes
 @_silgen_name("AGGraphCreateAttribute")
 @inline(__always) @inlinable internal func AGGraphCreateAttribute(index: Swift.Int, body: Swift.UnsafeRawPointer, value: Swift.UnsafeRawPointer?) -> AttributeGraph.AnyAttribute
-#endif
 @_silgen_name("AGGraphGetValue")
 @inline(__always) @inlinable internal func AGGraphGetValue<Value>(_ attribute: AttributeGraph.AnyAttribute, options: AttributeGraph.AGValueOptions = [], type: Value.Type = Value.self) -> AttributeGraph.AGValue
 @_silgen_name("AGGraphSetValue")
@@ -215,40 +207,26 @@ extension AttributeGraph._AttributeBody {
   public init(base: AttributeGraph.AnyWeakAttribute)
   public init()
   public init(_ attribute: AttributeGraph.Attribute<Value>)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.Attribute<Value>?)
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var wrappedValue: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var projectedValue: AttributeGraph.Attribute<Value>? {
     get
     set
     _modify
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.Attribute<Value>? {
     get
     set
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var value: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
-  #endif
 }
 extension AttributeGraph.WeakAttribute : Swift.Hashable {
   public static func == (a: AttributeGraph.WeakAttribute<Value>, b: AttributeGraph.WeakAttribute<Value>) -> Swift.Bool
@@ -263,17 +241,13 @@ extension AttributeGraph.WeakAttribute : Swift.CustomStringConvertible {
   }
 }
 extension AttributeGraph.AnyWeakAttribute {
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.AnyAttribute?)
-  #endif
   public init<Value>(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.WeakAttribute<Value>
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.AnyAttribute? {
     get
     set
   }
-  #endif
 }
 extension AttributeGraph.AnyWeakAttribute : Swift.Hashable {
   public static func == (lhs: AttributeGraph.AnyWeakAttribute, rhs: AttributeGraph.AnyWeakAttribute) -> Swift.Bool
@@ -289,17 +263,13 @@ extension AttributeGraph.AnyWeakAttribute : Swift.CustomStringConvertible {
 }
 public protocol Rule : AttributeGraph._AttributeBody {
   associatedtype Value
-  #if compiler(>=5.3) && $NonescapableTypes
   static var initialValue: Self.Value? { get }
-  #endif
   var value: Self.Value { get }
 }
 extension AttributeGraph.Rule {
-  #if compiler(>=5.3) && $NonescapableTypes
   public static var initialValue: Self.Value? {
     get
   }
-  #endif
   public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AttributeGraph.AnyAttribute)
   public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
 }
@@ -312,15 +282,9 @@ extension AttributeGraph.Rule {
   }
 }
 extension AttributeGraph.Rule where Self : Swift.Hashable {
-  #if compiler(>=5.3) && $NonescapableTypes
   public func cachedValue(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?) -> Self.Value
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func cachedValueIfExists(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?) -> Self.Value?
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public static func _cachedValue(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?, hashValue: Swift.Int, bodyPtr: Swift.UnsafeRawPointer, update: () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void) -> Swift.UnsafePointer<Self.Value>
-  #endif
 }
 @frozen public struct Map<Source, Value> : AttributeGraph.Rule, Swift.CustomStringConvertible {
   public var arg: AttributeGraph.Attribute<Source>
@@ -338,17 +302,13 @@ extension AttributeGraph.Rule where Self : Swift.Hashable {
 }
 public protocol StatefulRule : AttributeGraph._AttributeBody {
   associatedtype Value
-  #if compiler(>=5.3) && $NonescapableTypes
   static var initialValue: Self.Value? { get }
-  #endif
   mutating func updateValue()
 }
 extension AttributeGraph.StatefulRule {
-  #if compiler(>=5.3) && $NonescapableTypes
   public static var initialValue: Self.Value? {
     get
   }
-  #endif
   public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AttributeGraph.AnyAttribute)
   public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
 }
@@ -386,44 +346,28 @@ extension AttributeGraph.StatefulRule {
   public init()
   public init(base: AttributeGraph.AnyOptionalAttribute)
   public init(_ attribute: AttributeGraph.Attribute<Value>)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.Attribute<Value>?)
-  #endif
   public init(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.Attribute<Value>? {
     get
     set
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var value: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func map<V>(_ body: (AttributeGraph.Attribute<Value>) -> V) -> V?
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var wrappedValue: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var projectedValue: AttributeGraph.Attribute<Value>? {
     get
     set
     _modify
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
     get
   }
-  #endif
 }
 extension AttributeGraph.OptionalAttribute : Swift.Hashable {
   public static func == (a: AttributeGraph.OptionalAttribute<Value>, b: AttributeGraph.OptionalAttribute<Value>) -> Swift.Bool
@@ -441,22 +385,16 @@ extension AttributeGraph.OptionalAttribute : Swift.CustomStringConvertible {
   public var identifier: AttributeGraph.AnyAttribute
   public init()
   public init(_ attribute: AttributeGraph.AnyAttribute)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.AnyAttribute?)
-  #endif
   public init<Value>(_ attribute: AttributeGraph.OptionalAttribute<Value>)
   public static var current: AttributeGraph.AnyOptionalAttribute {
     get
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.AnyAttribute? {
     get
     set
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func map<Value>(_ body: (AttributeGraph.AnyAttribute) -> Value) -> Value?
-  #endif
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.OptionalAttribute<Value>
 }
 extension AttributeGraph.AnyOptionalAttribute : Swift.Hashable {
@@ -478,12 +416,10 @@ extension AttributeGraph.AnyOptionalAttribute : Swift.CustomStringConvertible {
     get
     nonmutating set
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public var dependency: AttributeGraph.AnyAttribute? {
     get
     nonmutating set
   }
-  #endif
   public var value: Value {
     get
     nonmutating set
@@ -516,16 +452,12 @@ extension AttributeGraph.IndirectAttribute : Swift.Hashable {
   public subscript<V>(attribute: AttributeGraph.Attribute<V>) -> V {
     unsafeAddress
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(weakAttribute: AttributeGraph.WeakAttribute<V>) -> V? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(optionalAttribute: AttributeGraph.OptionalAttribute<V>) -> V? {
     get
   }
-  #endif
   public func valueAndFlags<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, flags: AttributeGraph.AGChangedValueFlags)
   public func changedValue<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, changed: Swift.Bool)
   public func update(body: () -> Swift.Void)
@@ -538,16 +470,12 @@ extension AttributeGraph.IndirectAttribute : Swift.Hashable {
   public subscript<V>(attribute: AttributeGraph.Attribute<V>) -> V {
     unsafeAddress
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(weakAttribute: AttributeGraph.WeakAttribute<V>) -> V? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(optionalAttribute: AttributeGraph.OptionalAttribute<V>) -> V? {
     get
   }
-  #endif
   public var value: Value {
     unsafeAddress
     nonmutating set
@@ -609,10 +537,8 @@ extension AttributeGraph.Graph {
   }
 }
 extension AttributeGraph.Graph {
-  #if compiler(>=5.3) && $NonescapableTypes
   @_silgen_name("AGGraphGetOutputValue")
   @inline(__always) @inlinable public static func outputValue<Value>() -> Swift.UnsafePointer<Value>?
-  #endif
   @_silgen_name("AGGraphSetOutputValue")
   @inline(__always) @inlinable public static func setOutputValue<Value>(_ value: Swift.UnsafePointer<Value>)
 }
@@ -622,9 +548,7 @@ extension AttributeGraph.Graph {
     }
 }
 extension AttributeGraph.Graph {
-  #if compiler(>=5.3) && $NonescapableTypes
   public func archiveJSON(name: Swift.String?)
-  #endif
 }
 public func forEachField(of type: any Any.Type, do body: (Swift.UnsafePointer<Swift.Int8>, Swift.Int, any Any.Type) -> Swift.Void)
 extension AttributeGraph.Metadata : Swift.Hashable, Swift.CustomStringConvertible {

--- a/AG/2024/AttributeGraph.xcframework/ios-arm64-x86_64-simulator/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/x86_64-apple-ios-simulator.swiftinterface
+++ b/AG/2024/AttributeGraph.xcframework/ios-arm64-x86_64-simulator/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/x86_64-apple-ios-simulator.swiftinterface
@@ -7,19 +7,21 @@ public import Swift
 public import _Concurrency
 public import _StringProcessing
 public import _SwiftConcurrencyShims
-extension AnyAttribute {
+extension AttributeGraph.AnyAttribute {
   public init<Value>(_ attribute: AttributeGraph.Attribute<Value>)
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.Attribute<Value>
-  public static var current: AnyAttribute? {
+  #if compiler(>=5.3) && $NonescapableTypes
+  public static var current: AttributeGraph.AnyAttribute? {
     get
   }
-  public func unsafeOffset(at offset: Swift.Int) -> AnyAttribute
-  public func setFlags(_ newFlags: AnyAttribute.Flags, mask: AnyAttribute.Flags)
-  public func addInput(_ attribute: AnyAttribute, options: AGInputOptions = [], token: Swift.Int)
-  public func addInput<Value>(_ attribute: AttributeGraph.Attribute<Value>, options: AGInputOptions = [], token: Swift.Int)
+  #endif
+  public func unsafeOffset(at offset: Swift.Int) -> AttributeGraph.AnyAttribute
+  public func setFlags(_ newFlags: AttributeGraph.AnyAttribute.Flags, mask: AttributeGraph.AnyAttribute.Flags)
+  public func addInput(_ attribute: AttributeGraph.AnyAttribute, options: AttributeGraph.AGInputOptions = [], token: Swift.Int)
+  public func addInput<Value>(_ attribute: AttributeGraph.Attribute<Value>, options: AttributeGraph.AGInputOptions = [], token: Swift.Int)
   public func visitBody<Body>(_ visitor: inout Body) where Body : AttributeGraph.AttributeBodyVisitor
   public func mutateBody<Value>(as type: Value.Type, invalidating: Swift.Bool, _ body: (inout Value) -> Swift.Void)
-  public func breadthFirstSearch(options _: SearchOptions = [], _: (AnyAttribute) -> Swift.Bool) -> Swift.Bool
+  public func breadthFirstSearch(options _: AttributeGraph.SearchOptions = [], _: (AttributeGraph.AnyAttribute) -> Swift.Bool) -> Swift.Bool
   public var _bodyType: any Any.Type {
     get
   }
@@ -29,118 +31,19 @@ extension AnyAttribute {
   public var valueType: any Any.Type {
     get
   }
-  public var indirectDependency: AnyAttribute? {
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var indirectDependency: AttributeGraph.AnyAttribute? {
     get
     nonmutating set
   }
+  #endif
 }
-extension AnyAttribute : Swift.CustomStringConvertible {
+extension AttributeGraph.AnyAttribute : Swift.CustomStringConvertible {
   @inlinable public var description: Swift.String {
     get { "#\(rawValue)" }
   }
 }
-public typealias AttributeUpdateBlock = () -> (Swift.UnsafeMutableRawPointer, AnyAttribute) -> Swift.Void
-@frozen @propertyWrapper @dynamicMemberLookup public struct Attribute<Value> {
-  public var identifier: AnyAttribute
-  public init(identifier: AnyAttribute)
-  public init(_ attribute: AttributeGraph.Attribute<Value>)
-  public init(value: Value)
-  public init(type _: Value.Type)
-  public init<Body>(body: Swift.UnsafePointer<Body>, value: Swift.UnsafePointer<Value>?, flags: _AttributeType.Flags = [], update: () -> (Swift.UnsafeMutableRawPointer, AnyAttribute) -> Swift.Void) where Body : AttributeGraph._AttributeBody
-  public var wrappedValue: Value {
-    unsafeAddress
-    nonmutating set
-  }
-  public var projectedValue: AttributeGraph.Attribute<Value> {
-    get
-    set
-  }
-  public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member> {
-    get
-  }
-  public subscript<Member>(keyPath keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member> {
-    get
-  }
-  public subscript<Member>(offset body: (inout Value) -> AttributeGraph.PointerOffset<Value, Member>) -> AttributeGraph.Attribute<Member> {
-    get
-  }
-  public func unsafeCast<V>(to type: V.Type) -> AttributeGraph.Attribute<V>
-  public func unsafeOffset<Member>(at offset: Swift.Int, as _: Member.Type) -> AttributeGraph.Attribute<Member>
-  public func applying<Member>(offset: AttributeGraph.PointerOffset<Value, Member>) -> AttributeGraph.Attribute<Member>
-  public func visitBody<Body>(_ visitor: inout Body) where Body : AttributeGraph.AttributeBodyVisitor
-  public func mutateBody<V>(as type: V.Type, invalidating: Swift.Bool, _ body: (inout V) -> Swift.Void)
-  public func breadthFirstSearch(options: SearchOptions = [], _ body: (AnyAttribute) -> Swift.Bool) -> Swift.Bool
-  public var graph: Graph {
-    get
-  }
-  public var subgraph: Subgraph {
-    get
-  }
-  public var value: Value {
-    unsafeAddress
-    nonmutating set
-  }
-  public var valueState: ValueState {
-    get
-  }
-  public func valueAndFlags(options: AGValueOptions = []) -> (value: Value, flags: AGChangedValueFlags)
-  public func changedValue(options: AGValueOptions = []) -> (value: Value, changed: Swift.Bool)
-  public func setValue(_ value: Value) -> Swift.Bool
-  public var hasValue: Swift.Bool {
-    get
-  }
-  public func updateValue()
-  public func prefetchValue()
-  public func invalidateValue()
-  public func validate()
-  public func addInput(_ attribute: AnyAttribute, options: AGInputOptions = [], token: Swift.Int)
-  public func addInput<V>(_ attribute: AttributeGraph.Attribute<V>, options: AGInputOptions = [], token: Swift.Int)
-  public typealias Flags = AnyAttribute.Flags
-  public var flags: AttributeGraph.Attribute<Value>.Flags {
-    get
-    nonmutating set
-  }
-  public func setFlags(_ newFlags: AttributeGraph.Attribute<Value>.Flags, mask: AttributeGraph.Attribute<Value>.Flags)
-}
-extension AttributeGraph.Attribute : Swift.Hashable {
-  public static func == (a: AttributeGraph.Attribute<Value>, b: AttributeGraph.Attribute<Value>) -> Swift.Bool
-  public func hash(into hasher: inout Swift.Hasher)
-  public var hashValue: Swift.Int {
-    get
-  }
-}
-extension AttributeGraph.Attribute : Swift.CustomStringConvertible {
-  public var description: Swift.String {
-    get
-  }
-}
-extension AttributeGraph.Attribute {
-  public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.Rule
-  public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.StatefulRule
-}
-@_silgen_name("AGGraphCreateAttribute")
-@inline(__always) @inlinable internal func AGGraphCreateAttribute(index: Swift.Int, body: Swift.UnsafeRawPointer, value: Swift.UnsafeRawPointer?) -> AnyAttribute
-@_silgen_name("AGGraphGetValue")
-@inline(__always) @inlinable internal func AGGraphGetValue<Value>(_ attribute: AnyAttribute, options: AGValueOptions = [], type: Value.Type = Value.self) -> AGValue
-@_silgen_name("AGGraphSetValue")
-@inline(__always) @inlinable internal func AGGraphSetValue<Value>(_ attribute: AnyAttribute, valuePointer: Swift.UnsafePointer<Value>) -> Swift.Bool
-@frozen public struct External<Value> {
-  public init()
-}
-extension AttributeGraph.External : AttributeGraph._AttributeBody {
-  public static var comparisonMode: ComparisonMode {
-    get
-  }
-  public static var flags: AttributeGraph.External<Value>.Flags {
-    get
-  }
-  public static func _update(_: Swift.UnsafeMutableRawPointer, attribute _: AnyAttribute)
-}
-extension AttributeGraph.External : Swift.CustomStringConvertible {
-  public var description: Swift.String {
-    get
-  }
-}
+public typealias AttributeUpdateBlock = () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void
 @frozen public struct PointerOffset<Base, Member> {
   public var byteOffset: Swift.Int
   public init(byteOffset: Swift.Int)
@@ -169,27 +72,111 @@ extension Swift.UnsafeMutablePointer {
   }
   public static func + <Member>(lhs: Swift.UnsafeMutablePointer<Pointee>, rhs: AttributeGraph.PointerOffset<Pointee, Member>) -> Swift.UnsafeMutablePointer<Member>
 }
-public protocol _AttributeBody {
-  static func _destroySelf(_ pointer: Swift.UnsafeMutableRawPointer)
-  static var _hasDestroySelf: Swift.Bool { get }
-  static func _updateDefault(_ pointer: Swift.UnsafeMutableRawPointer)
-  static var comparisonMode: ComparisonMode { get }
-  typealias Flags = _AttributeType.Flags
-  static var flags: Self.Flags { get }
+@frozen public struct External<Value> {
+  public init()
 }
-extension AttributeGraph._AttributeBody {
-  public static func _destroySelf(_ pointer: Swift.UnsafeMutableRawPointer)
-  public static var _hasDestroySelf: Swift.Bool {
+extension AttributeGraph.External : AttributeGraph._AttributeBody {
+  public static var comparisonMode: AttributeGraph.ComparisonMode {
     get
   }
-  public static func _updateDefault(_ pointer: Swift.UnsafeMutableRawPointer)
-  public static var comparisonMode: ComparisonMode {
+  public static var flags: AttributeGraph.External<Value>.Flags {
     get
   }
-  public static var flags: Self.Flags {
+  public static func _update(_: Swift.UnsafeMutableRawPointer, attribute _: AttributeGraph.AnyAttribute)
+}
+extension AttributeGraph.External : Swift.CustomStringConvertible {
+  public var description: Swift.String {
     get
   }
 }
+@frozen @propertyWrapper @dynamicMemberLookup public struct Attribute<Value> {
+  public var identifier: AttributeGraph.AnyAttribute
+  public init(identifier: AttributeGraph.AnyAttribute)
+  public init(_ attribute: AttributeGraph.Attribute<Value>)
+  public init(value: Value)
+  public init(type _: Value.Type)
+  #if compiler(>=5.3) && $NonescapableTypes
+  public init<Body>(body: Swift.UnsafePointer<Body>, value: Swift.UnsafePointer<Value>?, flags: AttributeGraph._AttributeType.Flags = [], update: () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void) where Body : AttributeGraph._AttributeBody
+  #endif
+  public var wrappedValue: Value {
+    unsafeAddress
+    nonmutating set
+  }
+  public var projectedValue: AttributeGraph.Attribute<Value> {
+    get
+    set
+  }
+  public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member> {
+    get
+  }
+  public subscript<Member>(keyPath keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member> {
+    get
+  }
+  public subscript<Member>(offset body: (inout Value) -> AttributeGraph.PointerOffset<Value, Member>) -> AttributeGraph.Attribute<Member> {
+    get
+  }
+  public func unsafeCast<V>(to type: V.Type) -> AttributeGraph.Attribute<V>
+  public func unsafeOffset<Member>(at offset: Swift.Int, as _: Member.Type) -> AttributeGraph.Attribute<Member>
+  public func applying<Member>(offset: AttributeGraph.PointerOffset<Value, Member>) -> AttributeGraph.Attribute<Member>
+  public func visitBody<Body>(_ visitor: inout Body) where Body : AttributeGraph.AttributeBodyVisitor
+  public func mutateBody<V>(as type: V.Type, invalidating: Swift.Bool, _ body: (inout V) -> Swift.Void)
+  public func breadthFirstSearch(options: AttributeGraph.SearchOptions = [], _ body: (AttributeGraph.AnyAttribute) -> Swift.Bool) -> Swift.Bool
+  public var graph: AttributeGraph.Graph {
+    get
+  }
+  public var subgraph: AttributeGraph.Subgraph {
+    get
+  }
+  public var value: Value {
+    unsafeAddress
+    nonmutating set
+  }
+  public var valueState: AttributeGraph.ValueState {
+    get
+  }
+  public func valueAndFlags(options: AttributeGraph.AGValueOptions = []) -> (value: Value, flags: AttributeGraph.AGChangedValueFlags)
+  public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)
+  public func setValue(_ value: Value) -> Swift.Bool
+  public var hasValue: Swift.Bool {
+    get
+  }
+  public func updateValue()
+  public func prefetchValue()
+  public func invalidateValue()
+  public func validate()
+  public func addInput(_ attribute: AttributeGraph.AnyAttribute, options: AttributeGraph.AGInputOptions = [], token: Swift.Int)
+  public func addInput<V>(_ attribute: AttributeGraph.Attribute<V>, options: AttributeGraph.AGInputOptions = [], token: Swift.Int)
+  public typealias Flags = AttributeGraph.AnyAttribute.Flags
+  public var flags: AttributeGraph.Attribute<Value>.Flags {
+    get
+    nonmutating set
+  }
+  public func setFlags(_ newFlags: AttributeGraph.Attribute<Value>.Flags, mask: AttributeGraph.Attribute<Value>.Flags)
+}
+extension AttributeGraph.Attribute : Swift.Hashable {
+  public static func == (a: AttributeGraph.Attribute<Value>, b: AttributeGraph.Attribute<Value>) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+extension AttributeGraph.Attribute : Swift.CustomStringConvertible {
+  public var description: Swift.String {
+    get
+  }
+}
+extension AttributeGraph.Attribute {
+  public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.Rule
+  public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.StatefulRule
+}
+#if compiler(>=5.3) && $NonescapableTypes
+@_silgen_name("AGGraphCreateAttribute")
+@inline(__always) @inlinable internal func AGGraphCreateAttribute(index: Swift.Int, body: Swift.UnsafeRawPointer, value: Swift.UnsafeRawPointer?) -> AttributeGraph.AnyAttribute
+#endif
+@_silgen_name("AGGraphGetValue")
+@inline(__always) @inlinable internal func AGGraphGetValue<Value>(_ attribute: AttributeGraph.AnyAttribute, options: AttributeGraph.AGValueOptions = [], type: Value.Type = Value.self) -> AttributeGraph.AGValue
+@_silgen_name("AGGraphSetValue")
+@inline(__always) @inlinable internal func AGGraphSetValue<Value>(_ attribute: AttributeGraph.AnyAttribute, valuePointer: Swift.UnsafePointer<Value>) -> Swift.Bool
 public protocol AttributeBodyVisitor {
   func visit<Body>(body: Swift.UnsafePointer<Body>) where Body : AttributeGraph._AttributeBody
 }
@@ -202,23 +189,307 @@ extension AttributeGraph.ObservedAttribute {
     get
   }
 }
+public protocol _AttributeBody {
+  static func _destroySelf(_ pointer: Swift.UnsafeMutableRawPointer)
+  static var _hasDestroySelf: Swift.Bool { get }
+  static func _updateDefault(_ pointer: Swift.UnsafeMutableRawPointer)
+  static var comparisonMode: AttributeGraph.ComparisonMode { get }
+  typealias Flags = AttributeGraph._AttributeType.Flags
+  static var flags: Self.Flags { get }
+}
+extension AttributeGraph._AttributeBody {
+  public static func _destroySelf(_ pointer: Swift.UnsafeMutableRawPointer)
+  public static var _hasDestroySelf: Swift.Bool {
+    get
+  }
+  public static func _updateDefault(_ pointer: Swift.UnsafeMutableRawPointer)
+  public static var comparisonMode: AttributeGraph.ComparisonMode {
+    get
+  }
+  public static var flags: Self.Flags {
+    get
+  }
+}
+@frozen @propertyWrapper @dynamicMemberLookup public struct WeakAttribute<Value> {
+  internal var base: AttributeGraph.AnyWeakAttribute
+  public init(base: AttributeGraph.AnyWeakAttribute)
+  public init()
+  public init(_ attribute: AttributeGraph.Attribute<Value>)
+  #if compiler(>=5.3) && $NonescapableTypes
+  public init(_ attribute: AttributeGraph.Attribute<Value>?)
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var wrappedValue: Value? {
+    get
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var projectedValue: AttributeGraph.Attribute<Value>? {
+    get
+    set
+    _modify
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
+    get
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var attribute: AttributeGraph.Attribute<Value>? {
+    get
+    set
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var value: Value? {
+    get
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
+  #endif
+}
+extension AttributeGraph.WeakAttribute : Swift.Hashable {
+  public static func == (a: AttributeGraph.WeakAttribute<Value>, b: AttributeGraph.WeakAttribute<Value>) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+extension AttributeGraph.WeakAttribute : Swift.CustomStringConvertible {
+  public var description: Swift.String {
+    get
+  }
+}
+extension AttributeGraph.AnyWeakAttribute {
+  #if compiler(>=5.3) && $NonescapableTypes
+  public init(_ attribute: AttributeGraph.AnyAttribute?)
+  #endif
+  public init<Value>(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
+  public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.WeakAttribute<Value>
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var attribute: AttributeGraph.AnyAttribute? {
+    get
+    set
+  }
+  #endif
+}
+extension AttributeGraph.AnyWeakAttribute : Swift.Hashable {
+  public static func == (lhs: AttributeGraph.AnyWeakAttribute, rhs: AttributeGraph.AnyWeakAttribute) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+extension AttributeGraph.AnyWeakAttribute : Swift.CustomStringConvertible {
+  @_alwaysEmitIntoClient public var description: Swift.String {
+    get { attribute?.description ?? "nil" }
+  }
+}
+public protocol Rule : AttributeGraph._AttributeBody {
+  associatedtype Value
+  #if compiler(>=5.3) && $NonescapableTypes
+  static var initialValue: Self.Value? { get }
+  #endif
+  var value: Self.Value { get }
+}
+extension AttributeGraph.Rule {
+  #if compiler(>=5.3) && $NonescapableTypes
+  public static var initialValue: Self.Value? {
+    get
+  }
+  #endif
+  public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AttributeGraph.AnyAttribute)
+  public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
+}
+extension AttributeGraph.Rule {
+  public var attribute: AttributeGraph.Attribute<Self.Value> {
+    get
+  }
+  public var context: AttributeGraph.RuleContext<Self.Value> {
+    get
+  }
+}
+extension AttributeGraph.Rule where Self : Swift.Hashable {
+  #if compiler(>=5.3) && $NonescapableTypes
+  public func cachedValue(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?) -> Self.Value
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public func cachedValueIfExists(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?) -> Self.Value?
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public static func _cachedValue(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?, hashValue: Swift.Int, bodyPtr: Swift.UnsafeRawPointer, update: () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void) -> Swift.UnsafePointer<Self.Value>
+  #endif
+}
+@frozen public struct Map<Source, Value> : AttributeGraph.Rule, Swift.CustomStringConvertible {
+  public var arg: AttributeGraph.Attribute<Source>
+  public let body: (Source) -> Value
+  public init(_ arg: AttributeGraph.Attribute<Source>, _ body: @escaping (Source) -> Value)
+  public var value: Value {
+    get
+  }
+  public static var flags: AttributeGraph.Map<Source, Value>.Flags {
+    get
+  }
+  public var description: Swift.String {
+    get
+  }
+}
+public protocol StatefulRule : AttributeGraph._AttributeBody {
+  associatedtype Value
+  #if compiler(>=5.3) && $NonescapableTypes
+  static var initialValue: Self.Value? { get }
+  #endif
+  mutating func updateValue()
+}
+extension AttributeGraph.StatefulRule {
+  #if compiler(>=5.3) && $NonescapableTypes
+  public static var initialValue: Self.Value? {
+    get
+  }
+  #endif
+  public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AttributeGraph.AnyAttribute)
+  public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
+}
+extension AttributeGraph.StatefulRule {
+  public var attribute: AttributeGraph.Attribute<Self.Value> {
+    get
+  }
+  public var context: AttributeGraph.RuleContext<Self.Value> {
+    get
+  }
+  public var value: Self.Value {
+    unsafeAddress
+    nonmutating set
+  }
+  public var hasValue: Swift.Bool {
+    get
+  }
+}
+@frozen public struct Focus<Root, Value> : AttributeGraph.Rule, Swift.CustomStringConvertible {
+  public var root: AttributeGraph.Attribute<Root>
+  public var keyPath: Swift.KeyPath<Root, Value>
+  public init(root: AttributeGraph.Attribute<Root>, keyPath: Swift.KeyPath<Root, Value>)
+  public var value: Value {
+    get
+  }
+  public static var flags: AttributeGraph.Focus<Root, Value>.Flags {
+    get
+  }
+  public var description: Swift.String {
+    get
+  }
+}
+@frozen @propertyWrapper @dynamicMemberLookup public struct OptionalAttribute<Value> {
+  public var base: AttributeGraph.AnyOptionalAttribute
+  public init()
+  public init(base: AttributeGraph.AnyOptionalAttribute)
+  public init(_ attribute: AttributeGraph.Attribute<Value>)
+  #if compiler(>=5.3) && $NonescapableTypes
+  public init(_ attribute: AttributeGraph.Attribute<Value>?)
+  #endif
+  public init(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var attribute: AttributeGraph.Attribute<Value>? {
+    get
+    set
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var value: Value? {
+    get
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public func map<V>(_ body: (AttributeGraph.Attribute<Value>) -> V) -> V?
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var wrappedValue: Value? {
+    get
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var projectedValue: AttributeGraph.Attribute<Value>? {
+    get
+    set
+    _modify
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
+    get
+  }
+  #endif
+}
+extension AttributeGraph.OptionalAttribute : Swift.Hashable {
+  public static func == (a: AttributeGraph.OptionalAttribute<Value>, b: AttributeGraph.OptionalAttribute<Value>) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+extension AttributeGraph.OptionalAttribute : Swift.CustomStringConvertible {
+  public var description: Swift.String {
+    get
+  }
+}
+@frozen public struct AnyOptionalAttribute {
+  public var identifier: AttributeGraph.AnyAttribute
+  public init()
+  public init(_ attribute: AttributeGraph.AnyAttribute)
+  #if compiler(>=5.3) && $NonescapableTypes
+  public init(_ attribute: AttributeGraph.AnyAttribute?)
+  #endif
+  public init<Value>(_ attribute: AttributeGraph.OptionalAttribute<Value>)
+  public static var current: AttributeGraph.AnyOptionalAttribute {
+    get
+  }
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var attribute: AttributeGraph.AnyAttribute? {
+    get
+    set
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public func map<Value>(_ body: (AttributeGraph.AnyAttribute) -> Value) -> Value?
+  #endif
+  public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.OptionalAttribute<Value>
+}
+extension AttributeGraph.AnyOptionalAttribute : Swift.Hashable {
+  public static func == (a: AttributeGraph.AnyOptionalAttribute, b: AttributeGraph.AnyOptionalAttribute) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+extension AttributeGraph.AnyOptionalAttribute : Swift.CustomStringConvertible {
+  public var description: Swift.String {
+    get
+  }
+}
 @frozen @propertyWrapper @dynamicMemberLookup public struct IndirectAttribute<Value> {
-  public let identifier: AnyAttribute
+  public let identifier: AttributeGraph.AnyAttribute
   public init(source: AttributeGraph.Attribute<Value>)
   public var source: AttributeGraph.Attribute<Value> {
     get
     nonmutating set
   }
-  public var dependency: AnyAttribute? {
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var dependency: AttributeGraph.AnyAttribute? {
     get
     nonmutating set
   }
+  #endif
   public var value: Value {
     get
     nonmutating set
     nonmutating _modify
   }
-  public func changedValue(options: AGValueOptions = []) -> (value: Value, changed: Swift.Bool)
+  public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)
   public var wrappedValue: Value {
     get
     nonmutating set
@@ -238,169 +509,25 @@ extension AttributeGraph.IndirectAttribute : Swift.Hashable {
     get
   }
 }
-@frozen public struct AnyOptionalAttribute {
-  public var identifier: AnyAttribute
-  public init()
-  public init(_ attribute: AnyAttribute)
-  public init(_ attribute: AnyAttribute?)
-  public init<Value>(_ attribute: AttributeGraph.OptionalAttribute<Value>)
-  public static var current: AttributeGraph.AnyOptionalAttribute {
-    get
-  }
-  public var attribute: AnyAttribute? {
-    get
-    set
-  }
-  public func map<Value>(_ body: (AnyAttribute) -> Value) -> Value?
-  public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.OptionalAttribute<Value>
-}
-extension AttributeGraph.AnyOptionalAttribute : Swift.Hashable {
-  public static func == (a: AttributeGraph.AnyOptionalAttribute, b: AttributeGraph.AnyOptionalAttribute) -> Swift.Bool
-  public func hash(into hasher: inout Swift.Hasher)
-  public var hashValue: Swift.Int {
-    get
-  }
-}
-extension AttributeGraph.AnyOptionalAttribute : Swift.CustomStringConvertible {
-  public var description: Swift.String {
-    get
-  }
-}
-@frozen @propertyWrapper @dynamicMemberLookup public struct OptionalAttribute<Value> {
-  public var base: AttributeGraph.AnyOptionalAttribute
-  public init()
-  public init(base: AttributeGraph.AnyOptionalAttribute)
-  public init(_ attribute: AttributeGraph.Attribute<Value>)
-  public init(_ attribute: AttributeGraph.Attribute<Value>?)
-  public init(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
-  public var attribute: AttributeGraph.Attribute<Value>? {
-    get
-    set
-  }
-  public var value: Value? {
-    get
-  }
-  public func changedValue(options: AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
-  public func map<V>(_ body: (AttributeGraph.Attribute<Value>) -> V) -> V?
-  public var wrappedValue: Value? {
-    get
-  }
-  public var projectedValue: AttributeGraph.Attribute<Value>? {
-    get
-    set
-    _modify
-  }
-  public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
-    get
-  }
-}
-extension AttributeGraph.OptionalAttribute : Swift.Hashable {
-  public static func == (a: AttributeGraph.OptionalAttribute<Value>, b: AttributeGraph.OptionalAttribute<Value>) -> Swift.Bool
-  public func hash(into hasher: inout Swift.Hasher)
-  public var hashValue: Swift.Int {
-    get
-  }
-}
-extension AttributeGraph.OptionalAttribute : Swift.CustomStringConvertible {
-  public var description: Swift.String {
-    get
-  }
-}
-@frozen public struct Focus<Root, Value> : AttributeGraph.Rule, Swift.CustomStringConvertible {
-  public var root: AttributeGraph.Attribute<Root>
-  public var keyPath: Swift.KeyPath<Root, Value>
-  public init(root: AttributeGraph.Attribute<Root>, keyPath: Swift.KeyPath<Root, Value>)
-  public var value: Value {
-    get
-  }
-  public static var flags: AttributeGraph.Focus<Root, Value>.Flags {
-    get
-  }
-  public var description: Swift.String {
-    get
-  }
-}
-@frozen public struct Map<Source, Value> : AttributeGraph.Rule, Swift.CustomStringConvertible {
-  public var arg: AttributeGraph.Attribute<Source>
-  public let body: (Source) -> Value
-  public init(_ arg: AttributeGraph.Attribute<Source>, _ body: @escaping (Source) -> Value)
-  public var value: Value {
-    get
-  }
-  public static var flags: AttributeGraph.Map<Source, Value>.Flags {
-    get
-  }
-  public var description: Swift.String {
-    get
-  }
-}
-public protocol Rule : AttributeGraph._AttributeBody {
-  associatedtype Value
-  static var initialValue: Self.Value? { get }
-  var value: Self.Value { get }
-}
-extension AttributeGraph.Rule {
-  public static var initialValue: Self.Value? {
-    get
-  }
-  public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AnyAttribute)
-  public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
-}
-extension AttributeGraph.Rule {
-  public var attribute: AttributeGraph.Attribute<Self.Value> {
-    get
-  }
-  public var context: AttributeGraph.RuleContext<Self.Value> {
-    get
-  }
-}
-extension AttributeGraph.Rule where Self : Swift.Hashable {
-  public func cachedValue(options: AGCachedValueOptions = [], owner: AnyAttribute?) -> Self.Value
-  public func cachedValueIfExists(options: AGCachedValueOptions = [], owner: AnyAttribute?) -> Self.Value?
-  public static func _cachedValue(options: AGCachedValueOptions = [], owner: AnyAttribute?, hashValue: Swift.Int, bodyPtr: Swift.UnsafeRawPointer, update: () -> (Swift.UnsafeMutableRawPointer, AnyAttribute) -> Swift.Void) -> Swift.UnsafePointer<Self.Value>
-}
-public protocol StatefulRule : AttributeGraph._AttributeBody {
-  associatedtype Value
-  static var initialValue: Self.Value? { get }
-  mutating func updateValue()
-}
-extension AttributeGraph.StatefulRule {
-  public static var initialValue: Self.Value? {
-    get
-  }
-  public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AnyAttribute)
-  public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
-}
-extension AttributeGraph.StatefulRule {
-  public var attribute: AttributeGraph.Attribute<Self.Value> {
-    get
-  }
-  public var context: AttributeGraph.RuleContext<Self.Value> {
-    get
-  }
-  public var value: Self.Value {
-    unsafeAddress
-    nonmutating set
-  }
-  public var hasValue: Swift.Bool {
-    get
-  }
-}
 @frozen public struct AnyRuleContext : Swift.Equatable {
-  public var attribute: AnyAttribute
-  public init(attribute: AnyAttribute)
+  public var attribute: AttributeGraph.AnyAttribute
+  public init(attribute: AttributeGraph.AnyAttribute)
   public init<V>(_ context: AttributeGraph.RuleContext<V>)
   public subscript<V>(attribute: AttributeGraph.Attribute<V>) -> V {
     unsafeAddress
   }
+  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(weakAttribute: AttributeGraph.WeakAttribute<V>) -> V? {
     get
   }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(optionalAttribute: AttributeGraph.OptionalAttribute<V>) -> V? {
     get
   }
-  public func valueAndFlags<V>(of input: AttributeGraph.Attribute<V>, options: AGValueOptions = []) -> (value: V, flags: AGChangedValueFlags)
-  public func changedValue<V>(of input: AttributeGraph.Attribute<V>, options: AGValueOptions = []) -> (value: V, changed: Swift.Bool)
+  #endif
+  public func valueAndFlags<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, flags: AttributeGraph.AGChangedValueFlags)
+  public func changedValue<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, changed: Swift.Bool)
   public func update(body: () -> Swift.Void)
   public func unsafeCast<V>(to _: V.Type) -> AttributeGraph.RuleContext<V>
   public static func == (a: AttributeGraph.AnyRuleContext, b: AttributeGraph.AnyRuleContext) -> Swift.Bool
@@ -411,12 +538,16 @@ extension AttributeGraph.StatefulRule {
   public subscript<V>(attribute: AttributeGraph.Attribute<V>) -> V {
     unsafeAddress
   }
+  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(weakAttribute: AttributeGraph.WeakAttribute<V>) -> V? {
     get
   }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(optionalAttribute: AttributeGraph.OptionalAttribute<V>) -> V? {
     get
   }
+  #endif
   public var value: Value {
     unsafeAddress
     nonmutating set
@@ -424,86 +555,41 @@ extension AttributeGraph.StatefulRule {
   public var hasValue: Swift.Bool {
     get
   }
-  public func valueAndFlags<V>(of input: AttributeGraph.Attribute<V>, options: AGValueOptions = []) -> (value: V, flags: AGChangedValueFlags)
-  public func changedValue<V>(of input: AttributeGraph.Attribute<V>, options: AGValueOptions = []) -> (value: V, changed: Swift.Bool)
+  public func valueAndFlags<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, flags: AttributeGraph.AGChangedValueFlags)
+  public func changedValue<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, changed: Swift.Bool)
   public func update(body: () -> Swift.Void)
   public static func == (a: AttributeGraph.RuleContext<Value>, b: AttributeGraph.RuleContext<Value>) -> Swift.Bool
 }
 @_silgen_name("AGGraphGetInputValue")
-@inline(__always) @inlinable internal func AGGraphGetInputValue<Value>(_ attribute: AnyAttribute, input: AnyAttribute, options: AGValueOptions = [], type: Value.Type = Value.self) -> AGValue
+@inline(__always) @inlinable internal func AGGraphGetInputValue<Value>(_ attribute: AttributeGraph.AnyAttribute, input: AttributeGraph.AnyAttribute, options: AttributeGraph.AGValueOptions = [], type: Value.Type = Value.self) -> AttributeGraph.AGValue
 @_silgen_name("AGGraphWithUpdate")
-@inline(__always) @inlinable internal func AGGraphWithUpdate(_ attribute: AnyAttribute, body: () -> Swift.Void)
-extension AnyWeakAttribute {
-  public init(_ attribute: AnyAttribute?)
-  public init<Value>(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
-  public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.WeakAttribute<Value>
-  public var attribute: AnyAttribute? {
-    get
-    set
-  }
+@inline(__always) @inlinable internal func AGGraphWithUpdate(_ attribute: AttributeGraph.AnyAttribute, body: () -> Swift.Void)
+extension AttributeGraph.Subgraph {
+  public typealias Flags = AttributeGraph.AnyAttribute.Flags
+  public typealias ChildFlags = AttributeGraph.AnyAttribute.Flags
 }
-extension AnyWeakAttribute : Swift.Hashable {
-  public static func == (lhs: AnyWeakAttribute, rhs: AnyWeakAttribute) -> Swift.Bool
-  public func hash(into hasher: inout Swift.Hasher)
-  public var hashValue: Swift.Int {
-    get
-  }
+extension AttributeGraph.Subgraph {
+  public func addObserver(_ observer: @escaping () -> Swift.Void) -> Swift.Int
+  public func apply<Value>(_ body: () -> Value) -> Value
+  public func forEach(_ flags: AttributeGraph.Subgraph.Flags, _ callback: (AttributeGraph.AnyAttribute) -> Swift.Void)
 }
-extension AnyWeakAttribute : Swift.CustomStringConvertible {
-  @_alwaysEmitIntoClient public var description: Swift.String {
-    get { attribute?.description ?? "nil" }
-  }
+extension AttributeGraph.Subgraph {
+  public static func beginTreeElement<Value>(value: AttributeGraph.Attribute<Value>, flags: Swift.UInt32)
+  public static func addTreeValue<Value>(_ value: AttributeGraph.Attribute<Value>, forKey key: Swift.UnsafePointer<Swift.Int8>, flags: Swift.UInt32)
+  public static func endTreeElement<Value>(value: AttributeGraph.Attribute<Value>)
 }
-@frozen @propertyWrapper @dynamicMemberLookup public struct WeakAttribute<Value> {
-  internal var base: AnyWeakAttribute
-  public init(base: AnyWeakAttribute)
-  public init()
-  public init(_ attribute: AttributeGraph.Attribute<Value>)
-  public init(_ attribute: AttributeGraph.Attribute<Value>?)
-  public var wrappedValue: Value? {
-    get
-  }
-  public var projectedValue: AttributeGraph.Attribute<Value>? {
-    get
-    set
-    _modify
-  }
-  public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
-    get
-  }
-  public var attribute: AttributeGraph.Attribute<Value>? {
-    get
-    set
-  }
-  public var value: Value? {
-    get
-  }
-  public func changedValue(options: AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
+extension AttributeGraph.Graph {
+  public static func typeIndex(ctx: AttributeGraph.GraphContext, body: any AttributeGraph._AttributeBody.Type, valueType: AttributeGraph.Metadata, flags: AttributeGraph._AttributeType.Flags, update: () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void) -> Swift.Int
 }
-extension AttributeGraph.WeakAttribute : Swift.Hashable {
-  public static func == (a: AttributeGraph.WeakAttribute<Value>, b: AttributeGraph.WeakAttribute<Value>) -> Swift.Bool
-  public func hash(into hasher: inout Swift.Hasher)
-  public var hashValue: Swift.Int {
-    get
-  }
-}
-extension AttributeGraph.WeakAttribute : Swift.CustomStringConvertible {
-  public var description: Swift.String {
-    get
-  }
-}
-extension Graph {
-  public static func typeIndex(ctx: GraphContext, body: any AttributeGraph._AttributeBody.Type, valueType: Metadata, flags: _AttributeType.Flags, update: () -> (Swift.UnsafeMutableRawPointer, AnyAttribute) -> Swift.Void) -> Swift.Int
-}
-extension Graph {
+extension AttributeGraph.Graph {
   public static func withoutUpdate<V>(_ body: () -> V) -> V
   public func withoutSubgraphInvalidation<V>(_ body: () -> V) -> V
   public func withDeadline<V>(_: Swift.UInt64, _: () -> V) -> V
-  public func onInvalidation(_ callback: @escaping (AnyAttribute) -> Swift.Void)
+  public func onInvalidation(_ callback: @escaping (AttributeGraph.AnyAttribute) -> Swift.Void)
   public func onUpdate(_ callback: @escaping () -> Swift.Void)
   public func withMainThreadHandler(_: (() -> Swift.Void) -> Swift.Void, do: () -> Swift.Void)
 }
-extension Graph {
+extension AttributeGraph.Graph {
   @_transparent public func startProfiling() {
         __AGGraphStartProfiling(self)
     }
@@ -517,46 +603,31 @@ extension Graph {
   public static func stopProfiling()
   public static func resetProfile()
 }
-extension Graph {
+extension AttributeGraph.Graph {
   @_transparent public var mainUpdates: Swift.Int {
     @_transparent get { numericCast(counter(for: .mainThreadUpdates)) }
   }
 }
-extension Graph {
+extension AttributeGraph.Graph {
+  #if compiler(>=5.3) && $NonescapableTypes
   @_silgen_name("AGGraphGetOutputValue")
   @inline(__always) @inlinable public static func outputValue<Value>() -> Swift.UnsafePointer<Value>?
+  #endif
   @_silgen_name("AGGraphSetOutputValue")
   @inline(__always) @inlinable public static func setOutputValue<Value>(_ value: Swift.UnsafePointer<Value>)
 }
-extension Graph {
-  @_transparent public static func anyInputsChanged(excluding excludedInputs: [AnyAttribute]) -> Swift.Bool {
+extension AttributeGraph.Graph {
+  @_transparent public static func anyInputsChanged(excluding excludedInputs: [AttributeGraph.AnyAttribute]) -> Swift.Bool {
         return __AGGraphAnyInputsChanged(excludedInputs, excludedInputs.count)
     }
 }
-extension Graph {
+extension AttributeGraph.Graph {
+  #if compiler(>=5.3) && $NonescapableTypes
   public func archiveJSON(name: Swift.String?)
-}
-extension Subgraph {
-  public typealias Flags = AnyAttribute.Flags
-  public typealias ChildFlags = AnyAttribute.Flags
-}
-extension Subgraph {
-  public func addObserver(_ observer: @escaping () -> Swift.Void) -> Swift.Int
-  public func apply<Value>(_ body: () -> Value) -> Value
-  public func forEach(_ flags: Subgraph.Flags, _ callback: (AnyAttribute) -> Swift.Void)
-}
-extension Subgraph {
-  public static func beginTreeElement<Value>(value: AttributeGraph.Attribute<Value>, flags: Swift.UInt32)
-  public static func addTreeValue<Value>(_ value: AttributeGraph.Attribute<Value>, forKey key: Swift.UnsafePointer<Swift.Int8>, flags: Swift.UInt32)
-  public static func endTreeElement<Value>(value: AttributeGraph.Attribute<Value>)
-}
-public func compareValues<Value>(_ lhs: Value, _ rhs: Value, mode: ComparisonMode = .equatableAlways) -> Swift.Bool
-public func compareValues<Value>(_ lhs: Value, _ rhs: Value, options: ComparisonOptions) -> Swift.Bool
-extension ComparisonOptions {
-  public init(mode: ComparisonMode)
+  #endif
 }
 public func forEachField(of type: any Any.Type, do body: (Swift.UnsafePointer<Swift.Int8>, Swift.Int, any Any.Type) -> Swift.Void)
-extension Metadata : Swift.Hashable, Swift.CustomStringConvertible {
+extension AttributeGraph.Metadata : Swift.Hashable, Swift.CustomStringConvertible {
   public init(_ type: any Any.Type)
   public var type: any Any.Type {
     get
@@ -564,16 +635,12 @@ extension Metadata : Swift.Hashable, Swift.CustomStringConvertible {
   public var description: Swift.String {
     get
   }
-  public func forEachField(options: Metadata.ApplyOptions, do body: (Swift.UnsafePointer<Swift.Int8>, Swift.Int, any Any.Type) -> Swift.Bool) -> Swift.Bool
+  public func forEachField(options: AttributeGraph.Metadata.ApplyOptions, do body: (Swift.UnsafePointer<Swift.Int8>, Swift.Int, any Any.Type) -> Swift.Bool) -> Swift.Bool
 }
-extension Signature : Swift.Equatable {
-  public static func == (lhs: Signature, rhs: Signature) -> Swift.Bool
+extension AttributeGraph.Signature : Swift.Equatable {
+  public static func == (lhs: AttributeGraph.Signature, rhs: AttributeGraph.Signature) -> Swift.Bool
 }
-@discardableResult
-public func withUnsafePointerToEnumCase<T>(of value: Swift.UnsafeMutablePointer<T>, do body: (Swift.Int, any Any.Type, Swift.UnsafeRawPointer) -> ()) -> Swift.Bool
-@discardableResult
-public func withUnsafeMutablePointerToEnumCase<T>(of value: Swift.UnsafeMutablePointer<T>, do body: (Swift.Int, any Any.Type, Swift.UnsafeMutableRawPointer) -> ()) -> Swift.Bool
-extension TupleType {
+extension AttributeGraph.TupleType {
   @_transparent public init(_ types: [any Any.Type]) {
         self.init(count: types.count, elements: types.map(Metadata.init))
     }
@@ -597,16 +664,16 @@ extension TupleType {
   @_transparent public func offset<T>(at index: Swift.Int, as type: T.Type) -> Swift.Int {
         elementOffset(at: index, type: Metadata(type))
     }
-  @_transparent public func setElement<T>(in tupleValue: Swift.UnsafeMutableRawPointer, at index: Swift.Int, from srcValue: Swift.UnsafePointer<T>, options: TupleType.CopyOptions) {
+  @_transparent public func setElement<T>(in tupleValue: Swift.UnsafeMutableRawPointer, at index: Swift.Int, from srcValue: Swift.UnsafePointer<T>, options: AttributeGraph.TupleType.CopyOptions) {
         __AGTupleSetElement(self, tupleValue, index, srcValue, Metadata(T.self), options)
     }
-  @_transparent public func getElement<T>(in tupleValue: Swift.UnsafeMutableRawPointer, at index: Swift.Int, to dstValue: Swift.UnsafeMutablePointer<T>, options: TupleType.CopyOptions) {
+  @_transparent public func getElement<T>(in tupleValue: Swift.UnsafeMutableRawPointer, at index: Swift.Int, to dstValue: Swift.UnsafeMutablePointer<T>, options: AttributeGraph.TupleType.CopyOptions) {
         __AGTupleGetElement(self, tupleValue, index, dstValue, Metadata(T.self), options)
     }
 }
 @_silgen_name("AGTupleWithBuffer")
-public func withUnsafeTuple(of type: TupleType, count: Swift.Int, _ body: (UnsafeMutableTuple) -> Swift.Void)
-extension UnsafeTuple {
+public func withUnsafeTuple(of type: AttributeGraph.TupleType, count: Swift.Int, _ body: (AttributeGraph.UnsafeMutableTuple) -> Swift.Void)
+extension AttributeGraph.UnsafeTuple {
   @_transparent public var count: Swift.Int {
     @_transparent get { type.count }
   }
@@ -633,8 +700,8 @@ extension UnsafeTuple {
     @_transparent unsafeAddress { address(of: index, as: T.self) }
   }
 }
-extension UnsafeMutableTuple {
-  @_transparent public init(with tupleType: TupleType) {
+extension AttributeGraph.UnsafeMutableTuple {
+  @_transparent public init(with tupleType: AttributeGraph.TupleType) {
         self.init(
             type: tupleType,
             value: UnsafeMutableRawPointer.allocate(
@@ -688,21 +755,30 @@ extension UnsafeMutableTuple {
     @_transparent nonmutating unsafeMutableAddress { address(of: index, as: T.self) }
   }
 }
-extension AttributeGraph.Attribute : Swift.Sendable {}
-extension AttributeGraph.Attribute : Swift.BitwiseCopyable {}
-extension AttributeGraph.External : Swift.Sendable {}
-extension AttributeGraph.External : Swift.BitwiseCopyable {}
+@discardableResult
+public func withUnsafePointerToEnumCase<T>(of value: Swift.UnsafeMutablePointer<T>, do body: (Swift.Int, any Any.Type, Swift.UnsafeRawPointer) -> ()) -> Swift.Bool
+@discardableResult
+public func withUnsafeMutablePointerToEnumCase<T>(of value: Swift.UnsafeMutablePointer<T>, do body: (Swift.Int, any Any.Type, Swift.UnsafeMutableRawPointer) -> ()) -> Swift.Bool
+public func compareValues<Value>(_ lhs: Value, _ rhs: Value, mode: AttributeGraph.ComparisonMode = .equatableAlways) -> Swift.Bool
+public func compareValues<Value>(_ lhs: Value, _ rhs: Value, options: AttributeGraph.ComparisonOptions) -> Swift.Bool
+extension AttributeGraph.ComparisonOptions {
+  public init(mode: AttributeGraph.ComparisonMode)
+}
 extension AttributeGraph.PointerOffset : Swift.Sendable {}
 extension AttributeGraph.PointerOffset : Swift.BitwiseCopyable {}
-extension AttributeGraph.IndirectAttribute : Swift.Sendable {}
-extension AttributeGraph.IndirectAttribute : Swift.BitwiseCopyable {}
-extension AttributeGraph.AnyOptionalAttribute : Swift.Sendable {}
-extension AttributeGraph.AnyOptionalAttribute : Swift.BitwiseCopyable {}
+extension AttributeGraph.External : Swift.Sendable {}
+extension AttributeGraph.External : Swift.BitwiseCopyable {}
+extension AttributeGraph.Attribute : Swift.Sendable {}
+extension AttributeGraph.Attribute : Swift.BitwiseCopyable {}
+extension AttributeGraph.WeakAttribute : Swift.Sendable {}
+extension AttributeGraph.WeakAttribute : Swift.BitwiseCopyable {}
 extension AttributeGraph.OptionalAttribute : Swift.Sendable {}
 extension AttributeGraph.OptionalAttribute : Swift.BitwiseCopyable {}
+extension AttributeGraph.AnyOptionalAttribute : Swift.Sendable {}
+extension AttributeGraph.AnyOptionalAttribute : Swift.BitwiseCopyable {}
+extension AttributeGraph.IndirectAttribute : Swift.Sendable {}
+extension AttributeGraph.IndirectAttribute : Swift.BitwiseCopyable {}
 extension AttributeGraph.AnyRuleContext : Swift.Sendable {}
 extension AttributeGraph.AnyRuleContext : Swift.BitwiseCopyable {}
 extension AttributeGraph.RuleContext : Swift.Sendable {}
 extension AttributeGraph.RuleContext : Swift.BitwiseCopyable {}
-extension AttributeGraph.WeakAttribute : Swift.Sendable {}
-extension AttributeGraph.WeakAttribute : Swift.BitwiseCopyable {}

--- a/AG/2024/AttributeGraph.xcframework/ios-arm64-x86_64-simulator/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/x86_64-apple-ios-simulator.swiftinterface
+++ b/AG/2024/AttributeGraph.xcframework/ios-arm64-x86_64-simulator/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/x86_64-apple-ios-simulator.swiftinterface
@@ -10,11 +10,9 @@ public import _SwiftConcurrencyShims
 extension AttributeGraph.AnyAttribute {
   public init<Value>(_ attribute: AttributeGraph.Attribute<Value>)
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.Attribute<Value>
-  #if compiler(>=5.3) && $NonescapableTypes
   public static var current: AttributeGraph.AnyAttribute? {
     get
   }
-  #endif
   public func unsafeOffset(at offset: Swift.Int) -> AttributeGraph.AnyAttribute
   public func setFlags(_ newFlags: AttributeGraph.AnyAttribute.Flags, mask: AttributeGraph.AnyAttribute.Flags)
   public func addInput(_ attribute: AttributeGraph.AnyAttribute, options: AttributeGraph.AGInputOptions = [], token: Swift.Int)
@@ -31,12 +29,10 @@ extension AttributeGraph.AnyAttribute {
   public var valueType: any Any.Type {
     get
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public var indirectDependency: AttributeGraph.AnyAttribute? {
     get
     nonmutating set
   }
-  #endif
 }
 extension AttributeGraph.AnyAttribute : Swift.CustomStringConvertible {
   @inlinable public var description: Swift.String {
@@ -95,9 +91,7 @@ extension AttributeGraph.External : Swift.CustomStringConvertible {
   public init(_ attribute: AttributeGraph.Attribute<Value>)
   public init(value: Value)
   public init(type _: Value.Type)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init<Body>(body: Swift.UnsafePointer<Body>, value: Swift.UnsafePointer<Value>?, flags: AttributeGraph._AttributeType.Flags = [], update: () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void) where Body : AttributeGraph._AttributeBody
-  #endif
   public var wrappedValue: Value {
     unsafeAddress
     nonmutating set
@@ -169,10 +163,8 @@ extension AttributeGraph.Attribute {
   public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.Rule
   public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.StatefulRule
 }
-#if compiler(>=5.3) && $NonescapableTypes
 @_silgen_name("AGGraphCreateAttribute")
 @inline(__always) @inlinable internal func AGGraphCreateAttribute(index: Swift.Int, body: Swift.UnsafeRawPointer, value: Swift.UnsafeRawPointer?) -> AttributeGraph.AnyAttribute
-#endif
 @_silgen_name("AGGraphGetValue")
 @inline(__always) @inlinable internal func AGGraphGetValue<Value>(_ attribute: AttributeGraph.AnyAttribute, options: AttributeGraph.AGValueOptions = [], type: Value.Type = Value.self) -> AttributeGraph.AGValue
 @_silgen_name("AGGraphSetValue")
@@ -215,40 +207,26 @@ extension AttributeGraph._AttributeBody {
   public init(base: AttributeGraph.AnyWeakAttribute)
   public init()
   public init(_ attribute: AttributeGraph.Attribute<Value>)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.Attribute<Value>?)
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var wrappedValue: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var projectedValue: AttributeGraph.Attribute<Value>? {
     get
     set
     _modify
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.Attribute<Value>? {
     get
     set
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var value: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
-  #endif
 }
 extension AttributeGraph.WeakAttribute : Swift.Hashable {
   public static func == (a: AttributeGraph.WeakAttribute<Value>, b: AttributeGraph.WeakAttribute<Value>) -> Swift.Bool
@@ -263,17 +241,13 @@ extension AttributeGraph.WeakAttribute : Swift.CustomStringConvertible {
   }
 }
 extension AttributeGraph.AnyWeakAttribute {
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.AnyAttribute?)
-  #endif
   public init<Value>(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.WeakAttribute<Value>
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.AnyAttribute? {
     get
     set
   }
-  #endif
 }
 extension AttributeGraph.AnyWeakAttribute : Swift.Hashable {
   public static func == (lhs: AttributeGraph.AnyWeakAttribute, rhs: AttributeGraph.AnyWeakAttribute) -> Swift.Bool
@@ -289,17 +263,13 @@ extension AttributeGraph.AnyWeakAttribute : Swift.CustomStringConvertible {
 }
 public protocol Rule : AttributeGraph._AttributeBody {
   associatedtype Value
-  #if compiler(>=5.3) && $NonescapableTypes
   static var initialValue: Self.Value? { get }
-  #endif
   var value: Self.Value { get }
 }
 extension AttributeGraph.Rule {
-  #if compiler(>=5.3) && $NonescapableTypes
   public static var initialValue: Self.Value? {
     get
   }
-  #endif
   public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AttributeGraph.AnyAttribute)
   public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
 }
@@ -312,15 +282,9 @@ extension AttributeGraph.Rule {
   }
 }
 extension AttributeGraph.Rule where Self : Swift.Hashable {
-  #if compiler(>=5.3) && $NonescapableTypes
   public func cachedValue(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?) -> Self.Value
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func cachedValueIfExists(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?) -> Self.Value?
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public static func _cachedValue(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?, hashValue: Swift.Int, bodyPtr: Swift.UnsafeRawPointer, update: () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void) -> Swift.UnsafePointer<Self.Value>
-  #endif
 }
 @frozen public struct Map<Source, Value> : AttributeGraph.Rule, Swift.CustomStringConvertible {
   public var arg: AttributeGraph.Attribute<Source>
@@ -338,17 +302,13 @@ extension AttributeGraph.Rule where Self : Swift.Hashable {
 }
 public protocol StatefulRule : AttributeGraph._AttributeBody {
   associatedtype Value
-  #if compiler(>=5.3) && $NonescapableTypes
   static var initialValue: Self.Value? { get }
-  #endif
   mutating func updateValue()
 }
 extension AttributeGraph.StatefulRule {
-  #if compiler(>=5.3) && $NonescapableTypes
   public static var initialValue: Self.Value? {
     get
   }
-  #endif
   public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AttributeGraph.AnyAttribute)
   public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
 }
@@ -386,44 +346,28 @@ extension AttributeGraph.StatefulRule {
   public init()
   public init(base: AttributeGraph.AnyOptionalAttribute)
   public init(_ attribute: AttributeGraph.Attribute<Value>)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.Attribute<Value>?)
-  #endif
   public init(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.Attribute<Value>? {
     get
     set
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var value: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func map<V>(_ body: (AttributeGraph.Attribute<Value>) -> V) -> V?
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var wrappedValue: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var projectedValue: AttributeGraph.Attribute<Value>? {
     get
     set
     _modify
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
     get
   }
-  #endif
 }
 extension AttributeGraph.OptionalAttribute : Swift.Hashable {
   public static func == (a: AttributeGraph.OptionalAttribute<Value>, b: AttributeGraph.OptionalAttribute<Value>) -> Swift.Bool
@@ -441,22 +385,16 @@ extension AttributeGraph.OptionalAttribute : Swift.CustomStringConvertible {
   public var identifier: AttributeGraph.AnyAttribute
   public init()
   public init(_ attribute: AttributeGraph.AnyAttribute)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.AnyAttribute?)
-  #endif
   public init<Value>(_ attribute: AttributeGraph.OptionalAttribute<Value>)
   public static var current: AttributeGraph.AnyOptionalAttribute {
     get
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.AnyAttribute? {
     get
     set
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func map<Value>(_ body: (AttributeGraph.AnyAttribute) -> Value) -> Value?
-  #endif
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.OptionalAttribute<Value>
 }
 extension AttributeGraph.AnyOptionalAttribute : Swift.Hashable {
@@ -478,12 +416,10 @@ extension AttributeGraph.AnyOptionalAttribute : Swift.CustomStringConvertible {
     get
     nonmutating set
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public var dependency: AttributeGraph.AnyAttribute? {
     get
     nonmutating set
   }
-  #endif
   public var value: Value {
     get
     nonmutating set
@@ -516,16 +452,12 @@ extension AttributeGraph.IndirectAttribute : Swift.Hashable {
   public subscript<V>(attribute: AttributeGraph.Attribute<V>) -> V {
     unsafeAddress
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(weakAttribute: AttributeGraph.WeakAttribute<V>) -> V? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(optionalAttribute: AttributeGraph.OptionalAttribute<V>) -> V? {
     get
   }
-  #endif
   public func valueAndFlags<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, flags: AttributeGraph.AGChangedValueFlags)
   public func changedValue<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, changed: Swift.Bool)
   public func update(body: () -> Swift.Void)
@@ -538,16 +470,12 @@ extension AttributeGraph.IndirectAttribute : Swift.Hashable {
   public subscript<V>(attribute: AttributeGraph.Attribute<V>) -> V {
     unsafeAddress
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(weakAttribute: AttributeGraph.WeakAttribute<V>) -> V? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(optionalAttribute: AttributeGraph.OptionalAttribute<V>) -> V? {
     get
   }
-  #endif
   public var value: Value {
     unsafeAddress
     nonmutating set
@@ -609,10 +537,8 @@ extension AttributeGraph.Graph {
   }
 }
 extension AttributeGraph.Graph {
-  #if compiler(>=5.3) && $NonescapableTypes
   @_silgen_name("AGGraphGetOutputValue")
   @inline(__always) @inlinable public static func outputValue<Value>() -> Swift.UnsafePointer<Value>?
-  #endif
   @_silgen_name("AGGraphSetOutputValue")
   @inline(__always) @inlinable public static func setOutputValue<Value>(_ value: Swift.UnsafePointer<Value>)
 }
@@ -622,9 +548,7 @@ extension AttributeGraph.Graph {
     }
 }
 extension AttributeGraph.Graph {
-  #if compiler(>=5.3) && $NonescapableTypes
   public func archiveJSON(name: Swift.String?)
-  #endif
 }
 public func forEachField(of type: any Any.Type, do body: (Swift.UnsafePointer<Swift.Int8>, Swift.Int, any Any.Type) -> Swift.Void)
 extension AttributeGraph.Metadata : Swift.Hashable, Swift.CustomStringConvertible {

--- a/AG/2024/AttributeGraph.xcframework/macos-arm64e-arm64-x86_64/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/arm64-apple-macos.swiftinterface
+++ b/AG/2024/AttributeGraph.xcframework/macos-arm64e-arm64-x86_64/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/arm64-apple-macos.swiftinterface
@@ -7,19 +7,21 @@ public import Swift
 public import _Concurrency
 public import _StringProcessing
 public import _SwiftConcurrencyShims
-extension AnyAttribute {
+extension AttributeGraph.AnyAttribute {
   public init<Value>(_ attribute: AttributeGraph.Attribute<Value>)
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.Attribute<Value>
-  public static var current: AnyAttribute? {
+  #if compiler(>=5.3) && $NonescapableTypes
+  public static var current: AttributeGraph.AnyAttribute? {
     get
   }
-  public func unsafeOffset(at offset: Swift.Int) -> AnyAttribute
-  public func setFlags(_ newFlags: AnyAttribute.Flags, mask: AnyAttribute.Flags)
-  public func addInput(_ attribute: AnyAttribute, options: AGInputOptions = [], token: Swift.Int)
-  public func addInput<Value>(_ attribute: AttributeGraph.Attribute<Value>, options: AGInputOptions = [], token: Swift.Int)
+  #endif
+  public func unsafeOffset(at offset: Swift.Int) -> AttributeGraph.AnyAttribute
+  public func setFlags(_ newFlags: AttributeGraph.AnyAttribute.Flags, mask: AttributeGraph.AnyAttribute.Flags)
+  public func addInput(_ attribute: AttributeGraph.AnyAttribute, options: AttributeGraph.AGInputOptions = [], token: Swift.Int)
+  public func addInput<Value>(_ attribute: AttributeGraph.Attribute<Value>, options: AttributeGraph.AGInputOptions = [], token: Swift.Int)
   public func visitBody<Body>(_ visitor: inout Body) where Body : AttributeGraph.AttributeBodyVisitor
   public func mutateBody<Value>(as type: Value.Type, invalidating: Swift.Bool, _ body: (inout Value) -> Swift.Void)
-  public func breadthFirstSearch(options _: SearchOptions = [], _: (AnyAttribute) -> Swift.Bool) -> Swift.Bool
+  public func breadthFirstSearch(options _: AttributeGraph.SearchOptions = [], _: (AttributeGraph.AnyAttribute) -> Swift.Bool) -> Swift.Bool
   public var _bodyType: any Any.Type {
     get
   }
@@ -29,118 +31,19 @@ extension AnyAttribute {
   public var valueType: any Any.Type {
     get
   }
-  public var indirectDependency: AnyAttribute? {
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var indirectDependency: AttributeGraph.AnyAttribute? {
     get
     nonmutating set
   }
+  #endif
 }
-extension AnyAttribute : Swift.CustomStringConvertible {
+extension AttributeGraph.AnyAttribute : Swift.CustomStringConvertible {
   @inlinable public var description: Swift.String {
     get { "#\(rawValue)" }
   }
 }
-public typealias AttributeUpdateBlock = () -> (Swift.UnsafeMutableRawPointer, AnyAttribute) -> Swift.Void
-@frozen @propertyWrapper @dynamicMemberLookup public struct Attribute<Value> {
-  public var identifier: AnyAttribute
-  public init(identifier: AnyAttribute)
-  public init(_ attribute: AttributeGraph.Attribute<Value>)
-  public init(value: Value)
-  public init(type _: Value.Type)
-  public init<Body>(body: Swift.UnsafePointer<Body>, value: Swift.UnsafePointer<Value>?, flags: _AttributeType.Flags = [], update: () -> (Swift.UnsafeMutableRawPointer, AnyAttribute) -> Swift.Void) where Body : AttributeGraph._AttributeBody
-  public var wrappedValue: Value {
-    unsafeAddress
-    nonmutating set
-  }
-  public var projectedValue: AttributeGraph.Attribute<Value> {
-    get
-    set
-  }
-  public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member> {
-    get
-  }
-  public subscript<Member>(keyPath keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member> {
-    get
-  }
-  public subscript<Member>(offset body: (inout Value) -> AttributeGraph.PointerOffset<Value, Member>) -> AttributeGraph.Attribute<Member> {
-    get
-  }
-  public func unsafeCast<V>(to type: V.Type) -> AttributeGraph.Attribute<V>
-  public func unsafeOffset<Member>(at offset: Swift.Int, as _: Member.Type) -> AttributeGraph.Attribute<Member>
-  public func applying<Member>(offset: AttributeGraph.PointerOffset<Value, Member>) -> AttributeGraph.Attribute<Member>
-  public func visitBody<Body>(_ visitor: inout Body) where Body : AttributeGraph.AttributeBodyVisitor
-  public func mutateBody<V>(as type: V.Type, invalidating: Swift.Bool, _ body: (inout V) -> Swift.Void)
-  public func breadthFirstSearch(options: SearchOptions = [], _ body: (AnyAttribute) -> Swift.Bool) -> Swift.Bool
-  public var graph: Graph {
-    get
-  }
-  public var subgraph: Subgraph {
-    get
-  }
-  public var value: Value {
-    unsafeAddress
-    nonmutating set
-  }
-  public var valueState: ValueState {
-    get
-  }
-  public func valueAndFlags(options: AGValueOptions = []) -> (value: Value, flags: AGChangedValueFlags)
-  public func changedValue(options: AGValueOptions = []) -> (value: Value, changed: Swift.Bool)
-  public func setValue(_ value: Value) -> Swift.Bool
-  public var hasValue: Swift.Bool {
-    get
-  }
-  public func updateValue()
-  public func prefetchValue()
-  public func invalidateValue()
-  public func validate()
-  public func addInput(_ attribute: AnyAttribute, options: AGInputOptions = [], token: Swift.Int)
-  public func addInput<V>(_ attribute: AttributeGraph.Attribute<V>, options: AGInputOptions = [], token: Swift.Int)
-  public typealias Flags = AnyAttribute.Flags
-  public var flags: AttributeGraph.Attribute<Value>.Flags {
-    get
-    nonmutating set
-  }
-  public func setFlags(_ newFlags: AttributeGraph.Attribute<Value>.Flags, mask: AttributeGraph.Attribute<Value>.Flags)
-}
-extension AttributeGraph.Attribute : Swift.Hashable {
-  public static func == (a: AttributeGraph.Attribute<Value>, b: AttributeGraph.Attribute<Value>) -> Swift.Bool
-  public func hash(into hasher: inout Swift.Hasher)
-  public var hashValue: Swift.Int {
-    get
-  }
-}
-extension AttributeGraph.Attribute : Swift.CustomStringConvertible {
-  public var description: Swift.String {
-    get
-  }
-}
-extension AttributeGraph.Attribute {
-  public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.Rule
-  public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.StatefulRule
-}
-@_silgen_name("AGGraphCreateAttribute")
-@inline(__always) @inlinable internal func AGGraphCreateAttribute(index: Swift.Int, body: Swift.UnsafeRawPointer, value: Swift.UnsafeRawPointer?) -> AnyAttribute
-@_silgen_name("AGGraphGetValue")
-@inline(__always) @inlinable internal func AGGraphGetValue<Value>(_ attribute: AnyAttribute, options: AGValueOptions = [], type: Value.Type = Value.self) -> AGValue
-@_silgen_name("AGGraphSetValue")
-@inline(__always) @inlinable internal func AGGraphSetValue<Value>(_ attribute: AnyAttribute, valuePointer: Swift.UnsafePointer<Value>) -> Swift.Bool
-@frozen public struct External<Value> {
-  public init()
-}
-extension AttributeGraph.External : AttributeGraph._AttributeBody {
-  public static var comparisonMode: ComparisonMode {
-    get
-  }
-  public static var flags: AttributeGraph.External<Value>.Flags {
-    get
-  }
-  public static func _update(_: Swift.UnsafeMutableRawPointer, attribute _: AnyAttribute)
-}
-extension AttributeGraph.External : Swift.CustomStringConvertible {
-  public var description: Swift.String {
-    get
-  }
-}
+public typealias AttributeUpdateBlock = () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void
 @frozen public struct PointerOffset<Base, Member> {
   public var byteOffset: Swift.Int
   public init(byteOffset: Swift.Int)
@@ -169,27 +72,111 @@ extension Swift.UnsafeMutablePointer {
   }
   public static func + <Member>(lhs: Swift.UnsafeMutablePointer<Pointee>, rhs: AttributeGraph.PointerOffset<Pointee, Member>) -> Swift.UnsafeMutablePointer<Member>
 }
-public protocol _AttributeBody {
-  static func _destroySelf(_ pointer: Swift.UnsafeMutableRawPointer)
-  static var _hasDestroySelf: Swift.Bool { get }
-  static func _updateDefault(_ pointer: Swift.UnsafeMutableRawPointer)
-  static var comparisonMode: ComparisonMode { get }
-  typealias Flags = _AttributeType.Flags
-  static var flags: Self.Flags { get }
+@frozen public struct External<Value> {
+  public init()
 }
-extension AttributeGraph._AttributeBody {
-  public static func _destroySelf(_ pointer: Swift.UnsafeMutableRawPointer)
-  public static var _hasDestroySelf: Swift.Bool {
+extension AttributeGraph.External : AttributeGraph._AttributeBody {
+  public static var comparisonMode: AttributeGraph.ComparisonMode {
     get
   }
-  public static func _updateDefault(_ pointer: Swift.UnsafeMutableRawPointer)
-  public static var comparisonMode: ComparisonMode {
+  public static var flags: AttributeGraph.External<Value>.Flags {
     get
   }
-  public static var flags: Self.Flags {
+  public static func _update(_: Swift.UnsafeMutableRawPointer, attribute _: AttributeGraph.AnyAttribute)
+}
+extension AttributeGraph.External : Swift.CustomStringConvertible {
+  public var description: Swift.String {
     get
   }
 }
+@frozen @propertyWrapper @dynamicMemberLookup public struct Attribute<Value> {
+  public var identifier: AttributeGraph.AnyAttribute
+  public init(identifier: AttributeGraph.AnyAttribute)
+  public init(_ attribute: AttributeGraph.Attribute<Value>)
+  public init(value: Value)
+  public init(type _: Value.Type)
+  #if compiler(>=5.3) && $NonescapableTypes
+  public init<Body>(body: Swift.UnsafePointer<Body>, value: Swift.UnsafePointer<Value>?, flags: AttributeGraph._AttributeType.Flags = [], update: () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void) where Body : AttributeGraph._AttributeBody
+  #endif
+  public var wrappedValue: Value {
+    unsafeAddress
+    nonmutating set
+  }
+  public var projectedValue: AttributeGraph.Attribute<Value> {
+    get
+    set
+  }
+  public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member> {
+    get
+  }
+  public subscript<Member>(keyPath keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member> {
+    get
+  }
+  public subscript<Member>(offset body: (inout Value) -> AttributeGraph.PointerOffset<Value, Member>) -> AttributeGraph.Attribute<Member> {
+    get
+  }
+  public func unsafeCast<V>(to type: V.Type) -> AttributeGraph.Attribute<V>
+  public func unsafeOffset<Member>(at offset: Swift.Int, as _: Member.Type) -> AttributeGraph.Attribute<Member>
+  public func applying<Member>(offset: AttributeGraph.PointerOffset<Value, Member>) -> AttributeGraph.Attribute<Member>
+  public func visitBody<Body>(_ visitor: inout Body) where Body : AttributeGraph.AttributeBodyVisitor
+  public func mutateBody<V>(as type: V.Type, invalidating: Swift.Bool, _ body: (inout V) -> Swift.Void)
+  public func breadthFirstSearch(options: AttributeGraph.SearchOptions = [], _ body: (AttributeGraph.AnyAttribute) -> Swift.Bool) -> Swift.Bool
+  public var graph: AttributeGraph.Graph {
+    get
+  }
+  public var subgraph: AttributeGraph.Subgraph {
+    get
+  }
+  public var value: Value {
+    unsafeAddress
+    nonmutating set
+  }
+  public var valueState: AttributeGraph.ValueState {
+    get
+  }
+  public func valueAndFlags(options: AttributeGraph.AGValueOptions = []) -> (value: Value, flags: AttributeGraph.AGChangedValueFlags)
+  public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)
+  public func setValue(_ value: Value) -> Swift.Bool
+  public var hasValue: Swift.Bool {
+    get
+  }
+  public func updateValue()
+  public func prefetchValue()
+  public func invalidateValue()
+  public func validate()
+  public func addInput(_ attribute: AttributeGraph.AnyAttribute, options: AttributeGraph.AGInputOptions = [], token: Swift.Int)
+  public func addInput<V>(_ attribute: AttributeGraph.Attribute<V>, options: AttributeGraph.AGInputOptions = [], token: Swift.Int)
+  public typealias Flags = AttributeGraph.AnyAttribute.Flags
+  public var flags: AttributeGraph.Attribute<Value>.Flags {
+    get
+    nonmutating set
+  }
+  public func setFlags(_ newFlags: AttributeGraph.Attribute<Value>.Flags, mask: AttributeGraph.Attribute<Value>.Flags)
+}
+extension AttributeGraph.Attribute : Swift.Hashable {
+  public static func == (a: AttributeGraph.Attribute<Value>, b: AttributeGraph.Attribute<Value>) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+extension AttributeGraph.Attribute : Swift.CustomStringConvertible {
+  public var description: Swift.String {
+    get
+  }
+}
+extension AttributeGraph.Attribute {
+  public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.Rule
+  public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.StatefulRule
+}
+#if compiler(>=5.3) && $NonescapableTypes
+@_silgen_name("AGGraphCreateAttribute")
+@inline(__always) @inlinable internal func AGGraphCreateAttribute(index: Swift.Int, body: Swift.UnsafeRawPointer, value: Swift.UnsafeRawPointer?) -> AttributeGraph.AnyAttribute
+#endif
+@_silgen_name("AGGraphGetValue")
+@inline(__always) @inlinable internal func AGGraphGetValue<Value>(_ attribute: AttributeGraph.AnyAttribute, options: AttributeGraph.AGValueOptions = [], type: Value.Type = Value.self) -> AttributeGraph.AGValue
+@_silgen_name("AGGraphSetValue")
+@inline(__always) @inlinable internal func AGGraphSetValue<Value>(_ attribute: AttributeGraph.AnyAttribute, valuePointer: Swift.UnsafePointer<Value>) -> Swift.Bool
 public protocol AttributeBodyVisitor {
   func visit<Body>(body: Swift.UnsafePointer<Body>) where Body : AttributeGraph._AttributeBody
 }
@@ -202,23 +189,307 @@ extension AttributeGraph.ObservedAttribute {
     get
   }
 }
+public protocol _AttributeBody {
+  static func _destroySelf(_ pointer: Swift.UnsafeMutableRawPointer)
+  static var _hasDestroySelf: Swift.Bool { get }
+  static func _updateDefault(_ pointer: Swift.UnsafeMutableRawPointer)
+  static var comparisonMode: AttributeGraph.ComparisonMode { get }
+  typealias Flags = AttributeGraph._AttributeType.Flags
+  static var flags: Self.Flags { get }
+}
+extension AttributeGraph._AttributeBody {
+  public static func _destroySelf(_ pointer: Swift.UnsafeMutableRawPointer)
+  public static var _hasDestroySelf: Swift.Bool {
+    get
+  }
+  public static func _updateDefault(_ pointer: Swift.UnsafeMutableRawPointer)
+  public static var comparisonMode: AttributeGraph.ComparisonMode {
+    get
+  }
+  public static var flags: Self.Flags {
+    get
+  }
+}
+@frozen @propertyWrapper @dynamicMemberLookup public struct WeakAttribute<Value> {
+  internal var base: AttributeGraph.AnyWeakAttribute
+  public init(base: AttributeGraph.AnyWeakAttribute)
+  public init()
+  public init(_ attribute: AttributeGraph.Attribute<Value>)
+  #if compiler(>=5.3) && $NonescapableTypes
+  public init(_ attribute: AttributeGraph.Attribute<Value>?)
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var wrappedValue: Value? {
+    get
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var projectedValue: AttributeGraph.Attribute<Value>? {
+    get
+    set
+    _modify
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
+    get
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var attribute: AttributeGraph.Attribute<Value>? {
+    get
+    set
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var value: Value? {
+    get
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
+  #endif
+}
+extension AttributeGraph.WeakAttribute : Swift.Hashable {
+  public static func == (a: AttributeGraph.WeakAttribute<Value>, b: AttributeGraph.WeakAttribute<Value>) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+extension AttributeGraph.WeakAttribute : Swift.CustomStringConvertible {
+  public var description: Swift.String {
+    get
+  }
+}
+extension AttributeGraph.AnyWeakAttribute {
+  #if compiler(>=5.3) && $NonescapableTypes
+  public init(_ attribute: AttributeGraph.AnyAttribute?)
+  #endif
+  public init<Value>(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
+  public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.WeakAttribute<Value>
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var attribute: AttributeGraph.AnyAttribute? {
+    get
+    set
+  }
+  #endif
+}
+extension AttributeGraph.AnyWeakAttribute : Swift.Hashable {
+  public static func == (lhs: AttributeGraph.AnyWeakAttribute, rhs: AttributeGraph.AnyWeakAttribute) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+extension AttributeGraph.AnyWeakAttribute : Swift.CustomStringConvertible {
+  @_alwaysEmitIntoClient public var description: Swift.String {
+    get { attribute?.description ?? "nil" }
+  }
+}
+public protocol Rule : AttributeGraph._AttributeBody {
+  associatedtype Value
+  #if compiler(>=5.3) && $NonescapableTypes
+  static var initialValue: Self.Value? { get }
+  #endif
+  var value: Self.Value { get }
+}
+extension AttributeGraph.Rule {
+  #if compiler(>=5.3) && $NonescapableTypes
+  public static var initialValue: Self.Value? {
+    get
+  }
+  #endif
+  public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AttributeGraph.AnyAttribute)
+  public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
+}
+extension AttributeGraph.Rule {
+  public var attribute: AttributeGraph.Attribute<Self.Value> {
+    get
+  }
+  public var context: AttributeGraph.RuleContext<Self.Value> {
+    get
+  }
+}
+extension AttributeGraph.Rule where Self : Swift.Hashable {
+  #if compiler(>=5.3) && $NonescapableTypes
+  public func cachedValue(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?) -> Self.Value
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public func cachedValueIfExists(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?) -> Self.Value?
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public static func _cachedValue(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?, hashValue: Swift.Int, bodyPtr: Swift.UnsafeRawPointer, update: () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void) -> Swift.UnsafePointer<Self.Value>
+  #endif
+}
+@frozen public struct Map<Source, Value> : AttributeGraph.Rule, Swift.CustomStringConvertible {
+  public var arg: AttributeGraph.Attribute<Source>
+  public let body: (Source) -> Value
+  public init(_ arg: AttributeGraph.Attribute<Source>, _ body: @escaping (Source) -> Value)
+  public var value: Value {
+    get
+  }
+  public static var flags: AttributeGraph.Map<Source, Value>.Flags {
+    get
+  }
+  public var description: Swift.String {
+    get
+  }
+}
+public protocol StatefulRule : AttributeGraph._AttributeBody {
+  associatedtype Value
+  #if compiler(>=5.3) && $NonescapableTypes
+  static var initialValue: Self.Value? { get }
+  #endif
+  mutating func updateValue()
+}
+extension AttributeGraph.StatefulRule {
+  #if compiler(>=5.3) && $NonescapableTypes
+  public static var initialValue: Self.Value? {
+    get
+  }
+  #endif
+  public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AttributeGraph.AnyAttribute)
+  public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
+}
+extension AttributeGraph.StatefulRule {
+  public var attribute: AttributeGraph.Attribute<Self.Value> {
+    get
+  }
+  public var context: AttributeGraph.RuleContext<Self.Value> {
+    get
+  }
+  public var value: Self.Value {
+    unsafeAddress
+    nonmutating set
+  }
+  public var hasValue: Swift.Bool {
+    get
+  }
+}
+@frozen public struct Focus<Root, Value> : AttributeGraph.Rule, Swift.CustomStringConvertible {
+  public var root: AttributeGraph.Attribute<Root>
+  public var keyPath: Swift.KeyPath<Root, Value>
+  public init(root: AttributeGraph.Attribute<Root>, keyPath: Swift.KeyPath<Root, Value>)
+  public var value: Value {
+    get
+  }
+  public static var flags: AttributeGraph.Focus<Root, Value>.Flags {
+    get
+  }
+  public var description: Swift.String {
+    get
+  }
+}
+@frozen @propertyWrapper @dynamicMemberLookup public struct OptionalAttribute<Value> {
+  public var base: AttributeGraph.AnyOptionalAttribute
+  public init()
+  public init(base: AttributeGraph.AnyOptionalAttribute)
+  public init(_ attribute: AttributeGraph.Attribute<Value>)
+  #if compiler(>=5.3) && $NonescapableTypes
+  public init(_ attribute: AttributeGraph.Attribute<Value>?)
+  #endif
+  public init(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var attribute: AttributeGraph.Attribute<Value>? {
+    get
+    set
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var value: Value? {
+    get
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public func map<V>(_ body: (AttributeGraph.Attribute<Value>) -> V) -> V?
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var wrappedValue: Value? {
+    get
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var projectedValue: AttributeGraph.Attribute<Value>? {
+    get
+    set
+    _modify
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
+    get
+  }
+  #endif
+}
+extension AttributeGraph.OptionalAttribute : Swift.Hashable {
+  public static func == (a: AttributeGraph.OptionalAttribute<Value>, b: AttributeGraph.OptionalAttribute<Value>) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+extension AttributeGraph.OptionalAttribute : Swift.CustomStringConvertible {
+  public var description: Swift.String {
+    get
+  }
+}
+@frozen public struct AnyOptionalAttribute {
+  public var identifier: AttributeGraph.AnyAttribute
+  public init()
+  public init(_ attribute: AttributeGraph.AnyAttribute)
+  #if compiler(>=5.3) && $NonescapableTypes
+  public init(_ attribute: AttributeGraph.AnyAttribute?)
+  #endif
+  public init<Value>(_ attribute: AttributeGraph.OptionalAttribute<Value>)
+  public static var current: AttributeGraph.AnyOptionalAttribute {
+    get
+  }
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var attribute: AttributeGraph.AnyAttribute? {
+    get
+    set
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public func map<Value>(_ body: (AttributeGraph.AnyAttribute) -> Value) -> Value?
+  #endif
+  public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.OptionalAttribute<Value>
+}
+extension AttributeGraph.AnyOptionalAttribute : Swift.Hashable {
+  public static func == (a: AttributeGraph.AnyOptionalAttribute, b: AttributeGraph.AnyOptionalAttribute) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+extension AttributeGraph.AnyOptionalAttribute : Swift.CustomStringConvertible {
+  public var description: Swift.String {
+    get
+  }
+}
 @frozen @propertyWrapper @dynamicMemberLookup public struct IndirectAttribute<Value> {
-  public let identifier: AnyAttribute
+  public let identifier: AttributeGraph.AnyAttribute
   public init(source: AttributeGraph.Attribute<Value>)
   public var source: AttributeGraph.Attribute<Value> {
     get
     nonmutating set
   }
-  public var dependency: AnyAttribute? {
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var dependency: AttributeGraph.AnyAttribute? {
     get
     nonmutating set
   }
+  #endif
   public var value: Value {
     get
     nonmutating set
     nonmutating _modify
   }
-  public func changedValue(options: AGValueOptions = []) -> (value: Value, changed: Swift.Bool)
+  public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)
   public var wrappedValue: Value {
     get
     nonmutating set
@@ -238,169 +509,25 @@ extension AttributeGraph.IndirectAttribute : Swift.Hashable {
     get
   }
 }
-@frozen public struct AnyOptionalAttribute {
-  public var identifier: AnyAttribute
-  public init()
-  public init(_ attribute: AnyAttribute)
-  public init(_ attribute: AnyAttribute?)
-  public init<Value>(_ attribute: AttributeGraph.OptionalAttribute<Value>)
-  public static var current: AttributeGraph.AnyOptionalAttribute {
-    get
-  }
-  public var attribute: AnyAttribute? {
-    get
-    set
-  }
-  public func map<Value>(_ body: (AnyAttribute) -> Value) -> Value?
-  public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.OptionalAttribute<Value>
-}
-extension AttributeGraph.AnyOptionalAttribute : Swift.Hashable {
-  public static func == (a: AttributeGraph.AnyOptionalAttribute, b: AttributeGraph.AnyOptionalAttribute) -> Swift.Bool
-  public func hash(into hasher: inout Swift.Hasher)
-  public var hashValue: Swift.Int {
-    get
-  }
-}
-extension AttributeGraph.AnyOptionalAttribute : Swift.CustomStringConvertible {
-  public var description: Swift.String {
-    get
-  }
-}
-@frozen @propertyWrapper @dynamicMemberLookup public struct OptionalAttribute<Value> {
-  public var base: AttributeGraph.AnyOptionalAttribute
-  public init()
-  public init(base: AttributeGraph.AnyOptionalAttribute)
-  public init(_ attribute: AttributeGraph.Attribute<Value>)
-  public init(_ attribute: AttributeGraph.Attribute<Value>?)
-  public init(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
-  public var attribute: AttributeGraph.Attribute<Value>? {
-    get
-    set
-  }
-  public var value: Value? {
-    get
-  }
-  public func changedValue(options: AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
-  public func map<V>(_ body: (AttributeGraph.Attribute<Value>) -> V) -> V?
-  public var wrappedValue: Value? {
-    get
-  }
-  public var projectedValue: AttributeGraph.Attribute<Value>? {
-    get
-    set
-    _modify
-  }
-  public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
-    get
-  }
-}
-extension AttributeGraph.OptionalAttribute : Swift.Hashable {
-  public static func == (a: AttributeGraph.OptionalAttribute<Value>, b: AttributeGraph.OptionalAttribute<Value>) -> Swift.Bool
-  public func hash(into hasher: inout Swift.Hasher)
-  public var hashValue: Swift.Int {
-    get
-  }
-}
-extension AttributeGraph.OptionalAttribute : Swift.CustomStringConvertible {
-  public var description: Swift.String {
-    get
-  }
-}
-@frozen public struct Focus<Root, Value> : AttributeGraph.Rule, Swift.CustomStringConvertible {
-  public var root: AttributeGraph.Attribute<Root>
-  public var keyPath: Swift.KeyPath<Root, Value>
-  public init(root: AttributeGraph.Attribute<Root>, keyPath: Swift.KeyPath<Root, Value>)
-  public var value: Value {
-    get
-  }
-  public static var flags: AttributeGraph.Focus<Root, Value>.Flags {
-    get
-  }
-  public var description: Swift.String {
-    get
-  }
-}
-@frozen public struct Map<Source, Value> : AttributeGraph.Rule, Swift.CustomStringConvertible {
-  public var arg: AttributeGraph.Attribute<Source>
-  public let body: (Source) -> Value
-  public init(_ arg: AttributeGraph.Attribute<Source>, _ body: @escaping (Source) -> Value)
-  public var value: Value {
-    get
-  }
-  public static var flags: AttributeGraph.Map<Source, Value>.Flags {
-    get
-  }
-  public var description: Swift.String {
-    get
-  }
-}
-public protocol Rule : AttributeGraph._AttributeBody {
-  associatedtype Value
-  static var initialValue: Self.Value? { get }
-  var value: Self.Value { get }
-}
-extension AttributeGraph.Rule {
-  public static var initialValue: Self.Value? {
-    get
-  }
-  public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AnyAttribute)
-  public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
-}
-extension AttributeGraph.Rule {
-  public var attribute: AttributeGraph.Attribute<Self.Value> {
-    get
-  }
-  public var context: AttributeGraph.RuleContext<Self.Value> {
-    get
-  }
-}
-extension AttributeGraph.Rule where Self : Swift.Hashable {
-  public func cachedValue(options: AGCachedValueOptions = [], owner: AnyAttribute?) -> Self.Value
-  public func cachedValueIfExists(options: AGCachedValueOptions = [], owner: AnyAttribute?) -> Self.Value?
-  public static func _cachedValue(options: AGCachedValueOptions = [], owner: AnyAttribute?, hashValue: Swift.Int, bodyPtr: Swift.UnsafeRawPointer, update: () -> (Swift.UnsafeMutableRawPointer, AnyAttribute) -> Swift.Void) -> Swift.UnsafePointer<Self.Value>
-}
-public protocol StatefulRule : AttributeGraph._AttributeBody {
-  associatedtype Value
-  static var initialValue: Self.Value? { get }
-  mutating func updateValue()
-}
-extension AttributeGraph.StatefulRule {
-  public static var initialValue: Self.Value? {
-    get
-  }
-  public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AnyAttribute)
-  public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
-}
-extension AttributeGraph.StatefulRule {
-  public var attribute: AttributeGraph.Attribute<Self.Value> {
-    get
-  }
-  public var context: AttributeGraph.RuleContext<Self.Value> {
-    get
-  }
-  public var value: Self.Value {
-    unsafeAddress
-    nonmutating set
-  }
-  public var hasValue: Swift.Bool {
-    get
-  }
-}
 @frozen public struct AnyRuleContext : Swift.Equatable {
-  public var attribute: AnyAttribute
-  public init(attribute: AnyAttribute)
+  public var attribute: AttributeGraph.AnyAttribute
+  public init(attribute: AttributeGraph.AnyAttribute)
   public init<V>(_ context: AttributeGraph.RuleContext<V>)
   public subscript<V>(attribute: AttributeGraph.Attribute<V>) -> V {
     unsafeAddress
   }
+  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(weakAttribute: AttributeGraph.WeakAttribute<V>) -> V? {
     get
   }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(optionalAttribute: AttributeGraph.OptionalAttribute<V>) -> V? {
     get
   }
-  public func valueAndFlags<V>(of input: AttributeGraph.Attribute<V>, options: AGValueOptions = []) -> (value: V, flags: AGChangedValueFlags)
-  public func changedValue<V>(of input: AttributeGraph.Attribute<V>, options: AGValueOptions = []) -> (value: V, changed: Swift.Bool)
+  #endif
+  public func valueAndFlags<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, flags: AttributeGraph.AGChangedValueFlags)
+  public func changedValue<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, changed: Swift.Bool)
   public func update(body: () -> Swift.Void)
   public func unsafeCast<V>(to _: V.Type) -> AttributeGraph.RuleContext<V>
   public static func == (a: AttributeGraph.AnyRuleContext, b: AttributeGraph.AnyRuleContext) -> Swift.Bool
@@ -411,12 +538,16 @@ extension AttributeGraph.StatefulRule {
   public subscript<V>(attribute: AttributeGraph.Attribute<V>) -> V {
     unsafeAddress
   }
+  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(weakAttribute: AttributeGraph.WeakAttribute<V>) -> V? {
     get
   }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(optionalAttribute: AttributeGraph.OptionalAttribute<V>) -> V? {
     get
   }
+  #endif
   public var value: Value {
     unsafeAddress
     nonmutating set
@@ -424,86 +555,41 @@ extension AttributeGraph.StatefulRule {
   public var hasValue: Swift.Bool {
     get
   }
-  public func valueAndFlags<V>(of input: AttributeGraph.Attribute<V>, options: AGValueOptions = []) -> (value: V, flags: AGChangedValueFlags)
-  public func changedValue<V>(of input: AttributeGraph.Attribute<V>, options: AGValueOptions = []) -> (value: V, changed: Swift.Bool)
+  public func valueAndFlags<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, flags: AttributeGraph.AGChangedValueFlags)
+  public func changedValue<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, changed: Swift.Bool)
   public func update(body: () -> Swift.Void)
   public static func == (a: AttributeGraph.RuleContext<Value>, b: AttributeGraph.RuleContext<Value>) -> Swift.Bool
 }
 @_silgen_name("AGGraphGetInputValue")
-@inline(__always) @inlinable internal func AGGraphGetInputValue<Value>(_ attribute: AnyAttribute, input: AnyAttribute, options: AGValueOptions = [], type: Value.Type = Value.self) -> AGValue
+@inline(__always) @inlinable internal func AGGraphGetInputValue<Value>(_ attribute: AttributeGraph.AnyAttribute, input: AttributeGraph.AnyAttribute, options: AttributeGraph.AGValueOptions = [], type: Value.Type = Value.self) -> AttributeGraph.AGValue
 @_silgen_name("AGGraphWithUpdate")
-@inline(__always) @inlinable internal func AGGraphWithUpdate(_ attribute: AnyAttribute, body: () -> Swift.Void)
-extension AnyWeakAttribute {
-  public init(_ attribute: AnyAttribute?)
-  public init<Value>(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
-  public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.WeakAttribute<Value>
-  public var attribute: AnyAttribute? {
-    get
-    set
-  }
+@inline(__always) @inlinable internal func AGGraphWithUpdate(_ attribute: AttributeGraph.AnyAttribute, body: () -> Swift.Void)
+extension AttributeGraph.Subgraph {
+  public typealias Flags = AttributeGraph.AnyAttribute.Flags
+  public typealias ChildFlags = AttributeGraph.AnyAttribute.Flags
 }
-extension AnyWeakAttribute : Swift.Hashable {
-  public static func == (lhs: AnyWeakAttribute, rhs: AnyWeakAttribute) -> Swift.Bool
-  public func hash(into hasher: inout Swift.Hasher)
-  public var hashValue: Swift.Int {
-    get
-  }
+extension AttributeGraph.Subgraph {
+  public func addObserver(_ observer: @escaping () -> Swift.Void) -> Swift.Int
+  public func apply<Value>(_ body: () -> Value) -> Value
+  public func forEach(_ flags: AttributeGraph.Subgraph.Flags, _ callback: (AttributeGraph.AnyAttribute) -> Swift.Void)
 }
-extension AnyWeakAttribute : Swift.CustomStringConvertible {
-  @_alwaysEmitIntoClient public var description: Swift.String {
-    get { attribute?.description ?? "nil" }
-  }
+extension AttributeGraph.Subgraph {
+  public static func beginTreeElement<Value>(value: AttributeGraph.Attribute<Value>, flags: Swift.UInt32)
+  public static func addTreeValue<Value>(_ value: AttributeGraph.Attribute<Value>, forKey key: Swift.UnsafePointer<Swift.Int8>, flags: Swift.UInt32)
+  public static func endTreeElement<Value>(value: AttributeGraph.Attribute<Value>)
 }
-@frozen @propertyWrapper @dynamicMemberLookup public struct WeakAttribute<Value> {
-  internal var base: AnyWeakAttribute
-  public init(base: AnyWeakAttribute)
-  public init()
-  public init(_ attribute: AttributeGraph.Attribute<Value>)
-  public init(_ attribute: AttributeGraph.Attribute<Value>?)
-  public var wrappedValue: Value? {
-    get
-  }
-  public var projectedValue: AttributeGraph.Attribute<Value>? {
-    get
-    set
-    _modify
-  }
-  public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
-    get
-  }
-  public var attribute: AttributeGraph.Attribute<Value>? {
-    get
-    set
-  }
-  public var value: Value? {
-    get
-  }
-  public func changedValue(options: AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
+extension AttributeGraph.Graph {
+  public static func typeIndex(ctx: AttributeGraph.GraphContext, body: any AttributeGraph._AttributeBody.Type, valueType: AttributeGraph.Metadata, flags: AttributeGraph._AttributeType.Flags, update: () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void) -> Swift.Int
 }
-extension AttributeGraph.WeakAttribute : Swift.Hashable {
-  public static func == (a: AttributeGraph.WeakAttribute<Value>, b: AttributeGraph.WeakAttribute<Value>) -> Swift.Bool
-  public func hash(into hasher: inout Swift.Hasher)
-  public var hashValue: Swift.Int {
-    get
-  }
-}
-extension AttributeGraph.WeakAttribute : Swift.CustomStringConvertible {
-  public var description: Swift.String {
-    get
-  }
-}
-extension Graph {
-  public static func typeIndex(ctx: GraphContext, body: any AttributeGraph._AttributeBody.Type, valueType: Metadata, flags: _AttributeType.Flags, update: () -> (Swift.UnsafeMutableRawPointer, AnyAttribute) -> Swift.Void) -> Swift.Int
-}
-extension Graph {
+extension AttributeGraph.Graph {
   public static func withoutUpdate<V>(_ body: () -> V) -> V
   public func withoutSubgraphInvalidation<V>(_ body: () -> V) -> V
   public func withDeadline<V>(_: Swift.UInt64, _: () -> V) -> V
-  public func onInvalidation(_ callback: @escaping (AnyAttribute) -> Swift.Void)
+  public func onInvalidation(_ callback: @escaping (AttributeGraph.AnyAttribute) -> Swift.Void)
   public func onUpdate(_ callback: @escaping () -> Swift.Void)
   public func withMainThreadHandler(_: (() -> Swift.Void) -> Swift.Void, do: () -> Swift.Void)
 }
-extension Graph {
+extension AttributeGraph.Graph {
   @_transparent public func startProfiling() {
         __AGGraphStartProfiling(self)
     }
@@ -517,46 +603,31 @@ extension Graph {
   public static func stopProfiling()
   public static func resetProfile()
 }
-extension Graph {
+extension AttributeGraph.Graph {
   @_transparent public var mainUpdates: Swift.Int {
     @_transparent get { numericCast(counter(for: .mainThreadUpdates)) }
   }
 }
-extension Graph {
+extension AttributeGraph.Graph {
+  #if compiler(>=5.3) && $NonescapableTypes
   @_silgen_name("AGGraphGetOutputValue")
   @inline(__always) @inlinable public static func outputValue<Value>() -> Swift.UnsafePointer<Value>?
+  #endif
   @_silgen_name("AGGraphSetOutputValue")
   @inline(__always) @inlinable public static func setOutputValue<Value>(_ value: Swift.UnsafePointer<Value>)
 }
-extension Graph {
-  @_transparent public static func anyInputsChanged(excluding excludedInputs: [AnyAttribute]) -> Swift.Bool {
+extension AttributeGraph.Graph {
+  @_transparent public static func anyInputsChanged(excluding excludedInputs: [AttributeGraph.AnyAttribute]) -> Swift.Bool {
         return __AGGraphAnyInputsChanged(excludedInputs, excludedInputs.count)
     }
 }
-extension Graph {
+extension AttributeGraph.Graph {
+  #if compiler(>=5.3) && $NonescapableTypes
   public func archiveJSON(name: Swift.String?)
-}
-extension Subgraph {
-  public typealias Flags = AnyAttribute.Flags
-  public typealias ChildFlags = AnyAttribute.Flags
-}
-extension Subgraph {
-  public func addObserver(_ observer: @escaping () -> Swift.Void) -> Swift.Int
-  public func apply<Value>(_ body: () -> Value) -> Value
-  public func forEach(_ flags: Subgraph.Flags, _ callback: (AnyAttribute) -> Swift.Void)
-}
-extension Subgraph {
-  public static func beginTreeElement<Value>(value: AttributeGraph.Attribute<Value>, flags: Swift.UInt32)
-  public static func addTreeValue<Value>(_ value: AttributeGraph.Attribute<Value>, forKey key: Swift.UnsafePointer<Swift.Int8>, flags: Swift.UInt32)
-  public static func endTreeElement<Value>(value: AttributeGraph.Attribute<Value>)
-}
-public func compareValues<Value>(_ lhs: Value, _ rhs: Value, mode: ComparisonMode = .equatableAlways) -> Swift.Bool
-public func compareValues<Value>(_ lhs: Value, _ rhs: Value, options: ComparisonOptions) -> Swift.Bool
-extension ComparisonOptions {
-  public init(mode: ComparisonMode)
+  #endif
 }
 public func forEachField(of type: any Any.Type, do body: (Swift.UnsafePointer<Swift.Int8>, Swift.Int, any Any.Type) -> Swift.Void)
-extension Metadata : Swift.Hashable, Swift.CustomStringConvertible {
+extension AttributeGraph.Metadata : Swift.Hashable, Swift.CustomStringConvertible {
   public init(_ type: any Any.Type)
   public var type: any Any.Type {
     get
@@ -564,16 +635,12 @@ extension Metadata : Swift.Hashable, Swift.CustomStringConvertible {
   public var description: Swift.String {
     get
   }
-  public func forEachField(options: Metadata.ApplyOptions, do body: (Swift.UnsafePointer<Swift.Int8>, Swift.Int, any Any.Type) -> Swift.Bool) -> Swift.Bool
+  public func forEachField(options: AttributeGraph.Metadata.ApplyOptions, do body: (Swift.UnsafePointer<Swift.Int8>, Swift.Int, any Any.Type) -> Swift.Bool) -> Swift.Bool
 }
-extension Signature : Swift.Equatable {
-  public static func == (lhs: Signature, rhs: Signature) -> Swift.Bool
+extension AttributeGraph.Signature : Swift.Equatable {
+  public static func == (lhs: AttributeGraph.Signature, rhs: AttributeGraph.Signature) -> Swift.Bool
 }
-@discardableResult
-public func withUnsafePointerToEnumCase<T>(of value: Swift.UnsafeMutablePointer<T>, do body: (Swift.Int, any Any.Type, Swift.UnsafeRawPointer) -> ()) -> Swift.Bool
-@discardableResult
-public func withUnsafeMutablePointerToEnumCase<T>(of value: Swift.UnsafeMutablePointer<T>, do body: (Swift.Int, any Any.Type, Swift.UnsafeMutableRawPointer) -> ()) -> Swift.Bool
-extension TupleType {
+extension AttributeGraph.TupleType {
   @_transparent public init(_ types: [any Any.Type]) {
         self.init(count: types.count, elements: types.map(Metadata.init))
     }
@@ -597,16 +664,16 @@ extension TupleType {
   @_transparent public func offset<T>(at index: Swift.Int, as type: T.Type) -> Swift.Int {
         elementOffset(at: index, type: Metadata(type))
     }
-  @_transparent public func setElement<T>(in tupleValue: Swift.UnsafeMutableRawPointer, at index: Swift.Int, from srcValue: Swift.UnsafePointer<T>, options: TupleType.CopyOptions) {
+  @_transparent public func setElement<T>(in tupleValue: Swift.UnsafeMutableRawPointer, at index: Swift.Int, from srcValue: Swift.UnsafePointer<T>, options: AttributeGraph.TupleType.CopyOptions) {
         __AGTupleSetElement(self, tupleValue, index, srcValue, Metadata(T.self), options)
     }
-  @_transparent public func getElement<T>(in tupleValue: Swift.UnsafeMutableRawPointer, at index: Swift.Int, to dstValue: Swift.UnsafeMutablePointer<T>, options: TupleType.CopyOptions) {
+  @_transparent public func getElement<T>(in tupleValue: Swift.UnsafeMutableRawPointer, at index: Swift.Int, to dstValue: Swift.UnsafeMutablePointer<T>, options: AttributeGraph.TupleType.CopyOptions) {
         __AGTupleGetElement(self, tupleValue, index, dstValue, Metadata(T.self), options)
     }
 }
 @_silgen_name("AGTupleWithBuffer")
-public func withUnsafeTuple(of type: TupleType, count: Swift.Int, _ body: (UnsafeMutableTuple) -> Swift.Void)
-extension UnsafeTuple {
+public func withUnsafeTuple(of type: AttributeGraph.TupleType, count: Swift.Int, _ body: (AttributeGraph.UnsafeMutableTuple) -> Swift.Void)
+extension AttributeGraph.UnsafeTuple {
   @_transparent public var count: Swift.Int {
     @_transparent get { type.count }
   }
@@ -633,8 +700,8 @@ extension UnsafeTuple {
     @_transparent unsafeAddress { address(of: index, as: T.self) }
   }
 }
-extension UnsafeMutableTuple {
-  @_transparent public init(with tupleType: TupleType) {
+extension AttributeGraph.UnsafeMutableTuple {
+  @_transparent public init(with tupleType: AttributeGraph.TupleType) {
         self.init(
             type: tupleType,
             value: UnsafeMutableRawPointer.allocate(
@@ -688,21 +755,30 @@ extension UnsafeMutableTuple {
     @_transparent nonmutating unsafeMutableAddress { address(of: index, as: T.self) }
   }
 }
-extension AttributeGraph.Attribute : Swift.Sendable {}
-extension AttributeGraph.Attribute : Swift.BitwiseCopyable {}
-extension AttributeGraph.External : Swift.Sendable {}
-extension AttributeGraph.External : Swift.BitwiseCopyable {}
+@discardableResult
+public func withUnsafePointerToEnumCase<T>(of value: Swift.UnsafeMutablePointer<T>, do body: (Swift.Int, any Any.Type, Swift.UnsafeRawPointer) -> ()) -> Swift.Bool
+@discardableResult
+public func withUnsafeMutablePointerToEnumCase<T>(of value: Swift.UnsafeMutablePointer<T>, do body: (Swift.Int, any Any.Type, Swift.UnsafeMutableRawPointer) -> ()) -> Swift.Bool
+public func compareValues<Value>(_ lhs: Value, _ rhs: Value, mode: AttributeGraph.ComparisonMode = .equatableAlways) -> Swift.Bool
+public func compareValues<Value>(_ lhs: Value, _ rhs: Value, options: AttributeGraph.ComparisonOptions) -> Swift.Bool
+extension AttributeGraph.ComparisonOptions {
+  public init(mode: AttributeGraph.ComparisonMode)
+}
 extension AttributeGraph.PointerOffset : Swift.Sendable {}
 extension AttributeGraph.PointerOffset : Swift.BitwiseCopyable {}
-extension AttributeGraph.IndirectAttribute : Swift.Sendable {}
-extension AttributeGraph.IndirectAttribute : Swift.BitwiseCopyable {}
-extension AttributeGraph.AnyOptionalAttribute : Swift.Sendable {}
-extension AttributeGraph.AnyOptionalAttribute : Swift.BitwiseCopyable {}
+extension AttributeGraph.External : Swift.Sendable {}
+extension AttributeGraph.External : Swift.BitwiseCopyable {}
+extension AttributeGraph.Attribute : Swift.Sendable {}
+extension AttributeGraph.Attribute : Swift.BitwiseCopyable {}
+extension AttributeGraph.WeakAttribute : Swift.Sendable {}
+extension AttributeGraph.WeakAttribute : Swift.BitwiseCopyable {}
 extension AttributeGraph.OptionalAttribute : Swift.Sendable {}
 extension AttributeGraph.OptionalAttribute : Swift.BitwiseCopyable {}
+extension AttributeGraph.AnyOptionalAttribute : Swift.Sendable {}
+extension AttributeGraph.AnyOptionalAttribute : Swift.BitwiseCopyable {}
+extension AttributeGraph.IndirectAttribute : Swift.Sendable {}
+extension AttributeGraph.IndirectAttribute : Swift.BitwiseCopyable {}
 extension AttributeGraph.AnyRuleContext : Swift.Sendable {}
 extension AttributeGraph.AnyRuleContext : Swift.BitwiseCopyable {}
 extension AttributeGraph.RuleContext : Swift.Sendable {}
 extension AttributeGraph.RuleContext : Swift.BitwiseCopyable {}
-extension AttributeGraph.WeakAttribute : Swift.Sendable {}
-extension AttributeGraph.WeakAttribute : Swift.BitwiseCopyable {}

--- a/AG/2024/AttributeGraph.xcframework/macos-arm64e-arm64-x86_64/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/arm64-apple-macos.swiftinterface
+++ b/AG/2024/AttributeGraph.xcframework/macos-arm64e-arm64-x86_64/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/arm64-apple-macos.swiftinterface
@@ -10,11 +10,9 @@ public import _SwiftConcurrencyShims
 extension AttributeGraph.AnyAttribute {
   public init<Value>(_ attribute: AttributeGraph.Attribute<Value>)
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.Attribute<Value>
-  #if compiler(>=5.3) && $NonescapableTypes
   public static var current: AttributeGraph.AnyAttribute? {
     get
   }
-  #endif
   public func unsafeOffset(at offset: Swift.Int) -> AttributeGraph.AnyAttribute
   public func setFlags(_ newFlags: AttributeGraph.AnyAttribute.Flags, mask: AttributeGraph.AnyAttribute.Flags)
   public func addInput(_ attribute: AttributeGraph.AnyAttribute, options: AttributeGraph.AGInputOptions = [], token: Swift.Int)
@@ -31,12 +29,10 @@ extension AttributeGraph.AnyAttribute {
   public var valueType: any Any.Type {
     get
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public var indirectDependency: AttributeGraph.AnyAttribute? {
     get
     nonmutating set
   }
-  #endif
 }
 extension AttributeGraph.AnyAttribute : Swift.CustomStringConvertible {
   @inlinable public var description: Swift.String {
@@ -95,9 +91,7 @@ extension AttributeGraph.External : Swift.CustomStringConvertible {
   public init(_ attribute: AttributeGraph.Attribute<Value>)
   public init(value: Value)
   public init(type _: Value.Type)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init<Body>(body: Swift.UnsafePointer<Body>, value: Swift.UnsafePointer<Value>?, flags: AttributeGraph._AttributeType.Flags = [], update: () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void) where Body : AttributeGraph._AttributeBody
-  #endif
   public var wrappedValue: Value {
     unsafeAddress
     nonmutating set
@@ -169,10 +163,8 @@ extension AttributeGraph.Attribute {
   public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.Rule
   public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.StatefulRule
 }
-#if compiler(>=5.3) && $NonescapableTypes
 @_silgen_name("AGGraphCreateAttribute")
 @inline(__always) @inlinable internal func AGGraphCreateAttribute(index: Swift.Int, body: Swift.UnsafeRawPointer, value: Swift.UnsafeRawPointer?) -> AttributeGraph.AnyAttribute
-#endif
 @_silgen_name("AGGraphGetValue")
 @inline(__always) @inlinable internal func AGGraphGetValue<Value>(_ attribute: AttributeGraph.AnyAttribute, options: AttributeGraph.AGValueOptions = [], type: Value.Type = Value.self) -> AttributeGraph.AGValue
 @_silgen_name("AGGraphSetValue")
@@ -215,40 +207,26 @@ extension AttributeGraph._AttributeBody {
   public init(base: AttributeGraph.AnyWeakAttribute)
   public init()
   public init(_ attribute: AttributeGraph.Attribute<Value>)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.Attribute<Value>?)
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var wrappedValue: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var projectedValue: AttributeGraph.Attribute<Value>? {
     get
     set
     _modify
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.Attribute<Value>? {
     get
     set
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var value: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
-  #endif
 }
 extension AttributeGraph.WeakAttribute : Swift.Hashable {
   public static func == (a: AttributeGraph.WeakAttribute<Value>, b: AttributeGraph.WeakAttribute<Value>) -> Swift.Bool
@@ -263,17 +241,13 @@ extension AttributeGraph.WeakAttribute : Swift.CustomStringConvertible {
   }
 }
 extension AttributeGraph.AnyWeakAttribute {
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.AnyAttribute?)
-  #endif
   public init<Value>(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.WeakAttribute<Value>
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.AnyAttribute? {
     get
     set
   }
-  #endif
 }
 extension AttributeGraph.AnyWeakAttribute : Swift.Hashable {
   public static func == (lhs: AttributeGraph.AnyWeakAttribute, rhs: AttributeGraph.AnyWeakAttribute) -> Swift.Bool
@@ -289,17 +263,13 @@ extension AttributeGraph.AnyWeakAttribute : Swift.CustomStringConvertible {
 }
 public protocol Rule : AttributeGraph._AttributeBody {
   associatedtype Value
-  #if compiler(>=5.3) && $NonescapableTypes
   static var initialValue: Self.Value? { get }
-  #endif
   var value: Self.Value { get }
 }
 extension AttributeGraph.Rule {
-  #if compiler(>=5.3) && $NonescapableTypes
   public static var initialValue: Self.Value? {
     get
   }
-  #endif
   public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AttributeGraph.AnyAttribute)
   public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
 }
@@ -312,15 +282,9 @@ extension AttributeGraph.Rule {
   }
 }
 extension AttributeGraph.Rule where Self : Swift.Hashable {
-  #if compiler(>=5.3) && $NonescapableTypes
   public func cachedValue(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?) -> Self.Value
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func cachedValueIfExists(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?) -> Self.Value?
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public static func _cachedValue(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?, hashValue: Swift.Int, bodyPtr: Swift.UnsafeRawPointer, update: () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void) -> Swift.UnsafePointer<Self.Value>
-  #endif
 }
 @frozen public struct Map<Source, Value> : AttributeGraph.Rule, Swift.CustomStringConvertible {
   public var arg: AttributeGraph.Attribute<Source>
@@ -338,17 +302,13 @@ extension AttributeGraph.Rule where Self : Swift.Hashable {
 }
 public protocol StatefulRule : AttributeGraph._AttributeBody {
   associatedtype Value
-  #if compiler(>=5.3) && $NonescapableTypes
   static var initialValue: Self.Value? { get }
-  #endif
   mutating func updateValue()
 }
 extension AttributeGraph.StatefulRule {
-  #if compiler(>=5.3) && $NonescapableTypes
   public static var initialValue: Self.Value? {
     get
   }
-  #endif
   public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AttributeGraph.AnyAttribute)
   public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
 }
@@ -386,44 +346,28 @@ extension AttributeGraph.StatefulRule {
   public init()
   public init(base: AttributeGraph.AnyOptionalAttribute)
   public init(_ attribute: AttributeGraph.Attribute<Value>)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.Attribute<Value>?)
-  #endif
   public init(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.Attribute<Value>? {
     get
     set
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var value: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func map<V>(_ body: (AttributeGraph.Attribute<Value>) -> V) -> V?
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var wrappedValue: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var projectedValue: AttributeGraph.Attribute<Value>? {
     get
     set
     _modify
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
     get
   }
-  #endif
 }
 extension AttributeGraph.OptionalAttribute : Swift.Hashable {
   public static func == (a: AttributeGraph.OptionalAttribute<Value>, b: AttributeGraph.OptionalAttribute<Value>) -> Swift.Bool
@@ -441,22 +385,16 @@ extension AttributeGraph.OptionalAttribute : Swift.CustomStringConvertible {
   public var identifier: AttributeGraph.AnyAttribute
   public init()
   public init(_ attribute: AttributeGraph.AnyAttribute)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.AnyAttribute?)
-  #endif
   public init<Value>(_ attribute: AttributeGraph.OptionalAttribute<Value>)
   public static var current: AttributeGraph.AnyOptionalAttribute {
     get
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.AnyAttribute? {
     get
     set
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func map<Value>(_ body: (AttributeGraph.AnyAttribute) -> Value) -> Value?
-  #endif
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.OptionalAttribute<Value>
 }
 extension AttributeGraph.AnyOptionalAttribute : Swift.Hashable {
@@ -478,12 +416,10 @@ extension AttributeGraph.AnyOptionalAttribute : Swift.CustomStringConvertible {
     get
     nonmutating set
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public var dependency: AttributeGraph.AnyAttribute? {
     get
     nonmutating set
   }
-  #endif
   public var value: Value {
     get
     nonmutating set
@@ -516,16 +452,12 @@ extension AttributeGraph.IndirectAttribute : Swift.Hashable {
   public subscript<V>(attribute: AttributeGraph.Attribute<V>) -> V {
     unsafeAddress
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(weakAttribute: AttributeGraph.WeakAttribute<V>) -> V? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(optionalAttribute: AttributeGraph.OptionalAttribute<V>) -> V? {
     get
   }
-  #endif
   public func valueAndFlags<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, flags: AttributeGraph.AGChangedValueFlags)
   public func changedValue<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, changed: Swift.Bool)
   public func update(body: () -> Swift.Void)
@@ -538,16 +470,12 @@ extension AttributeGraph.IndirectAttribute : Swift.Hashable {
   public subscript<V>(attribute: AttributeGraph.Attribute<V>) -> V {
     unsafeAddress
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(weakAttribute: AttributeGraph.WeakAttribute<V>) -> V? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(optionalAttribute: AttributeGraph.OptionalAttribute<V>) -> V? {
     get
   }
-  #endif
   public var value: Value {
     unsafeAddress
     nonmutating set
@@ -609,10 +537,8 @@ extension AttributeGraph.Graph {
   }
 }
 extension AttributeGraph.Graph {
-  #if compiler(>=5.3) && $NonescapableTypes
   @_silgen_name("AGGraphGetOutputValue")
   @inline(__always) @inlinable public static func outputValue<Value>() -> Swift.UnsafePointer<Value>?
-  #endif
   @_silgen_name("AGGraphSetOutputValue")
   @inline(__always) @inlinable public static func setOutputValue<Value>(_ value: Swift.UnsafePointer<Value>)
 }
@@ -622,9 +548,7 @@ extension AttributeGraph.Graph {
     }
 }
 extension AttributeGraph.Graph {
-  #if compiler(>=5.3) && $NonescapableTypes
   public func archiveJSON(name: Swift.String?)
-  #endif
 }
 public func forEachField(of type: any Any.Type, do body: (Swift.UnsafePointer<Swift.Int8>, Swift.Int, any Any.Type) -> Swift.Void)
 extension AttributeGraph.Metadata : Swift.Hashable, Swift.CustomStringConvertible {

--- a/AG/2024/AttributeGraph.xcframework/macos-arm64e-arm64-x86_64/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/arm64e-apple-macos.swiftinterface
+++ b/AG/2024/AttributeGraph.xcframework/macos-arm64e-arm64-x86_64/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/arm64e-apple-macos.swiftinterface
@@ -7,19 +7,21 @@ public import Swift
 public import _Concurrency
 public import _StringProcessing
 public import _SwiftConcurrencyShims
-extension AnyAttribute {
+extension AttributeGraph.AnyAttribute {
   public init<Value>(_ attribute: AttributeGraph.Attribute<Value>)
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.Attribute<Value>
-  public static var current: AnyAttribute? {
+  #if compiler(>=5.3) && $NonescapableTypes
+  public static var current: AttributeGraph.AnyAttribute? {
     get
   }
-  public func unsafeOffset(at offset: Swift.Int) -> AnyAttribute
-  public func setFlags(_ newFlags: AnyAttribute.Flags, mask: AnyAttribute.Flags)
-  public func addInput(_ attribute: AnyAttribute, options: AGInputOptions = [], token: Swift.Int)
-  public func addInput<Value>(_ attribute: AttributeGraph.Attribute<Value>, options: AGInputOptions = [], token: Swift.Int)
+  #endif
+  public func unsafeOffset(at offset: Swift.Int) -> AttributeGraph.AnyAttribute
+  public func setFlags(_ newFlags: AttributeGraph.AnyAttribute.Flags, mask: AttributeGraph.AnyAttribute.Flags)
+  public func addInput(_ attribute: AttributeGraph.AnyAttribute, options: AttributeGraph.AGInputOptions = [], token: Swift.Int)
+  public func addInput<Value>(_ attribute: AttributeGraph.Attribute<Value>, options: AttributeGraph.AGInputOptions = [], token: Swift.Int)
   public func visitBody<Body>(_ visitor: inout Body) where Body : AttributeGraph.AttributeBodyVisitor
   public func mutateBody<Value>(as type: Value.Type, invalidating: Swift.Bool, _ body: (inout Value) -> Swift.Void)
-  public func breadthFirstSearch(options _: SearchOptions = [], _: (AnyAttribute) -> Swift.Bool) -> Swift.Bool
+  public func breadthFirstSearch(options _: AttributeGraph.SearchOptions = [], _: (AttributeGraph.AnyAttribute) -> Swift.Bool) -> Swift.Bool
   public var _bodyType: any Any.Type {
     get
   }
@@ -29,118 +31,19 @@ extension AnyAttribute {
   public var valueType: any Any.Type {
     get
   }
-  public var indirectDependency: AnyAttribute? {
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var indirectDependency: AttributeGraph.AnyAttribute? {
     get
     nonmutating set
   }
+  #endif
 }
-extension AnyAttribute : Swift.CustomStringConvertible {
+extension AttributeGraph.AnyAttribute : Swift.CustomStringConvertible {
   @inlinable public var description: Swift.String {
     get { "#\(rawValue)" }
   }
 }
-public typealias AttributeUpdateBlock = () -> (Swift.UnsafeMutableRawPointer, AnyAttribute) -> Swift.Void
-@frozen @propertyWrapper @dynamicMemberLookup public struct Attribute<Value> {
-  public var identifier: AnyAttribute
-  public init(identifier: AnyAttribute)
-  public init(_ attribute: AttributeGraph.Attribute<Value>)
-  public init(value: Value)
-  public init(type _: Value.Type)
-  public init<Body>(body: Swift.UnsafePointer<Body>, value: Swift.UnsafePointer<Value>?, flags: _AttributeType.Flags = [], update: () -> (Swift.UnsafeMutableRawPointer, AnyAttribute) -> Swift.Void) where Body : AttributeGraph._AttributeBody
-  public var wrappedValue: Value {
-    unsafeAddress
-    nonmutating set
-  }
-  public var projectedValue: AttributeGraph.Attribute<Value> {
-    get
-    set
-  }
-  public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member> {
-    get
-  }
-  public subscript<Member>(keyPath keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member> {
-    get
-  }
-  public subscript<Member>(offset body: (inout Value) -> AttributeGraph.PointerOffset<Value, Member>) -> AttributeGraph.Attribute<Member> {
-    get
-  }
-  public func unsafeCast<V>(to type: V.Type) -> AttributeGraph.Attribute<V>
-  public func unsafeOffset<Member>(at offset: Swift.Int, as _: Member.Type) -> AttributeGraph.Attribute<Member>
-  public func applying<Member>(offset: AttributeGraph.PointerOffset<Value, Member>) -> AttributeGraph.Attribute<Member>
-  public func visitBody<Body>(_ visitor: inout Body) where Body : AttributeGraph.AttributeBodyVisitor
-  public func mutateBody<V>(as type: V.Type, invalidating: Swift.Bool, _ body: (inout V) -> Swift.Void)
-  public func breadthFirstSearch(options: SearchOptions = [], _ body: (AnyAttribute) -> Swift.Bool) -> Swift.Bool
-  public var graph: Graph {
-    get
-  }
-  public var subgraph: Subgraph {
-    get
-  }
-  public var value: Value {
-    unsafeAddress
-    nonmutating set
-  }
-  public var valueState: ValueState {
-    get
-  }
-  public func valueAndFlags(options: AGValueOptions = []) -> (value: Value, flags: AGChangedValueFlags)
-  public func changedValue(options: AGValueOptions = []) -> (value: Value, changed: Swift.Bool)
-  public func setValue(_ value: Value) -> Swift.Bool
-  public var hasValue: Swift.Bool {
-    get
-  }
-  public func updateValue()
-  public func prefetchValue()
-  public func invalidateValue()
-  public func validate()
-  public func addInput(_ attribute: AnyAttribute, options: AGInputOptions = [], token: Swift.Int)
-  public func addInput<V>(_ attribute: AttributeGraph.Attribute<V>, options: AGInputOptions = [], token: Swift.Int)
-  public typealias Flags = AnyAttribute.Flags
-  public var flags: AttributeGraph.Attribute<Value>.Flags {
-    get
-    nonmutating set
-  }
-  public func setFlags(_ newFlags: AttributeGraph.Attribute<Value>.Flags, mask: AttributeGraph.Attribute<Value>.Flags)
-}
-extension AttributeGraph.Attribute : Swift.Hashable {
-  public static func == (a: AttributeGraph.Attribute<Value>, b: AttributeGraph.Attribute<Value>) -> Swift.Bool
-  public func hash(into hasher: inout Swift.Hasher)
-  public var hashValue: Swift.Int {
-    get
-  }
-}
-extension AttributeGraph.Attribute : Swift.CustomStringConvertible {
-  public var description: Swift.String {
-    get
-  }
-}
-extension AttributeGraph.Attribute {
-  public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.Rule
-  public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.StatefulRule
-}
-@_silgen_name("AGGraphCreateAttribute")
-@inline(__always) @inlinable internal func AGGraphCreateAttribute(index: Swift.Int, body: Swift.UnsafeRawPointer, value: Swift.UnsafeRawPointer?) -> AnyAttribute
-@_silgen_name("AGGraphGetValue")
-@inline(__always) @inlinable internal func AGGraphGetValue<Value>(_ attribute: AnyAttribute, options: AGValueOptions = [], type: Value.Type = Value.self) -> AGValue
-@_silgen_name("AGGraphSetValue")
-@inline(__always) @inlinable internal func AGGraphSetValue<Value>(_ attribute: AnyAttribute, valuePointer: Swift.UnsafePointer<Value>) -> Swift.Bool
-@frozen public struct External<Value> {
-  public init()
-}
-extension AttributeGraph.External : AttributeGraph._AttributeBody {
-  public static var comparisonMode: ComparisonMode {
-    get
-  }
-  public static var flags: AttributeGraph.External<Value>.Flags {
-    get
-  }
-  public static func _update(_: Swift.UnsafeMutableRawPointer, attribute _: AnyAttribute)
-}
-extension AttributeGraph.External : Swift.CustomStringConvertible {
-  public var description: Swift.String {
-    get
-  }
-}
+public typealias AttributeUpdateBlock = () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void
 @frozen public struct PointerOffset<Base, Member> {
   public var byteOffset: Swift.Int
   public init(byteOffset: Swift.Int)
@@ -169,27 +72,111 @@ extension Swift.UnsafeMutablePointer {
   }
   public static func + <Member>(lhs: Swift.UnsafeMutablePointer<Pointee>, rhs: AttributeGraph.PointerOffset<Pointee, Member>) -> Swift.UnsafeMutablePointer<Member>
 }
-public protocol _AttributeBody {
-  static func _destroySelf(_ pointer: Swift.UnsafeMutableRawPointer)
-  static var _hasDestroySelf: Swift.Bool { get }
-  static func _updateDefault(_ pointer: Swift.UnsafeMutableRawPointer)
-  static var comparisonMode: ComparisonMode { get }
-  typealias Flags = _AttributeType.Flags
-  static var flags: Self.Flags { get }
+@frozen public struct External<Value> {
+  public init()
 }
-extension AttributeGraph._AttributeBody {
-  public static func _destroySelf(_ pointer: Swift.UnsafeMutableRawPointer)
-  public static var _hasDestroySelf: Swift.Bool {
+extension AttributeGraph.External : AttributeGraph._AttributeBody {
+  public static var comparisonMode: AttributeGraph.ComparisonMode {
     get
   }
-  public static func _updateDefault(_ pointer: Swift.UnsafeMutableRawPointer)
-  public static var comparisonMode: ComparisonMode {
+  public static var flags: AttributeGraph.External<Value>.Flags {
     get
   }
-  public static var flags: Self.Flags {
+  public static func _update(_: Swift.UnsafeMutableRawPointer, attribute _: AttributeGraph.AnyAttribute)
+}
+extension AttributeGraph.External : Swift.CustomStringConvertible {
+  public var description: Swift.String {
     get
   }
 }
+@frozen @propertyWrapper @dynamicMemberLookup public struct Attribute<Value> {
+  public var identifier: AttributeGraph.AnyAttribute
+  public init(identifier: AttributeGraph.AnyAttribute)
+  public init(_ attribute: AttributeGraph.Attribute<Value>)
+  public init(value: Value)
+  public init(type _: Value.Type)
+  #if compiler(>=5.3) && $NonescapableTypes
+  public init<Body>(body: Swift.UnsafePointer<Body>, value: Swift.UnsafePointer<Value>?, flags: AttributeGraph._AttributeType.Flags = [], update: () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void) where Body : AttributeGraph._AttributeBody
+  #endif
+  public var wrappedValue: Value {
+    unsafeAddress
+    nonmutating set
+  }
+  public var projectedValue: AttributeGraph.Attribute<Value> {
+    get
+    set
+  }
+  public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member> {
+    get
+  }
+  public subscript<Member>(keyPath keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member> {
+    get
+  }
+  public subscript<Member>(offset body: (inout Value) -> AttributeGraph.PointerOffset<Value, Member>) -> AttributeGraph.Attribute<Member> {
+    get
+  }
+  public func unsafeCast<V>(to type: V.Type) -> AttributeGraph.Attribute<V>
+  public func unsafeOffset<Member>(at offset: Swift.Int, as _: Member.Type) -> AttributeGraph.Attribute<Member>
+  public func applying<Member>(offset: AttributeGraph.PointerOffset<Value, Member>) -> AttributeGraph.Attribute<Member>
+  public func visitBody<Body>(_ visitor: inout Body) where Body : AttributeGraph.AttributeBodyVisitor
+  public func mutateBody<V>(as type: V.Type, invalidating: Swift.Bool, _ body: (inout V) -> Swift.Void)
+  public func breadthFirstSearch(options: AttributeGraph.SearchOptions = [], _ body: (AttributeGraph.AnyAttribute) -> Swift.Bool) -> Swift.Bool
+  public var graph: AttributeGraph.Graph {
+    get
+  }
+  public var subgraph: AttributeGraph.Subgraph {
+    get
+  }
+  public var value: Value {
+    unsafeAddress
+    nonmutating set
+  }
+  public var valueState: AttributeGraph.ValueState {
+    get
+  }
+  public func valueAndFlags(options: AttributeGraph.AGValueOptions = []) -> (value: Value, flags: AttributeGraph.AGChangedValueFlags)
+  public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)
+  public func setValue(_ value: Value) -> Swift.Bool
+  public var hasValue: Swift.Bool {
+    get
+  }
+  public func updateValue()
+  public func prefetchValue()
+  public func invalidateValue()
+  public func validate()
+  public func addInput(_ attribute: AttributeGraph.AnyAttribute, options: AttributeGraph.AGInputOptions = [], token: Swift.Int)
+  public func addInput<V>(_ attribute: AttributeGraph.Attribute<V>, options: AttributeGraph.AGInputOptions = [], token: Swift.Int)
+  public typealias Flags = AttributeGraph.AnyAttribute.Flags
+  public var flags: AttributeGraph.Attribute<Value>.Flags {
+    get
+    nonmutating set
+  }
+  public func setFlags(_ newFlags: AttributeGraph.Attribute<Value>.Flags, mask: AttributeGraph.Attribute<Value>.Flags)
+}
+extension AttributeGraph.Attribute : Swift.Hashable {
+  public static func == (a: AttributeGraph.Attribute<Value>, b: AttributeGraph.Attribute<Value>) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+extension AttributeGraph.Attribute : Swift.CustomStringConvertible {
+  public var description: Swift.String {
+    get
+  }
+}
+extension AttributeGraph.Attribute {
+  public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.Rule
+  public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.StatefulRule
+}
+#if compiler(>=5.3) && $NonescapableTypes
+@_silgen_name("AGGraphCreateAttribute")
+@inline(__always) @inlinable internal func AGGraphCreateAttribute(index: Swift.Int, body: Swift.UnsafeRawPointer, value: Swift.UnsafeRawPointer?) -> AttributeGraph.AnyAttribute
+#endif
+@_silgen_name("AGGraphGetValue")
+@inline(__always) @inlinable internal func AGGraphGetValue<Value>(_ attribute: AttributeGraph.AnyAttribute, options: AttributeGraph.AGValueOptions = [], type: Value.Type = Value.self) -> AttributeGraph.AGValue
+@_silgen_name("AGGraphSetValue")
+@inline(__always) @inlinable internal func AGGraphSetValue<Value>(_ attribute: AttributeGraph.AnyAttribute, valuePointer: Swift.UnsafePointer<Value>) -> Swift.Bool
 public protocol AttributeBodyVisitor {
   func visit<Body>(body: Swift.UnsafePointer<Body>) where Body : AttributeGraph._AttributeBody
 }
@@ -202,23 +189,307 @@ extension AttributeGraph.ObservedAttribute {
     get
   }
 }
+public protocol _AttributeBody {
+  static func _destroySelf(_ pointer: Swift.UnsafeMutableRawPointer)
+  static var _hasDestroySelf: Swift.Bool { get }
+  static func _updateDefault(_ pointer: Swift.UnsafeMutableRawPointer)
+  static var comparisonMode: AttributeGraph.ComparisonMode { get }
+  typealias Flags = AttributeGraph._AttributeType.Flags
+  static var flags: Self.Flags { get }
+}
+extension AttributeGraph._AttributeBody {
+  public static func _destroySelf(_ pointer: Swift.UnsafeMutableRawPointer)
+  public static var _hasDestroySelf: Swift.Bool {
+    get
+  }
+  public static func _updateDefault(_ pointer: Swift.UnsafeMutableRawPointer)
+  public static var comparisonMode: AttributeGraph.ComparisonMode {
+    get
+  }
+  public static var flags: Self.Flags {
+    get
+  }
+}
+@frozen @propertyWrapper @dynamicMemberLookup public struct WeakAttribute<Value> {
+  internal var base: AttributeGraph.AnyWeakAttribute
+  public init(base: AttributeGraph.AnyWeakAttribute)
+  public init()
+  public init(_ attribute: AttributeGraph.Attribute<Value>)
+  #if compiler(>=5.3) && $NonescapableTypes
+  public init(_ attribute: AttributeGraph.Attribute<Value>?)
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var wrappedValue: Value? {
+    get
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var projectedValue: AttributeGraph.Attribute<Value>? {
+    get
+    set
+    _modify
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
+    get
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var attribute: AttributeGraph.Attribute<Value>? {
+    get
+    set
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var value: Value? {
+    get
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
+  #endif
+}
+extension AttributeGraph.WeakAttribute : Swift.Hashable {
+  public static func == (a: AttributeGraph.WeakAttribute<Value>, b: AttributeGraph.WeakAttribute<Value>) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+extension AttributeGraph.WeakAttribute : Swift.CustomStringConvertible {
+  public var description: Swift.String {
+    get
+  }
+}
+extension AttributeGraph.AnyWeakAttribute {
+  #if compiler(>=5.3) && $NonescapableTypes
+  public init(_ attribute: AttributeGraph.AnyAttribute?)
+  #endif
+  public init<Value>(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
+  public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.WeakAttribute<Value>
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var attribute: AttributeGraph.AnyAttribute? {
+    get
+    set
+  }
+  #endif
+}
+extension AttributeGraph.AnyWeakAttribute : Swift.Hashable {
+  public static func == (lhs: AttributeGraph.AnyWeakAttribute, rhs: AttributeGraph.AnyWeakAttribute) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+extension AttributeGraph.AnyWeakAttribute : Swift.CustomStringConvertible {
+  @_alwaysEmitIntoClient public var description: Swift.String {
+    get { attribute?.description ?? "nil" }
+  }
+}
+public protocol Rule : AttributeGraph._AttributeBody {
+  associatedtype Value
+  #if compiler(>=5.3) && $NonescapableTypes
+  static var initialValue: Self.Value? { get }
+  #endif
+  var value: Self.Value { get }
+}
+extension AttributeGraph.Rule {
+  #if compiler(>=5.3) && $NonescapableTypes
+  public static var initialValue: Self.Value? {
+    get
+  }
+  #endif
+  public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AttributeGraph.AnyAttribute)
+  public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
+}
+extension AttributeGraph.Rule {
+  public var attribute: AttributeGraph.Attribute<Self.Value> {
+    get
+  }
+  public var context: AttributeGraph.RuleContext<Self.Value> {
+    get
+  }
+}
+extension AttributeGraph.Rule where Self : Swift.Hashable {
+  #if compiler(>=5.3) && $NonescapableTypes
+  public func cachedValue(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?) -> Self.Value
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public func cachedValueIfExists(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?) -> Self.Value?
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public static func _cachedValue(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?, hashValue: Swift.Int, bodyPtr: Swift.UnsafeRawPointer, update: () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void) -> Swift.UnsafePointer<Self.Value>
+  #endif
+}
+@frozen public struct Map<Source, Value> : AttributeGraph.Rule, Swift.CustomStringConvertible {
+  public var arg: AttributeGraph.Attribute<Source>
+  public let body: (Source) -> Value
+  public init(_ arg: AttributeGraph.Attribute<Source>, _ body: @escaping (Source) -> Value)
+  public var value: Value {
+    get
+  }
+  public static var flags: AttributeGraph.Map<Source, Value>.Flags {
+    get
+  }
+  public var description: Swift.String {
+    get
+  }
+}
+public protocol StatefulRule : AttributeGraph._AttributeBody {
+  associatedtype Value
+  #if compiler(>=5.3) && $NonescapableTypes
+  static var initialValue: Self.Value? { get }
+  #endif
+  mutating func updateValue()
+}
+extension AttributeGraph.StatefulRule {
+  #if compiler(>=5.3) && $NonescapableTypes
+  public static var initialValue: Self.Value? {
+    get
+  }
+  #endif
+  public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AttributeGraph.AnyAttribute)
+  public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
+}
+extension AttributeGraph.StatefulRule {
+  public var attribute: AttributeGraph.Attribute<Self.Value> {
+    get
+  }
+  public var context: AttributeGraph.RuleContext<Self.Value> {
+    get
+  }
+  public var value: Self.Value {
+    unsafeAddress
+    nonmutating set
+  }
+  public var hasValue: Swift.Bool {
+    get
+  }
+}
+@frozen public struct Focus<Root, Value> : AttributeGraph.Rule, Swift.CustomStringConvertible {
+  public var root: AttributeGraph.Attribute<Root>
+  public var keyPath: Swift.KeyPath<Root, Value>
+  public init(root: AttributeGraph.Attribute<Root>, keyPath: Swift.KeyPath<Root, Value>)
+  public var value: Value {
+    get
+  }
+  public static var flags: AttributeGraph.Focus<Root, Value>.Flags {
+    get
+  }
+  public var description: Swift.String {
+    get
+  }
+}
+@frozen @propertyWrapper @dynamicMemberLookup public struct OptionalAttribute<Value> {
+  public var base: AttributeGraph.AnyOptionalAttribute
+  public init()
+  public init(base: AttributeGraph.AnyOptionalAttribute)
+  public init(_ attribute: AttributeGraph.Attribute<Value>)
+  #if compiler(>=5.3) && $NonescapableTypes
+  public init(_ attribute: AttributeGraph.Attribute<Value>?)
+  #endif
+  public init(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var attribute: AttributeGraph.Attribute<Value>? {
+    get
+    set
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var value: Value? {
+    get
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public func map<V>(_ body: (AttributeGraph.Attribute<Value>) -> V) -> V?
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var wrappedValue: Value? {
+    get
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var projectedValue: AttributeGraph.Attribute<Value>? {
+    get
+    set
+    _modify
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
+    get
+  }
+  #endif
+}
+extension AttributeGraph.OptionalAttribute : Swift.Hashable {
+  public static func == (a: AttributeGraph.OptionalAttribute<Value>, b: AttributeGraph.OptionalAttribute<Value>) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+extension AttributeGraph.OptionalAttribute : Swift.CustomStringConvertible {
+  public var description: Swift.String {
+    get
+  }
+}
+@frozen public struct AnyOptionalAttribute {
+  public var identifier: AttributeGraph.AnyAttribute
+  public init()
+  public init(_ attribute: AttributeGraph.AnyAttribute)
+  #if compiler(>=5.3) && $NonescapableTypes
+  public init(_ attribute: AttributeGraph.AnyAttribute?)
+  #endif
+  public init<Value>(_ attribute: AttributeGraph.OptionalAttribute<Value>)
+  public static var current: AttributeGraph.AnyOptionalAttribute {
+    get
+  }
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var attribute: AttributeGraph.AnyAttribute? {
+    get
+    set
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public func map<Value>(_ body: (AttributeGraph.AnyAttribute) -> Value) -> Value?
+  #endif
+  public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.OptionalAttribute<Value>
+}
+extension AttributeGraph.AnyOptionalAttribute : Swift.Hashable {
+  public static func == (a: AttributeGraph.AnyOptionalAttribute, b: AttributeGraph.AnyOptionalAttribute) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+extension AttributeGraph.AnyOptionalAttribute : Swift.CustomStringConvertible {
+  public var description: Swift.String {
+    get
+  }
+}
 @frozen @propertyWrapper @dynamicMemberLookup public struct IndirectAttribute<Value> {
-  public let identifier: AnyAttribute
+  public let identifier: AttributeGraph.AnyAttribute
   public init(source: AttributeGraph.Attribute<Value>)
   public var source: AttributeGraph.Attribute<Value> {
     get
     nonmutating set
   }
-  public var dependency: AnyAttribute? {
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var dependency: AttributeGraph.AnyAttribute? {
     get
     nonmutating set
   }
+  #endif
   public var value: Value {
     get
     nonmutating set
     nonmutating _modify
   }
-  public func changedValue(options: AGValueOptions = []) -> (value: Value, changed: Swift.Bool)
+  public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)
   public var wrappedValue: Value {
     get
     nonmutating set
@@ -238,169 +509,25 @@ extension AttributeGraph.IndirectAttribute : Swift.Hashable {
     get
   }
 }
-@frozen public struct AnyOptionalAttribute {
-  public var identifier: AnyAttribute
-  public init()
-  public init(_ attribute: AnyAttribute)
-  public init(_ attribute: AnyAttribute?)
-  public init<Value>(_ attribute: AttributeGraph.OptionalAttribute<Value>)
-  public static var current: AttributeGraph.AnyOptionalAttribute {
-    get
-  }
-  public var attribute: AnyAttribute? {
-    get
-    set
-  }
-  public func map<Value>(_ body: (AnyAttribute) -> Value) -> Value?
-  public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.OptionalAttribute<Value>
-}
-extension AttributeGraph.AnyOptionalAttribute : Swift.Hashable {
-  public static func == (a: AttributeGraph.AnyOptionalAttribute, b: AttributeGraph.AnyOptionalAttribute) -> Swift.Bool
-  public func hash(into hasher: inout Swift.Hasher)
-  public var hashValue: Swift.Int {
-    get
-  }
-}
-extension AttributeGraph.AnyOptionalAttribute : Swift.CustomStringConvertible {
-  public var description: Swift.String {
-    get
-  }
-}
-@frozen @propertyWrapper @dynamicMemberLookup public struct OptionalAttribute<Value> {
-  public var base: AttributeGraph.AnyOptionalAttribute
-  public init()
-  public init(base: AttributeGraph.AnyOptionalAttribute)
-  public init(_ attribute: AttributeGraph.Attribute<Value>)
-  public init(_ attribute: AttributeGraph.Attribute<Value>?)
-  public init(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
-  public var attribute: AttributeGraph.Attribute<Value>? {
-    get
-    set
-  }
-  public var value: Value? {
-    get
-  }
-  public func changedValue(options: AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
-  public func map<V>(_ body: (AttributeGraph.Attribute<Value>) -> V) -> V?
-  public var wrappedValue: Value? {
-    get
-  }
-  public var projectedValue: AttributeGraph.Attribute<Value>? {
-    get
-    set
-    _modify
-  }
-  public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
-    get
-  }
-}
-extension AttributeGraph.OptionalAttribute : Swift.Hashable {
-  public static func == (a: AttributeGraph.OptionalAttribute<Value>, b: AttributeGraph.OptionalAttribute<Value>) -> Swift.Bool
-  public func hash(into hasher: inout Swift.Hasher)
-  public var hashValue: Swift.Int {
-    get
-  }
-}
-extension AttributeGraph.OptionalAttribute : Swift.CustomStringConvertible {
-  public var description: Swift.String {
-    get
-  }
-}
-@frozen public struct Focus<Root, Value> : AttributeGraph.Rule, Swift.CustomStringConvertible {
-  public var root: AttributeGraph.Attribute<Root>
-  public var keyPath: Swift.KeyPath<Root, Value>
-  public init(root: AttributeGraph.Attribute<Root>, keyPath: Swift.KeyPath<Root, Value>)
-  public var value: Value {
-    get
-  }
-  public static var flags: AttributeGraph.Focus<Root, Value>.Flags {
-    get
-  }
-  public var description: Swift.String {
-    get
-  }
-}
-@frozen public struct Map<Source, Value> : AttributeGraph.Rule, Swift.CustomStringConvertible {
-  public var arg: AttributeGraph.Attribute<Source>
-  public let body: (Source) -> Value
-  public init(_ arg: AttributeGraph.Attribute<Source>, _ body: @escaping (Source) -> Value)
-  public var value: Value {
-    get
-  }
-  public static var flags: AttributeGraph.Map<Source, Value>.Flags {
-    get
-  }
-  public var description: Swift.String {
-    get
-  }
-}
-public protocol Rule : AttributeGraph._AttributeBody {
-  associatedtype Value
-  static var initialValue: Self.Value? { get }
-  var value: Self.Value { get }
-}
-extension AttributeGraph.Rule {
-  public static var initialValue: Self.Value? {
-    get
-  }
-  public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AnyAttribute)
-  public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
-}
-extension AttributeGraph.Rule {
-  public var attribute: AttributeGraph.Attribute<Self.Value> {
-    get
-  }
-  public var context: AttributeGraph.RuleContext<Self.Value> {
-    get
-  }
-}
-extension AttributeGraph.Rule where Self : Swift.Hashable {
-  public func cachedValue(options: AGCachedValueOptions = [], owner: AnyAttribute?) -> Self.Value
-  public func cachedValueIfExists(options: AGCachedValueOptions = [], owner: AnyAttribute?) -> Self.Value?
-  public static func _cachedValue(options: AGCachedValueOptions = [], owner: AnyAttribute?, hashValue: Swift.Int, bodyPtr: Swift.UnsafeRawPointer, update: () -> (Swift.UnsafeMutableRawPointer, AnyAttribute) -> Swift.Void) -> Swift.UnsafePointer<Self.Value>
-}
-public protocol StatefulRule : AttributeGraph._AttributeBody {
-  associatedtype Value
-  static var initialValue: Self.Value? { get }
-  mutating func updateValue()
-}
-extension AttributeGraph.StatefulRule {
-  public static var initialValue: Self.Value? {
-    get
-  }
-  public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AnyAttribute)
-  public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
-}
-extension AttributeGraph.StatefulRule {
-  public var attribute: AttributeGraph.Attribute<Self.Value> {
-    get
-  }
-  public var context: AttributeGraph.RuleContext<Self.Value> {
-    get
-  }
-  public var value: Self.Value {
-    unsafeAddress
-    nonmutating set
-  }
-  public var hasValue: Swift.Bool {
-    get
-  }
-}
 @frozen public struct AnyRuleContext : Swift.Equatable {
-  public var attribute: AnyAttribute
-  public init(attribute: AnyAttribute)
+  public var attribute: AttributeGraph.AnyAttribute
+  public init(attribute: AttributeGraph.AnyAttribute)
   public init<V>(_ context: AttributeGraph.RuleContext<V>)
   public subscript<V>(attribute: AttributeGraph.Attribute<V>) -> V {
     unsafeAddress
   }
+  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(weakAttribute: AttributeGraph.WeakAttribute<V>) -> V? {
     get
   }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(optionalAttribute: AttributeGraph.OptionalAttribute<V>) -> V? {
     get
   }
-  public func valueAndFlags<V>(of input: AttributeGraph.Attribute<V>, options: AGValueOptions = []) -> (value: V, flags: AGChangedValueFlags)
-  public func changedValue<V>(of input: AttributeGraph.Attribute<V>, options: AGValueOptions = []) -> (value: V, changed: Swift.Bool)
+  #endif
+  public func valueAndFlags<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, flags: AttributeGraph.AGChangedValueFlags)
+  public func changedValue<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, changed: Swift.Bool)
   public func update(body: () -> Swift.Void)
   public func unsafeCast<V>(to _: V.Type) -> AttributeGraph.RuleContext<V>
   public static func == (a: AttributeGraph.AnyRuleContext, b: AttributeGraph.AnyRuleContext) -> Swift.Bool
@@ -411,12 +538,16 @@ extension AttributeGraph.StatefulRule {
   public subscript<V>(attribute: AttributeGraph.Attribute<V>) -> V {
     unsafeAddress
   }
+  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(weakAttribute: AttributeGraph.WeakAttribute<V>) -> V? {
     get
   }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(optionalAttribute: AttributeGraph.OptionalAttribute<V>) -> V? {
     get
   }
+  #endif
   public var value: Value {
     unsafeAddress
     nonmutating set
@@ -424,86 +555,41 @@ extension AttributeGraph.StatefulRule {
   public var hasValue: Swift.Bool {
     get
   }
-  public func valueAndFlags<V>(of input: AttributeGraph.Attribute<V>, options: AGValueOptions = []) -> (value: V, flags: AGChangedValueFlags)
-  public func changedValue<V>(of input: AttributeGraph.Attribute<V>, options: AGValueOptions = []) -> (value: V, changed: Swift.Bool)
+  public func valueAndFlags<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, flags: AttributeGraph.AGChangedValueFlags)
+  public func changedValue<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, changed: Swift.Bool)
   public func update(body: () -> Swift.Void)
   public static func == (a: AttributeGraph.RuleContext<Value>, b: AttributeGraph.RuleContext<Value>) -> Swift.Bool
 }
 @_silgen_name("AGGraphGetInputValue")
-@inline(__always) @inlinable internal func AGGraphGetInputValue<Value>(_ attribute: AnyAttribute, input: AnyAttribute, options: AGValueOptions = [], type: Value.Type = Value.self) -> AGValue
+@inline(__always) @inlinable internal func AGGraphGetInputValue<Value>(_ attribute: AttributeGraph.AnyAttribute, input: AttributeGraph.AnyAttribute, options: AttributeGraph.AGValueOptions = [], type: Value.Type = Value.self) -> AttributeGraph.AGValue
 @_silgen_name("AGGraphWithUpdate")
-@inline(__always) @inlinable internal func AGGraphWithUpdate(_ attribute: AnyAttribute, body: () -> Swift.Void)
-extension AnyWeakAttribute {
-  public init(_ attribute: AnyAttribute?)
-  public init<Value>(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
-  public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.WeakAttribute<Value>
-  public var attribute: AnyAttribute? {
-    get
-    set
-  }
+@inline(__always) @inlinable internal func AGGraphWithUpdate(_ attribute: AttributeGraph.AnyAttribute, body: () -> Swift.Void)
+extension AttributeGraph.Subgraph {
+  public typealias Flags = AttributeGraph.AnyAttribute.Flags
+  public typealias ChildFlags = AttributeGraph.AnyAttribute.Flags
 }
-extension AnyWeakAttribute : Swift.Hashable {
-  public static func == (lhs: AnyWeakAttribute, rhs: AnyWeakAttribute) -> Swift.Bool
-  public func hash(into hasher: inout Swift.Hasher)
-  public var hashValue: Swift.Int {
-    get
-  }
+extension AttributeGraph.Subgraph {
+  public func addObserver(_ observer: @escaping () -> Swift.Void) -> Swift.Int
+  public func apply<Value>(_ body: () -> Value) -> Value
+  public func forEach(_ flags: AttributeGraph.Subgraph.Flags, _ callback: (AttributeGraph.AnyAttribute) -> Swift.Void)
 }
-extension AnyWeakAttribute : Swift.CustomStringConvertible {
-  @_alwaysEmitIntoClient public var description: Swift.String {
-    get { attribute?.description ?? "nil" }
-  }
+extension AttributeGraph.Subgraph {
+  public static func beginTreeElement<Value>(value: AttributeGraph.Attribute<Value>, flags: Swift.UInt32)
+  public static func addTreeValue<Value>(_ value: AttributeGraph.Attribute<Value>, forKey key: Swift.UnsafePointer<Swift.Int8>, flags: Swift.UInt32)
+  public static func endTreeElement<Value>(value: AttributeGraph.Attribute<Value>)
 }
-@frozen @propertyWrapper @dynamicMemberLookup public struct WeakAttribute<Value> {
-  internal var base: AnyWeakAttribute
-  public init(base: AnyWeakAttribute)
-  public init()
-  public init(_ attribute: AttributeGraph.Attribute<Value>)
-  public init(_ attribute: AttributeGraph.Attribute<Value>?)
-  public var wrappedValue: Value? {
-    get
-  }
-  public var projectedValue: AttributeGraph.Attribute<Value>? {
-    get
-    set
-    _modify
-  }
-  public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
-    get
-  }
-  public var attribute: AttributeGraph.Attribute<Value>? {
-    get
-    set
-  }
-  public var value: Value? {
-    get
-  }
-  public func changedValue(options: AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
+extension AttributeGraph.Graph {
+  public static func typeIndex(ctx: AttributeGraph.GraphContext, body: any AttributeGraph._AttributeBody.Type, valueType: AttributeGraph.Metadata, flags: AttributeGraph._AttributeType.Flags, update: () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void) -> Swift.Int
 }
-extension AttributeGraph.WeakAttribute : Swift.Hashable {
-  public static func == (a: AttributeGraph.WeakAttribute<Value>, b: AttributeGraph.WeakAttribute<Value>) -> Swift.Bool
-  public func hash(into hasher: inout Swift.Hasher)
-  public var hashValue: Swift.Int {
-    get
-  }
-}
-extension AttributeGraph.WeakAttribute : Swift.CustomStringConvertible {
-  public var description: Swift.String {
-    get
-  }
-}
-extension Graph {
-  public static func typeIndex(ctx: GraphContext, body: any AttributeGraph._AttributeBody.Type, valueType: Metadata, flags: _AttributeType.Flags, update: () -> (Swift.UnsafeMutableRawPointer, AnyAttribute) -> Swift.Void) -> Swift.Int
-}
-extension Graph {
+extension AttributeGraph.Graph {
   public static func withoutUpdate<V>(_ body: () -> V) -> V
   public func withoutSubgraphInvalidation<V>(_ body: () -> V) -> V
   public func withDeadline<V>(_: Swift.UInt64, _: () -> V) -> V
-  public func onInvalidation(_ callback: @escaping (AnyAttribute) -> Swift.Void)
+  public func onInvalidation(_ callback: @escaping (AttributeGraph.AnyAttribute) -> Swift.Void)
   public func onUpdate(_ callback: @escaping () -> Swift.Void)
   public func withMainThreadHandler(_: (() -> Swift.Void) -> Swift.Void, do: () -> Swift.Void)
 }
-extension Graph {
+extension AttributeGraph.Graph {
   @_transparent public func startProfiling() {
         __AGGraphStartProfiling(self)
     }
@@ -517,46 +603,31 @@ extension Graph {
   public static func stopProfiling()
   public static func resetProfile()
 }
-extension Graph {
+extension AttributeGraph.Graph {
   @_transparent public var mainUpdates: Swift.Int {
     @_transparent get { numericCast(counter(for: .mainThreadUpdates)) }
   }
 }
-extension Graph {
+extension AttributeGraph.Graph {
+  #if compiler(>=5.3) && $NonescapableTypes
   @_silgen_name("AGGraphGetOutputValue")
   @inline(__always) @inlinable public static func outputValue<Value>() -> Swift.UnsafePointer<Value>?
+  #endif
   @_silgen_name("AGGraphSetOutputValue")
   @inline(__always) @inlinable public static func setOutputValue<Value>(_ value: Swift.UnsafePointer<Value>)
 }
-extension Graph {
-  @_transparent public static func anyInputsChanged(excluding excludedInputs: [AnyAttribute]) -> Swift.Bool {
+extension AttributeGraph.Graph {
+  @_transparent public static func anyInputsChanged(excluding excludedInputs: [AttributeGraph.AnyAttribute]) -> Swift.Bool {
         return __AGGraphAnyInputsChanged(excludedInputs, excludedInputs.count)
     }
 }
-extension Graph {
+extension AttributeGraph.Graph {
+  #if compiler(>=5.3) && $NonescapableTypes
   public func archiveJSON(name: Swift.String?)
-}
-extension Subgraph {
-  public typealias Flags = AnyAttribute.Flags
-  public typealias ChildFlags = AnyAttribute.Flags
-}
-extension Subgraph {
-  public func addObserver(_ observer: @escaping () -> Swift.Void) -> Swift.Int
-  public func apply<Value>(_ body: () -> Value) -> Value
-  public func forEach(_ flags: Subgraph.Flags, _ callback: (AnyAttribute) -> Swift.Void)
-}
-extension Subgraph {
-  public static func beginTreeElement<Value>(value: AttributeGraph.Attribute<Value>, flags: Swift.UInt32)
-  public static func addTreeValue<Value>(_ value: AttributeGraph.Attribute<Value>, forKey key: Swift.UnsafePointer<Swift.Int8>, flags: Swift.UInt32)
-  public static func endTreeElement<Value>(value: AttributeGraph.Attribute<Value>)
-}
-public func compareValues<Value>(_ lhs: Value, _ rhs: Value, mode: ComparisonMode = .equatableAlways) -> Swift.Bool
-public func compareValues<Value>(_ lhs: Value, _ rhs: Value, options: ComparisonOptions) -> Swift.Bool
-extension ComparisonOptions {
-  public init(mode: ComparisonMode)
+  #endif
 }
 public func forEachField(of type: any Any.Type, do body: (Swift.UnsafePointer<Swift.Int8>, Swift.Int, any Any.Type) -> Swift.Void)
-extension Metadata : Swift.Hashable, Swift.CustomStringConvertible {
+extension AttributeGraph.Metadata : Swift.Hashable, Swift.CustomStringConvertible {
   public init(_ type: any Any.Type)
   public var type: any Any.Type {
     get
@@ -564,16 +635,12 @@ extension Metadata : Swift.Hashable, Swift.CustomStringConvertible {
   public var description: Swift.String {
     get
   }
-  public func forEachField(options: Metadata.ApplyOptions, do body: (Swift.UnsafePointer<Swift.Int8>, Swift.Int, any Any.Type) -> Swift.Bool) -> Swift.Bool
+  public func forEachField(options: AttributeGraph.Metadata.ApplyOptions, do body: (Swift.UnsafePointer<Swift.Int8>, Swift.Int, any Any.Type) -> Swift.Bool) -> Swift.Bool
 }
-extension Signature : Swift.Equatable {
-  public static func == (lhs: Signature, rhs: Signature) -> Swift.Bool
+extension AttributeGraph.Signature : Swift.Equatable {
+  public static func == (lhs: AttributeGraph.Signature, rhs: AttributeGraph.Signature) -> Swift.Bool
 }
-@discardableResult
-public func withUnsafePointerToEnumCase<T>(of value: Swift.UnsafeMutablePointer<T>, do body: (Swift.Int, any Any.Type, Swift.UnsafeRawPointer) -> ()) -> Swift.Bool
-@discardableResult
-public func withUnsafeMutablePointerToEnumCase<T>(of value: Swift.UnsafeMutablePointer<T>, do body: (Swift.Int, any Any.Type, Swift.UnsafeMutableRawPointer) -> ()) -> Swift.Bool
-extension TupleType {
+extension AttributeGraph.TupleType {
   @_transparent public init(_ types: [any Any.Type]) {
         self.init(count: types.count, elements: types.map(Metadata.init))
     }
@@ -597,16 +664,16 @@ extension TupleType {
   @_transparent public func offset<T>(at index: Swift.Int, as type: T.Type) -> Swift.Int {
         elementOffset(at: index, type: Metadata(type))
     }
-  @_transparent public func setElement<T>(in tupleValue: Swift.UnsafeMutableRawPointer, at index: Swift.Int, from srcValue: Swift.UnsafePointer<T>, options: TupleType.CopyOptions) {
+  @_transparent public func setElement<T>(in tupleValue: Swift.UnsafeMutableRawPointer, at index: Swift.Int, from srcValue: Swift.UnsafePointer<T>, options: AttributeGraph.TupleType.CopyOptions) {
         __AGTupleSetElement(self, tupleValue, index, srcValue, Metadata(T.self), options)
     }
-  @_transparent public func getElement<T>(in tupleValue: Swift.UnsafeMutableRawPointer, at index: Swift.Int, to dstValue: Swift.UnsafeMutablePointer<T>, options: TupleType.CopyOptions) {
+  @_transparent public func getElement<T>(in tupleValue: Swift.UnsafeMutableRawPointer, at index: Swift.Int, to dstValue: Swift.UnsafeMutablePointer<T>, options: AttributeGraph.TupleType.CopyOptions) {
         __AGTupleGetElement(self, tupleValue, index, dstValue, Metadata(T.self), options)
     }
 }
 @_silgen_name("AGTupleWithBuffer")
-public func withUnsafeTuple(of type: TupleType, count: Swift.Int, _ body: (UnsafeMutableTuple) -> Swift.Void)
-extension UnsafeTuple {
+public func withUnsafeTuple(of type: AttributeGraph.TupleType, count: Swift.Int, _ body: (AttributeGraph.UnsafeMutableTuple) -> Swift.Void)
+extension AttributeGraph.UnsafeTuple {
   @_transparent public var count: Swift.Int {
     @_transparent get { type.count }
   }
@@ -633,8 +700,8 @@ extension UnsafeTuple {
     @_transparent unsafeAddress { address(of: index, as: T.self) }
   }
 }
-extension UnsafeMutableTuple {
-  @_transparent public init(with tupleType: TupleType) {
+extension AttributeGraph.UnsafeMutableTuple {
+  @_transparent public init(with tupleType: AttributeGraph.TupleType) {
         self.init(
             type: tupleType,
             value: UnsafeMutableRawPointer.allocate(
@@ -688,21 +755,30 @@ extension UnsafeMutableTuple {
     @_transparent nonmutating unsafeMutableAddress { address(of: index, as: T.self) }
   }
 }
-extension AttributeGraph.Attribute : Swift.Sendable {}
-extension AttributeGraph.Attribute : Swift.BitwiseCopyable {}
-extension AttributeGraph.External : Swift.Sendable {}
-extension AttributeGraph.External : Swift.BitwiseCopyable {}
+@discardableResult
+public func withUnsafePointerToEnumCase<T>(of value: Swift.UnsafeMutablePointer<T>, do body: (Swift.Int, any Any.Type, Swift.UnsafeRawPointer) -> ()) -> Swift.Bool
+@discardableResult
+public func withUnsafeMutablePointerToEnumCase<T>(of value: Swift.UnsafeMutablePointer<T>, do body: (Swift.Int, any Any.Type, Swift.UnsafeMutableRawPointer) -> ()) -> Swift.Bool
+public func compareValues<Value>(_ lhs: Value, _ rhs: Value, mode: AttributeGraph.ComparisonMode = .equatableAlways) -> Swift.Bool
+public func compareValues<Value>(_ lhs: Value, _ rhs: Value, options: AttributeGraph.ComparisonOptions) -> Swift.Bool
+extension AttributeGraph.ComparisonOptions {
+  public init(mode: AttributeGraph.ComparisonMode)
+}
 extension AttributeGraph.PointerOffset : Swift.Sendable {}
 extension AttributeGraph.PointerOffset : Swift.BitwiseCopyable {}
-extension AttributeGraph.IndirectAttribute : Swift.Sendable {}
-extension AttributeGraph.IndirectAttribute : Swift.BitwiseCopyable {}
-extension AttributeGraph.AnyOptionalAttribute : Swift.Sendable {}
-extension AttributeGraph.AnyOptionalAttribute : Swift.BitwiseCopyable {}
+extension AttributeGraph.External : Swift.Sendable {}
+extension AttributeGraph.External : Swift.BitwiseCopyable {}
+extension AttributeGraph.Attribute : Swift.Sendable {}
+extension AttributeGraph.Attribute : Swift.BitwiseCopyable {}
+extension AttributeGraph.WeakAttribute : Swift.Sendable {}
+extension AttributeGraph.WeakAttribute : Swift.BitwiseCopyable {}
 extension AttributeGraph.OptionalAttribute : Swift.Sendable {}
 extension AttributeGraph.OptionalAttribute : Swift.BitwiseCopyable {}
+extension AttributeGraph.AnyOptionalAttribute : Swift.Sendable {}
+extension AttributeGraph.AnyOptionalAttribute : Swift.BitwiseCopyable {}
+extension AttributeGraph.IndirectAttribute : Swift.Sendable {}
+extension AttributeGraph.IndirectAttribute : Swift.BitwiseCopyable {}
 extension AttributeGraph.AnyRuleContext : Swift.Sendable {}
 extension AttributeGraph.AnyRuleContext : Swift.BitwiseCopyable {}
 extension AttributeGraph.RuleContext : Swift.Sendable {}
 extension AttributeGraph.RuleContext : Swift.BitwiseCopyable {}
-extension AttributeGraph.WeakAttribute : Swift.Sendable {}
-extension AttributeGraph.WeakAttribute : Swift.BitwiseCopyable {}

--- a/AG/2024/AttributeGraph.xcframework/macos-arm64e-arm64-x86_64/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/arm64e-apple-macos.swiftinterface
+++ b/AG/2024/AttributeGraph.xcframework/macos-arm64e-arm64-x86_64/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/arm64e-apple-macos.swiftinterface
@@ -10,11 +10,9 @@ public import _SwiftConcurrencyShims
 extension AttributeGraph.AnyAttribute {
   public init<Value>(_ attribute: AttributeGraph.Attribute<Value>)
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.Attribute<Value>
-  #if compiler(>=5.3) && $NonescapableTypes
   public static var current: AttributeGraph.AnyAttribute? {
     get
   }
-  #endif
   public func unsafeOffset(at offset: Swift.Int) -> AttributeGraph.AnyAttribute
   public func setFlags(_ newFlags: AttributeGraph.AnyAttribute.Flags, mask: AttributeGraph.AnyAttribute.Flags)
   public func addInput(_ attribute: AttributeGraph.AnyAttribute, options: AttributeGraph.AGInputOptions = [], token: Swift.Int)
@@ -31,12 +29,10 @@ extension AttributeGraph.AnyAttribute {
   public var valueType: any Any.Type {
     get
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public var indirectDependency: AttributeGraph.AnyAttribute? {
     get
     nonmutating set
   }
-  #endif
 }
 extension AttributeGraph.AnyAttribute : Swift.CustomStringConvertible {
   @inlinable public var description: Swift.String {
@@ -95,9 +91,7 @@ extension AttributeGraph.External : Swift.CustomStringConvertible {
   public init(_ attribute: AttributeGraph.Attribute<Value>)
   public init(value: Value)
   public init(type _: Value.Type)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init<Body>(body: Swift.UnsafePointer<Body>, value: Swift.UnsafePointer<Value>?, flags: AttributeGraph._AttributeType.Flags = [], update: () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void) where Body : AttributeGraph._AttributeBody
-  #endif
   public var wrappedValue: Value {
     unsafeAddress
     nonmutating set
@@ -169,10 +163,8 @@ extension AttributeGraph.Attribute {
   public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.Rule
   public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.StatefulRule
 }
-#if compiler(>=5.3) && $NonescapableTypes
 @_silgen_name("AGGraphCreateAttribute")
 @inline(__always) @inlinable internal func AGGraphCreateAttribute(index: Swift.Int, body: Swift.UnsafeRawPointer, value: Swift.UnsafeRawPointer?) -> AttributeGraph.AnyAttribute
-#endif
 @_silgen_name("AGGraphGetValue")
 @inline(__always) @inlinable internal func AGGraphGetValue<Value>(_ attribute: AttributeGraph.AnyAttribute, options: AttributeGraph.AGValueOptions = [], type: Value.Type = Value.self) -> AttributeGraph.AGValue
 @_silgen_name("AGGraphSetValue")
@@ -215,40 +207,26 @@ extension AttributeGraph._AttributeBody {
   public init(base: AttributeGraph.AnyWeakAttribute)
   public init()
   public init(_ attribute: AttributeGraph.Attribute<Value>)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.Attribute<Value>?)
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var wrappedValue: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var projectedValue: AttributeGraph.Attribute<Value>? {
     get
     set
     _modify
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.Attribute<Value>? {
     get
     set
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var value: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
-  #endif
 }
 extension AttributeGraph.WeakAttribute : Swift.Hashable {
   public static func == (a: AttributeGraph.WeakAttribute<Value>, b: AttributeGraph.WeakAttribute<Value>) -> Swift.Bool
@@ -263,17 +241,13 @@ extension AttributeGraph.WeakAttribute : Swift.CustomStringConvertible {
   }
 }
 extension AttributeGraph.AnyWeakAttribute {
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.AnyAttribute?)
-  #endif
   public init<Value>(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.WeakAttribute<Value>
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.AnyAttribute? {
     get
     set
   }
-  #endif
 }
 extension AttributeGraph.AnyWeakAttribute : Swift.Hashable {
   public static func == (lhs: AttributeGraph.AnyWeakAttribute, rhs: AttributeGraph.AnyWeakAttribute) -> Swift.Bool
@@ -289,17 +263,13 @@ extension AttributeGraph.AnyWeakAttribute : Swift.CustomStringConvertible {
 }
 public protocol Rule : AttributeGraph._AttributeBody {
   associatedtype Value
-  #if compiler(>=5.3) && $NonescapableTypes
   static var initialValue: Self.Value? { get }
-  #endif
   var value: Self.Value { get }
 }
 extension AttributeGraph.Rule {
-  #if compiler(>=5.3) && $NonescapableTypes
   public static var initialValue: Self.Value? {
     get
   }
-  #endif
   public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AttributeGraph.AnyAttribute)
   public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
 }
@@ -312,15 +282,9 @@ extension AttributeGraph.Rule {
   }
 }
 extension AttributeGraph.Rule where Self : Swift.Hashable {
-  #if compiler(>=5.3) && $NonescapableTypes
   public func cachedValue(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?) -> Self.Value
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func cachedValueIfExists(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?) -> Self.Value?
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public static func _cachedValue(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?, hashValue: Swift.Int, bodyPtr: Swift.UnsafeRawPointer, update: () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void) -> Swift.UnsafePointer<Self.Value>
-  #endif
 }
 @frozen public struct Map<Source, Value> : AttributeGraph.Rule, Swift.CustomStringConvertible {
   public var arg: AttributeGraph.Attribute<Source>
@@ -338,17 +302,13 @@ extension AttributeGraph.Rule where Self : Swift.Hashable {
 }
 public protocol StatefulRule : AttributeGraph._AttributeBody {
   associatedtype Value
-  #if compiler(>=5.3) && $NonescapableTypes
   static var initialValue: Self.Value? { get }
-  #endif
   mutating func updateValue()
 }
 extension AttributeGraph.StatefulRule {
-  #if compiler(>=5.3) && $NonescapableTypes
   public static var initialValue: Self.Value? {
     get
   }
-  #endif
   public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AttributeGraph.AnyAttribute)
   public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
 }
@@ -386,44 +346,28 @@ extension AttributeGraph.StatefulRule {
   public init()
   public init(base: AttributeGraph.AnyOptionalAttribute)
   public init(_ attribute: AttributeGraph.Attribute<Value>)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.Attribute<Value>?)
-  #endif
   public init(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.Attribute<Value>? {
     get
     set
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var value: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func map<V>(_ body: (AttributeGraph.Attribute<Value>) -> V) -> V?
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var wrappedValue: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var projectedValue: AttributeGraph.Attribute<Value>? {
     get
     set
     _modify
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
     get
   }
-  #endif
 }
 extension AttributeGraph.OptionalAttribute : Swift.Hashable {
   public static func == (a: AttributeGraph.OptionalAttribute<Value>, b: AttributeGraph.OptionalAttribute<Value>) -> Swift.Bool
@@ -441,22 +385,16 @@ extension AttributeGraph.OptionalAttribute : Swift.CustomStringConvertible {
   public var identifier: AttributeGraph.AnyAttribute
   public init()
   public init(_ attribute: AttributeGraph.AnyAttribute)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.AnyAttribute?)
-  #endif
   public init<Value>(_ attribute: AttributeGraph.OptionalAttribute<Value>)
   public static var current: AttributeGraph.AnyOptionalAttribute {
     get
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.AnyAttribute? {
     get
     set
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func map<Value>(_ body: (AttributeGraph.AnyAttribute) -> Value) -> Value?
-  #endif
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.OptionalAttribute<Value>
 }
 extension AttributeGraph.AnyOptionalAttribute : Swift.Hashable {
@@ -478,12 +416,10 @@ extension AttributeGraph.AnyOptionalAttribute : Swift.CustomStringConvertible {
     get
     nonmutating set
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public var dependency: AttributeGraph.AnyAttribute? {
     get
     nonmutating set
   }
-  #endif
   public var value: Value {
     get
     nonmutating set
@@ -516,16 +452,12 @@ extension AttributeGraph.IndirectAttribute : Swift.Hashable {
   public subscript<V>(attribute: AttributeGraph.Attribute<V>) -> V {
     unsafeAddress
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(weakAttribute: AttributeGraph.WeakAttribute<V>) -> V? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(optionalAttribute: AttributeGraph.OptionalAttribute<V>) -> V? {
     get
   }
-  #endif
   public func valueAndFlags<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, flags: AttributeGraph.AGChangedValueFlags)
   public func changedValue<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, changed: Swift.Bool)
   public func update(body: () -> Swift.Void)
@@ -538,16 +470,12 @@ extension AttributeGraph.IndirectAttribute : Swift.Hashable {
   public subscript<V>(attribute: AttributeGraph.Attribute<V>) -> V {
     unsafeAddress
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(weakAttribute: AttributeGraph.WeakAttribute<V>) -> V? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(optionalAttribute: AttributeGraph.OptionalAttribute<V>) -> V? {
     get
   }
-  #endif
   public var value: Value {
     unsafeAddress
     nonmutating set
@@ -609,10 +537,8 @@ extension AttributeGraph.Graph {
   }
 }
 extension AttributeGraph.Graph {
-  #if compiler(>=5.3) && $NonescapableTypes
   @_silgen_name("AGGraphGetOutputValue")
   @inline(__always) @inlinable public static func outputValue<Value>() -> Swift.UnsafePointer<Value>?
-  #endif
   @_silgen_name("AGGraphSetOutputValue")
   @inline(__always) @inlinable public static func setOutputValue<Value>(_ value: Swift.UnsafePointer<Value>)
 }
@@ -622,9 +548,7 @@ extension AttributeGraph.Graph {
     }
 }
 extension AttributeGraph.Graph {
-  #if compiler(>=5.3) && $NonescapableTypes
   public func archiveJSON(name: Swift.String?)
-  #endif
 }
 public func forEachField(of type: any Any.Type, do body: (Swift.UnsafePointer<Swift.Int8>, Swift.Int, any Any.Type) -> Swift.Void)
 extension AttributeGraph.Metadata : Swift.Hashable, Swift.CustomStringConvertible {

--- a/AG/2024/AttributeGraph.xcframework/macos-arm64e-arm64-x86_64/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/x86_64-apple-macos.swiftinterface
+++ b/AG/2024/AttributeGraph.xcframework/macos-arm64e-arm64-x86_64/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/x86_64-apple-macos.swiftinterface
@@ -7,19 +7,21 @@ public import Swift
 public import _Concurrency
 public import _StringProcessing
 public import _SwiftConcurrencyShims
-extension AnyAttribute {
+extension AttributeGraph.AnyAttribute {
   public init<Value>(_ attribute: AttributeGraph.Attribute<Value>)
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.Attribute<Value>
-  public static var current: AnyAttribute? {
+  #if compiler(>=5.3) && $NonescapableTypes
+  public static var current: AttributeGraph.AnyAttribute? {
     get
   }
-  public func unsafeOffset(at offset: Swift.Int) -> AnyAttribute
-  public func setFlags(_ newFlags: AnyAttribute.Flags, mask: AnyAttribute.Flags)
-  public func addInput(_ attribute: AnyAttribute, options: AGInputOptions = [], token: Swift.Int)
-  public func addInput<Value>(_ attribute: AttributeGraph.Attribute<Value>, options: AGInputOptions = [], token: Swift.Int)
+  #endif
+  public func unsafeOffset(at offset: Swift.Int) -> AttributeGraph.AnyAttribute
+  public func setFlags(_ newFlags: AttributeGraph.AnyAttribute.Flags, mask: AttributeGraph.AnyAttribute.Flags)
+  public func addInput(_ attribute: AttributeGraph.AnyAttribute, options: AttributeGraph.AGInputOptions = [], token: Swift.Int)
+  public func addInput<Value>(_ attribute: AttributeGraph.Attribute<Value>, options: AttributeGraph.AGInputOptions = [], token: Swift.Int)
   public func visitBody<Body>(_ visitor: inout Body) where Body : AttributeGraph.AttributeBodyVisitor
   public func mutateBody<Value>(as type: Value.Type, invalidating: Swift.Bool, _ body: (inout Value) -> Swift.Void)
-  public func breadthFirstSearch(options _: SearchOptions = [], _: (AnyAttribute) -> Swift.Bool) -> Swift.Bool
+  public func breadthFirstSearch(options _: AttributeGraph.SearchOptions = [], _: (AttributeGraph.AnyAttribute) -> Swift.Bool) -> Swift.Bool
   public var _bodyType: any Any.Type {
     get
   }
@@ -29,118 +31,19 @@ extension AnyAttribute {
   public var valueType: any Any.Type {
     get
   }
-  public var indirectDependency: AnyAttribute? {
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var indirectDependency: AttributeGraph.AnyAttribute? {
     get
     nonmutating set
   }
+  #endif
 }
-extension AnyAttribute : Swift.CustomStringConvertible {
+extension AttributeGraph.AnyAttribute : Swift.CustomStringConvertible {
   @inlinable public var description: Swift.String {
     get { "#\(rawValue)" }
   }
 }
-public typealias AttributeUpdateBlock = () -> (Swift.UnsafeMutableRawPointer, AnyAttribute) -> Swift.Void
-@frozen @propertyWrapper @dynamicMemberLookup public struct Attribute<Value> {
-  public var identifier: AnyAttribute
-  public init(identifier: AnyAttribute)
-  public init(_ attribute: AttributeGraph.Attribute<Value>)
-  public init(value: Value)
-  public init(type _: Value.Type)
-  public init<Body>(body: Swift.UnsafePointer<Body>, value: Swift.UnsafePointer<Value>?, flags: _AttributeType.Flags = [], update: () -> (Swift.UnsafeMutableRawPointer, AnyAttribute) -> Swift.Void) where Body : AttributeGraph._AttributeBody
-  public var wrappedValue: Value {
-    unsafeAddress
-    nonmutating set
-  }
-  public var projectedValue: AttributeGraph.Attribute<Value> {
-    get
-    set
-  }
-  public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member> {
-    get
-  }
-  public subscript<Member>(keyPath keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member> {
-    get
-  }
-  public subscript<Member>(offset body: (inout Value) -> AttributeGraph.PointerOffset<Value, Member>) -> AttributeGraph.Attribute<Member> {
-    get
-  }
-  public func unsafeCast<V>(to type: V.Type) -> AttributeGraph.Attribute<V>
-  public func unsafeOffset<Member>(at offset: Swift.Int, as _: Member.Type) -> AttributeGraph.Attribute<Member>
-  public func applying<Member>(offset: AttributeGraph.PointerOffset<Value, Member>) -> AttributeGraph.Attribute<Member>
-  public func visitBody<Body>(_ visitor: inout Body) where Body : AttributeGraph.AttributeBodyVisitor
-  public func mutateBody<V>(as type: V.Type, invalidating: Swift.Bool, _ body: (inout V) -> Swift.Void)
-  public func breadthFirstSearch(options: SearchOptions = [], _ body: (AnyAttribute) -> Swift.Bool) -> Swift.Bool
-  public var graph: Graph {
-    get
-  }
-  public var subgraph: Subgraph {
-    get
-  }
-  public var value: Value {
-    unsafeAddress
-    nonmutating set
-  }
-  public var valueState: ValueState {
-    get
-  }
-  public func valueAndFlags(options: AGValueOptions = []) -> (value: Value, flags: AGChangedValueFlags)
-  public func changedValue(options: AGValueOptions = []) -> (value: Value, changed: Swift.Bool)
-  public func setValue(_ value: Value) -> Swift.Bool
-  public var hasValue: Swift.Bool {
-    get
-  }
-  public func updateValue()
-  public func prefetchValue()
-  public func invalidateValue()
-  public func validate()
-  public func addInput(_ attribute: AnyAttribute, options: AGInputOptions = [], token: Swift.Int)
-  public func addInput<V>(_ attribute: AttributeGraph.Attribute<V>, options: AGInputOptions = [], token: Swift.Int)
-  public typealias Flags = AnyAttribute.Flags
-  public var flags: AttributeGraph.Attribute<Value>.Flags {
-    get
-    nonmutating set
-  }
-  public func setFlags(_ newFlags: AttributeGraph.Attribute<Value>.Flags, mask: AttributeGraph.Attribute<Value>.Flags)
-}
-extension AttributeGraph.Attribute : Swift.Hashable {
-  public static func == (a: AttributeGraph.Attribute<Value>, b: AttributeGraph.Attribute<Value>) -> Swift.Bool
-  public func hash(into hasher: inout Swift.Hasher)
-  public var hashValue: Swift.Int {
-    get
-  }
-}
-extension AttributeGraph.Attribute : Swift.CustomStringConvertible {
-  public var description: Swift.String {
-    get
-  }
-}
-extension AttributeGraph.Attribute {
-  public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.Rule
-  public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.StatefulRule
-}
-@_silgen_name("AGGraphCreateAttribute")
-@inline(__always) @inlinable internal func AGGraphCreateAttribute(index: Swift.Int, body: Swift.UnsafeRawPointer, value: Swift.UnsafeRawPointer?) -> AnyAttribute
-@_silgen_name("AGGraphGetValue")
-@inline(__always) @inlinable internal func AGGraphGetValue<Value>(_ attribute: AnyAttribute, options: AGValueOptions = [], type: Value.Type = Value.self) -> AGValue
-@_silgen_name("AGGraphSetValue")
-@inline(__always) @inlinable internal func AGGraphSetValue<Value>(_ attribute: AnyAttribute, valuePointer: Swift.UnsafePointer<Value>) -> Swift.Bool
-@frozen public struct External<Value> {
-  public init()
-}
-extension AttributeGraph.External : AttributeGraph._AttributeBody {
-  public static var comparisonMode: ComparisonMode {
-    get
-  }
-  public static var flags: AttributeGraph.External<Value>.Flags {
-    get
-  }
-  public static func _update(_: Swift.UnsafeMutableRawPointer, attribute _: AnyAttribute)
-}
-extension AttributeGraph.External : Swift.CustomStringConvertible {
-  public var description: Swift.String {
-    get
-  }
-}
+public typealias AttributeUpdateBlock = () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void
 @frozen public struct PointerOffset<Base, Member> {
   public var byteOffset: Swift.Int
   public init(byteOffset: Swift.Int)
@@ -169,27 +72,111 @@ extension Swift.UnsafeMutablePointer {
   }
   public static func + <Member>(lhs: Swift.UnsafeMutablePointer<Pointee>, rhs: AttributeGraph.PointerOffset<Pointee, Member>) -> Swift.UnsafeMutablePointer<Member>
 }
-public protocol _AttributeBody {
-  static func _destroySelf(_ pointer: Swift.UnsafeMutableRawPointer)
-  static var _hasDestroySelf: Swift.Bool { get }
-  static func _updateDefault(_ pointer: Swift.UnsafeMutableRawPointer)
-  static var comparisonMode: ComparisonMode { get }
-  typealias Flags = _AttributeType.Flags
-  static var flags: Self.Flags { get }
+@frozen public struct External<Value> {
+  public init()
 }
-extension AttributeGraph._AttributeBody {
-  public static func _destroySelf(_ pointer: Swift.UnsafeMutableRawPointer)
-  public static var _hasDestroySelf: Swift.Bool {
+extension AttributeGraph.External : AttributeGraph._AttributeBody {
+  public static var comparisonMode: AttributeGraph.ComparisonMode {
     get
   }
-  public static func _updateDefault(_ pointer: Swift.UnsafeMutableRawPointer)
-  public static var comparisonMode: ComparisonMode {
+  public static var flags: AttributeGraph.External<Value>.Flags {
     get
   }
-  public static var flags: Self.Flags {
+  public static func _update(_: Swift.UnsafeMutableRawPointer, attribute _: AttributeGraph.AnyAttribute)
+}
+extension AttributeGraph.External : Swift.CustomStringConvertible {
+  public var description: Swift.String {
     get
   }
 }
+@frozen @propertyWrapper @dynamicMemberLookup public struct Attribute<Value> {
+  public var identifier: AttributeGraph.AnyAttribute
+  public init(identifier: AttributeGraph.AnyAttribute)
+  public init(_ attribute: AttributeGraph.Attribute<Value>)
+  public init(value: Value)
+  public init(type _: Value.Type)
+  #if compiler(>=5.3) && $NonescapableTypes
+  public init<Body>(body: Swift.UnsafePointer<Body>, value: Swift.UnsafePointer<Value>?, flags: AttributeGraph._AttributeType.Flags = [], update: () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void) where Body : AttributeGraph._AttributeBody
+  #endif
+  public var wrappedValue: Value {
+    unsafeAddress
+    nonmutating set
+  }
+  public var projectedValue: AttributeGraph.Attribute<Value> {
+    get
+    set
+  }
+  public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member> {
+    get
+  }
+  public subscript<Member>(keyPath keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member> {
+    get
+  }
+  public subscript<Member>(offset body: (inout Value) -> AttributeGraph.PointerOffset<Value, Member>) -> AttributeGraph.Attribute<Member> {
+    get
+  }
+  public func unsafeCast<V>(to type: V.Type) -> AttributeGraph.Attribute<V>
+  public func unsafeOffset<Member>(at offset: Swift.Int, as _: Member.Type) -> AttributeGraph.Attribute<Member>
+  public func applying<Member>(offset: AttributeGraph.PointerOffset<Value, Member>) -> AttributeGraph.Attribute<Member>
+  public func visitBody<Body>(_ visitor: inout Body) where Body : AttributeGraph.AttributeBodyVisitor
+  public func mutateBody<V>(as type: V.Type, invalidating: Swift.Bool, _ body: (inout V) -> Swift.Void)
+  public func breadthFirstSearch(options: AttributeGraph.SearchOptions = [], _ body: (AttributeGraph.AnyAttribute) -> Swift.Bool) -> Swift.Bool
+  public var graph: AttributeGraph.Graph {
+    get
+  }
+  public var subgraph: AttributeGraph.Subgraph {
+    get
+  }
+  public var value: Value {
+    unsafeAddress
+    nonmutating set
+  }
+  public var valueState: AttributeGraph.ValueState {
+    get
+  }
+  public func valueAndFlags(options: AttributeGraph.AGValueOptions = []) -> (value: Value, flags: AttributeGraph.AGChangedValueFlags)
+  public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)
+  public func setValue(_ value: Value) -> Swift.Bool
+  public var hasValue: Swift.Bool {
+    get
+  }
+  public func updateValue()
+  public func prefetchValue()
+  public func invalidateValue()
+  public func validate()
+  public func addInput(_ attribute: AttributeGraph.AnyAttribute, options: AttributeGraph.AGInputOptions = [], token: Swift.Int)
+  public func addInput<V>(_ attribute: AttributeGraph.Attribute<V>, options: AttributeGraph.AGInputOptions = [], token: Swift.Int)
+  public typealias Flags = AttributeGraph.AnyAttribute.Flags
+  public var flags: AttributeGraph.Attribute<Value>.Flags {
+    get
+    nonmutating set
+  }
+  public func setFlags(_ newFlags: AttributeGraph.Attribute<Value>.Flags, mask: AttributeGraph.Attribute<Value>.Flags)
+}
+extension AttributeGraph.Attribute : Swift.Hashable {
+  public static func == (a: AttributeGraph.Attribute<Value>, b: AttributeGraph.Attribute<Value>) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+extension AttributeGraph.Attribute : Swift.CustomStringConvertible {
+  public var description: Swift.String {
+    get
+  }
+}
+extension AttributeGraph.Attribute {
+  public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.Rule
+  public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.StatefulRule
+}
+#if compiler(>=5.3) && $NonescapableTypes
+@_silgen_name("AGGraphCreateAttribute")
+@inline(__always) @inlinable internal func AGGraphCreateAttribute(index: Swift.Int, body: Swift.UnsafeRawPointer, value: Swift.UnsafeRawPointer?) -> AttributeGraph.AnyAttribute
+#endif
+@_silgen_name("AGGraphGetValue")
+@inline(__always) @inlinable internal func AGGraphGetValue<Value>(_ attribute: AttributeGraph.AnyAttribute, options: AttributeGraph.AGValueOptions = [], type: Value.Type = Value.self) -> AttributeGraph.AGValue
+@_silgen_name("AGGraphSetValue")
+@inline(__always) @inlinable internal func AGGraphSetValue<Value>(_ attribute: AttributeGraph.AnyAttribute, valuePointer: Swift.UnsafePointer<Value>) -> Swift.Bool
 public protocol AttributeBodyVisitor {
   func visit<Body>(body: Swift.UnsafePointer<Body>) where Body : AttributeGraph._AttributeBody
 }
@@ -202,23 +189,307 @@ extension AttributeGraph.ObservedAttribute {
     get
   }
 }
+public protocol _AttributeBody {
+  static func _destroySelf(_ pointer: Swift.UnsafeMutableRawPointer)
+  static var _hasDestroySelf: Swift.Bool { get }
+  static func _updateDefault(_ pointer: Swift.UnsafeMutableRawPointer)
+  static var comparisonMode: AttributeGraph.ComparisonMode { get }
+  typealias Flags = AttributeGraph._AttributeType.Flags
+  static var flags: Self.Flags { get }
+}
+extension AttributeGraph._AttributeBody {
+  public static func _destroySelf(_ pointer: Swift.UnsafeMutableRawPointer)
+  public static var _hasDestroySelf: Swift.Bool {
+    get
+  }
+  public static func _updateDefault(_ pointer: Swift.UnsafeMutableRawPointer)
+  public static var comparisonMode: AttributeGraph.ComparisonMode {
+    get
+  }
+  public static var flags: Self.Flags {
+    get
+  }
+}
+@frozen @propertyWrapper @dynamicMemberLookup public struct WeakAttribute<Value> {
+  internal var base: AttributeGraph.AnyWeakAttribute
+  public init(base: AttributeGraph.AnyWeakAttribute)
+  public init()
+  public init(_ attribute: AttributeGraph.Attribute<Value>)
+  #if compiler(>=5.3) && $NonescapableTypes
+  public init(_ attribute: AttributeGraph.Attribute<Value>?)
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var wrappedValue: Value? {
+    get
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var projectedValue: AttributeGraph.Attribute<Value>? {
+    get
+    set
+    _modify
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
+    get
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var attribute: AttributeGraph.Attribute<Value>? {
+    get
+    set
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var value: Value? {
+    get
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
+  #endif
+}
+extension AttributeGraph.WeakAttribute : Swift.Hashable {
+  public static func == (a: AttributeGraph.WeakAttribute<Value>, b: AttributeGraph.WeakAttribute<Value>) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+extension AttributeGraph.WeakAttribute : Swift.CustomStringConvertible {
+  public var description: Swift.String {
+    get
+  }
+}
+extension AttributeGraph.AnyWeakAttribute {
+  #if compiler(>=5.3) && $NonescapableTypes
+  public init(_ attribute: AttributeGraph.AnyAttribute?)
+  #endif
+  public init<Value>(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
+  public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.WeakAttribute<Value>
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var attribute: AttributeGraph.AnyAttribute? {
+    get
+    set
+  }
+  #endif
+}
+extension AttributeGraph.AnyWeakAttribute : Swift.Hashable {
+  public static func == (lhs: AttributeGraph.AnyWeakAttribute, rhs: AttributeGraph.AnyWeakAttribute) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+extension AttributeGraph.AnyWeakAttribute : Swift.CustomStringConvertible {
+  @_alwaysEmitIntoClient public var description: Swift.String {
+    get { attribute?.description ?? "nil" }
+  }
+}
+public protocol Rule : AttributeGraph._AttributeBody {
+  associatedtype Value
+  #if compiler(>=5.3) && $NonescapableTypes
+  static var initialValue: Self.Value? { get }
+  #endif
+  var value: Self.Value { get }
+}
+extension AttributeGraph.Rule {
+  #if compiler(>=5.3) && $NonescapableTypes
+  public static var initialValue: Self.Value? {
+    get
+  }
+  #endif
+  public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AttributeGraph.AnyAttribute)
+  public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
+}
+extension AttributeGraph.Rule {
+  public var attribute: AttributeGraph.Attribute<Self.Value> {
+    get
+  }
+  public var context: AttributeGraph.RuleContext<Self.Value> {
+    get
+  }
+}
+extension AttributeGraph.Rule where Self : Swift.Hashable {
+  #if compiler(>=5.3) && $NonescapableTypes
+  public func cachedValue(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?) -> Self.Value
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public func cachedValueIfExists(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?) -> Self.Value?
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public static func _cachedValue(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?, hashValue: Swift.Int, bodyPtr: Swift.UnsafeRawPointer, update: () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void) -> Swift.UnsafePointer<Self.Value>
+  #endif
+}
+@frozen public struct Map<Source, Value> : AttributeGraph.Rule, Swift.CustomStringConvertible {
+  public var arg: AttributeGraph.Attribute<Source>
+  public let body: (Source) -> Value
+  public init(_ arg: AttributeGraph.Attribute<Source>, _ body: @escaping (Source) -> Value)
+  public var value: Value {
+    get
+  }
+  public static var flags: AttributeGraph.Map<Source, Value>.Flags {
+    get
+  }
+  public var description: Swift.String {
+    get
+  }
+}
+public protocol StatefulRule : AttributeGraph._AttributeBody {
+  associatedtype Value
+  #if compiler(>=5.3) && $NonescapableTypes
+  static var initialValue: Self.Value? { get }
+  #endif
+  mutating func updateValue()
+}
+extension AttributeGraph.StatefulRule {
+  #if compiler(>=5.3) && $NonescapableTypes
+  public static var initialValue: Self.Value? {
+    get
+  }
+  #endif
+  public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AttributeGraph.AnyAttribute)
+  public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
+}
+extension AttributeGraph.StatefulRule {
+  public var attribute: AttributeGraph.Attribute<Self.Value> {
+    get
+  }
+  public var context: AttributeGraph.RuleContext<Self.Value> {
+    get
+  }
+  public var value: Self.Value {
+    unsafeAddress
+    nonmutating set
+  }
+  public var hasValue: Swift.Bool {
+    get
+  }
+}
+@frozen public struct Focus<Root, Value> : AttributeGraph.Rule, Swift.CustomStringConvertible {
+  public var root: AttributeGraph.Attribute<Root>
+  public var keyPath: Swift.KeyPath<Root, Value>
+  public init(root: AttributeGraph.Attribute<Root>, keyPath: Swift.KeyPath<Root, Value>)
+  public var value: Value {
+    get
+  }
+  public static var flags: AttributeGraph.Focus<Root, Value>.Flags {
+    get
+  }
+  public var description: Swift.String {
+    get
+  }
+}
+@frozen @propertyWrapper @dynamicMemberLookup public struct OptionalAttribute<Value> {
+  public var base: AttributeGraph.AnyOptionalAttribute
+  public init()
+  public init(base: AttributeGraph.AnyOptionalAttribute)
+  public init(_ attribute: AttributeGraph.Attribute<Value>)
+  #if compiler(>=5.3) && $NonescapableTypes
+  public init(_ attribute: AttributeGraph.Attribute<Value>?)
+  #endif
+  public init(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var attribute: AttributeGraph.Attribute<Value>? {
+    get
+    set
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var value: Value? {
+    get
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public func map<V>(_ body: (AttributeGraph.Attribute<Value>) -> V) -> V?
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var wrappedValue: Value? {
+    get
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var projectedValue: AttributeGraph.Attribute<Value>? {
+    get
+    set
+    _modify
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
+    get
+  }
+  #endif
+}
+extension AttributeGraph.OptionalAttribute : Swift.Hashable {
+  public static func == (a: AttributeGraph.OptionalAttribute<Value>, b: AttributeGraph.OptionalAttribute<Value>) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+extension AttributeGraph.OptionalAttribute : Swift.CustomStringConvertible {
+  public var description: Swift.String {
+    get
+  }
+}
+@frozen public struct AnyOptionalAttribute {
+  public var identifier: AttributeGraph.AnyAttribute
+  public init()
+  public init(_ attribute: AttributeGraph.AnyAttribute)
+  #if compiler(>=5.3) && $NonescapableTypes
+  public init(_ attribute: AttributeGraph.AnyAttribute?)
+  #endif
+  public init<Value>(_ attribute: AttributeGraph.OptionalAttribute<Value>)
+  public static var current: AttributeGraph.AnyOptionalAttribute {
+    get
+  }
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var attribute: AttributeGraph.AnyAttribute? {
+    get
+    set
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public func map<Value>(_ body: (AttributeGraph.AnyAttribute) -> Value) -> Value?
+  #endif
+  public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.OptionalAttribute<Value>
+}
+extension AttributeGraph.AnyOptionalAttribute : Swift.Hashable {
+  public static func == (a: AttributeGraph.AnyOptionalAttribute, b: AttributeGraph.AnyOptionalAttribute) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+extension AttributeGraph.AnyOptionalAttribute : Swift.CustomStringConvertible {
+  public var description: Swift.String {
+    get
+  }
+}
 @frozen @propertyWrapper @dynamicMemberLookup public struct IndirectAttribute<Value> {
-  public let identifier: AnyAttribute
+  public let identifier: AttributeGraph.AnyAttribute
   public init(source: AttributeGraph.Attribute<Value>)
   public var source: AttributeGraph.Attribute<Value> {
     get
     nonmutating set
   }
-  public var dependency: AnyAttribute? {
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var dependency: AttributeGraph.AnyAttribute? {
     get
     nonmutating set
   }
+  #endif
   public var value: Value {
     get
     nonmutating set
     nonmutating _modify
   }
-  public func changedValue(options: AGValueOptions = []) -> (value: Value, changed: Swift.Bool)
+  public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)
   public var wrappedValue: Value {
     get
     nonmutating set
@@ -238,169 +509,25 @@ extension AttributeGraph.IndirectAttribute : Swift.Hashable {
     get
   }
 }
-@frozen public struct AnyOptionalAttribute {
-  public var identifier: AnyAttribute
-  public init()
-  public init(_ attribute: AnyAttribute)
-  public init(_ attribute: AnyAttribute?)
-  public init<Value>(_ attribute: AttributeGraph.OptionalAttribute<Value>)
-  public static var current: AttributeGraph.AnyOptionalAttribute {
-    get
-  }
-  public var attribute: AnyAttribute? {
-    get
-    set
-  }
-  public func map<Value>(_ body: (AnyAttribute) -> Value) -> Value?
-  public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.OptionalAttribute<Value>
-}
-extension AttributeGraph.AnyOptionalAttribute : Swift.Hashable {
-  public static func == (a: AttributeGraph.AnyOptionalAttribute, b: AttributeGraph.AnyOptionalAttribute) -> Swift.Bool
-  public func hash(into hasher: inout Swift.Hasher)
-  public var hashValue: Swift.Int {
-    get
-  }
-}
-extension AttributeGraph.AnyOptionalAttribute : Swift.CustomStringConvertible {
-  public var description: Swift.String {
-    get
-  }
-}
-@frozen @propertyWrapper @dynamicMemberLookup public struct OptionalAttribute<Value> {
-  public var base: AttributeGraph.AnyOptionalAttribute
-  public init()
-  public init(base: AttributeGraph.AnyOptionalAttribute)
-  public init(_ attribute: AttributeGraph.Attribute<Value>)
-  public init(_ attribute: AttributeGraph.Attribute<Value>?)
-  public init(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
-  public var attribute: AttributeGraph.Attribute<Value>? {
-    get
-    set
-  }
-  public var value: Value? {
-    get
-  }
-  public func changedValue(options: AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
-  public func map<V>(_ body: (AttributeGraph.Attribute<Value>) -> V) -> V?
-  public var wrappedValue: Value? {
-    get
-  }
-  public var projectedValue: AttributeGraph.Attribute<Value>? {
-    get
-    set
-    _modify
-  }
-  public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
-    get
-  }
-}
-extension AttributeGraph.OptionalAttribute : Swift.Hashable {
-  public static func == (a: AttributeGraph.OptionalAttribute<Value>, b: AttributeGraph.OptionalAttribute<Value>) -> Swift.Bool
-  public func hash(into hasher: inout Swift.Hasher)
-  public var hashValue: Swift.Int {
-    get
-  }
-}
-extension AttributeGraph.OptionalAttribute : Swift.CustomStringConvertible {
-  public var description: Swift.String {
-    get
-  }
-}
-@frozen public struct Focus<Root, Value> : AttributeGraph.Rule, Swift.CustomStringConvertible {
-  public var root: AttributeGraph.Attribute<Root>
-  public var keyPath: Swift.KeyPath<Root, Value>
-  public init(root: AttributeGraph.Attribute<Root>, keyPath: Swift.KeyPath<Root, Value>)
-  public var value: Value {
-    get
-  }
-  public static var flags: AttributeGraph.Focus<Root, Value>.Flags {
-    get
-  }
-  public var description: Swift.String {
-    get
-  }
-}
-@frozen public struct Map<Source, Value> : AttributeGraph.Rule, Swift.CustomStringConvertible {
-  public var arg: AttributeGraph.Attribute<Source>
-  public let body: (Source) -> Value
-  public init(_ arg: AttributeGraph.Attribute<Source>, _ body: @escaping (Source) -> Value)
-  public var value: Value {
-    get
-  }
-  public static var flags: AttributeGraph.Map<Source, Value>.Flags {
-    get
-  }
-  public var description: Swift.String {
-    get
-  }
-}
-public protocol Rule : AttributeGraph._AttributeBody {
-  associatedtype Value
-  static var initialValue: Self.Value? { get }
-  var value: Self.Value { get }
-}
-extension AttributeGraph.Rule {
-  public static var initialValue: Self.Value? {
-    get
-  }
-  public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AnyAttribute)
-  public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
-}
-extension AttributeGraph.Rule {
-  public var attribute: AttributeGraph.Attribute<Self.Value> {
-    get
-  }
-  public var context: AttributeGraph.RuleContext<Self.Value> {
-    get
-  }
-}
-extension AttributeGraph.Rule where Self : Swift.Hashable {
-  public func cachedValue(options: AGCachedValueOptions = [], owner: AnyAttribute?) -> Self.Value
-  public func cachedValueIfExists(options: AGCachedValueOptions = [], owner: AnyAttribute?) -> Self.Value?
-  public static func _cachedValue(options: AGCachedValueOptions = [], owner: AnyAttribute?, hashValue: Swift.Int, bodyPtr: Swift.UnsafeRawPointer, update: () -> (Swift.UnsafeMutableRawPointer, AnyAttribute) -> Swift.Void) -> Swift.UnsafePointer<Self.Value>
-}
-public protocol StatefulRule : AttributeGraph._AttributeBody {
-  associatedtype Value
-  static var initialValue: Self.Value? { get }
-  mutating func updateValue()
-}
-extension AttributeGraph.StatefulRule {
-  public static var initialValue: Self.Value? {
-    get
-  }
-  public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AnyAttribute)
-  public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
-}
-extension AttributeGraph.StatefulRule {
-  public var attribute: AttributeGraph.Attribute<Self.Value> {
-    get
-  }
-  public var context: AttributeGraph.RuleContext<Self.Value> {
-    get
-  }
-  public var value: Self.Value {
-    unsafeAddress
-    nonmutating set
-  }
-  public var hasValue: Swift.Bool {
-    get
-  }
-}
 @frozen public struct AnyRuleContext : Swift.Equatable {
-  public var attribute: AnyAttribute
-  public init(attribute: AnyAttribute)
+  public var attribute: AttributeGraph.AnyAttribute
+  public init(attribute: AttributeGraph.AnyAttribute)
   public init<V>(_ context: AttributeGraph.RuleContext<V>)
   public subscript<V>(attribute: AttributeGraph.Attribute<V>) -> V {
     unsafeAddress
   }
+  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(weakAttribute: AttributeGraph.WeakAttribute<V>) -> V? {
     get
   }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(optionalAttribute: AttributeGraph.OptionalAttribute<V>) -> V? {
     get
   }
-  public func valueAndFlags<V>(of input: AttributeGraph.Attribute<V>, options: AGValueOptions = []) -> (value: V, flags: AGChangedValueFlags)
-  public func changedValue<V>(of input: AttributeGraph.Attribute<V>, options: AGValueOptions = []) -> (value: V, changed: Swift.Bool)
+  #endif
+  public func valueAndFlags<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, flags: AttributeGraph.AGChangedValueFlags)
+  public func changedValue<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, changed: Swift.Bool)
   public func update(body: () -> Swift.Void)
   public func unsafeCast<V>(to _: V.Type) -> AttributeGraph.RuleContext<V>
   public static func == (a: AttributeGraph.AnyRuleContext, b: AttributeGraph.AnyRuleContext) -> Swift.Bool
@@ -411,12 +538,16 @@ extension AttributeGraph.StatefulRule {
   public subscript<V>(attribute: AttributeGraph.Attribute<V>) -> V {
     unsafeAddress
   }
+  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(weakAttribute: AttributeGraph.WeakAttribute<V>) -> V? {
     get
   }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(optionalAttribute: AttributeGraph.OptionalAttribute<V>) -> V? {
     get
   }
+  #endif
   public var value: Value {
     unsafeAddress
     nonmutating set
@@ -424,86 +555,41 @@ extension AttributeGraph.StatefulRule {
   public var hasValue: Swift.Bool {
     get
   }
-  public func valueAndFlags<V>(of input: AttributeGraph.Attribute<V>, options: AGValueOptions = []) -> (value: V, flags: AGChangedValueFlags)
-  public func changedValue<V>(of input: AttributeGraph.Attribute<V>, options: AGValueOptions = []) -> (value: V, changed: Swift.Bool)
+  public func valueAndFlags<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, flags: AttributeGraph.AGChangedValueFlags)
+  public func changedValue<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, changed: Swift.Bool)
   public func update(body: () -> Swift.Void)
   public static func == (a: AttributeGraph.RuleContext<Value>, b: AttributeGraph.RuleContext<Value>) -> Swift.Bool
 }
 @_silgen_name("AGGraphGetInputValue")
-@inline(__always) @inlinable internal func AGGraphGetInputValue<Value>(_ attribute: AnyAttribute, input: AnyAttribute, options: AGValueOptions = [], type: Value.Type = Value.self) -> AGValue
+@inline(__always) @inlinable internal func AGGraphGetInputValue<Value>(_ attribute: AttributeGraph.AnyAttribute, input: AttributeGraph.AnyAttribute, options: AttributeGraph.AGValueOptions = [], type: Value.Type = Value.self) -> AttributeGraph.AGValue
 @_silgen_name("AGGraphWithUpdate")
-@inline(__always) @inlinable internal func AGGraphWithUpdate(_ attribute: AnyAttribute, body: () -> Swift.Void)
-extension AnyWeakAttribute {
-  public init(_ attribute: AnyAttribute?)
-  public init<Value>(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
-  public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.WeakAttribute<Value>
-  public var attribute: AnyAttribute? {
-    get
-    set
-  }
+@inline(__always) @inlinable internal func AGGraphWithUpdate(_ attribute: AttributeGraph.AnyAttribute, body: () -> Swift.Void)
+extension AttributeGraph.Subgraph {
+  public typealias Flags = AttributeGraph.AnyAttribute.Flags
+  public typealias ChildFlags = AttributeGraph.AnyAttribute.Flags
 }
-extension AnyWeakAttribute : Swift.Hashable {
-  public static func == (lhs: AnyWeakAttribute, rhs: AnyWeakAttribute) -> Swift.Bool
-  public func hash(into hasher: inout Swift.Hasher)
-  public var hashValue: Swift.Int {
-    get
-  }
+extension AttributeGraph.Subgraph {
+  public func addObserver(_ observer: @escaping () -> Swift.Void) -> Swift.Int
+  public func apply<Value>(_ body: () -> Value) -> Value
+  public func forEach(_ flags: AttributeGraph.Subgraph.Flags, _ callback: (AttributeGraph.AnyAttribute) -> Swift.Void)
 }
-extension AnyWeakAttribute : Swift.CustomStringConvertible {
-  @_alwaysEmitIntoClient public var description: Swift.String {
-    get { attribute?.description ?? "nil" }
-  }
+extension AttributeGraph.Subgraph {
+  public static func beginTreeElement<Value>(value: AttributeGraph.Attribute<Value>, flags: Swift.UInt32)
+  public static func addTreeValue<Value>(_ value: AttributeGraph.Attribute<Value>, forKey key: Swift.UnsafePointer<Swift.Int8>, flags: Swift.UInt32)
+  public static func endTreeElement<Value>(value: AttributeGraph.Attribute<Value>)
 }
-@frozen @propertyWrapper @dynamicMemberLookup public struct WeakAttribute<Value> {
-  internal var base: AnyWeakAttribute
-  public init(base: AnyWeakAttribute)
-  public init()
-  public init(_ attribute: AttributeGraph.Attribute<Value>)
-  public init(_ attribute: AttributeGraph.Attribute<Value>?)
-  public var wrappedValue: Value? {
-    get
-  }
-  public var projectedValue: AttributeGraph.Attribute<Value>? {
-    get
-    set
-    _modify
-  }
-  public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
-    get
-  }
-  public var attribute: AttributeGraph.Attribute<Value>? {
-    get
-    set
-  }
-  public var value: Value? {
-    get
-  }
-  public func changedValue(options: AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
+extension AttributeGraph.Graph {
+  public static func typeIndex(ctx: AttributeGraph.GraphContext, body: any AttributeGraph._AttributeBody.Type, valueType: AttributeGraph.Metadata, flags: AttributeGraph._AttributeType.Flags, update: () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void) -> Swift.Int
 }
-extension AttributeGraph.WeakAttribute : Swift.Hashable {
-  public static func == (a: AttributeGraph.WeakAttribute<Value>, b: AttributeGraph.WeakAttribute<Value>) -> Swift.Bool
-  public func hash(into hasher: inout Swift.Hasher)
-  public var hashValue: Swift.Int {
-    get
-  }
-}
-extension AttributeGraph.WeakAttribute : Swift.CustomStringConvertible {
-  public var description: Swift.String {
-    get
-  }
-}
-extension Graph {
-  public static func typeIndex(ctx: GraphContext, body: any AttributeGraph._AttributeBody.Type, valueType: Metadata, flags: _AttributeType.Flags, update: () -> (Swift.UnsafeMutableRawPointer, AnyAttribute) -> Swift.Void) -> Swift.Int
-}
-extension Graph {
+extension AttributeGraph.Graph {
   public static func withoutUpdate<V>(_ body: () -> V) -> V
   public func withoutSubgraphInvalidation<V>(_ body: () -> V) -> V
   public func withDeadline<V>(_: Swift.UInt64, _: () -> V) -> V
-  public func onInvalidation(_ callback: @escaping (AnyAttribute) -> Swift.Void)
+  public func onInvalidation(_ callback: @escaping (AttributeGraph.AnyAttribute) -> Swift.Void)
   public func onUpdate(_ callback: @escaping () -> Swift.Void)
   public func withMainThreadHandler(_: (() -> Swift.Void) -> Swift.Void, do: () -> Swift.Void)
 }
-extension Graph {
+extension AttributeGraph.Graph {
   @_transparent public func startProfiling() {
         __AGGraphStartProfiling(self)
     }
@@ -517,46 +603,31 @@ extension Graph {
   public static func stopProfiling()
   public static func resetProfile()
 }
-extension Graph {
+extension AttributeGraph.Graph {
   @_transparent public var mainUpdates: Swift.Int {
     @_transparent get { numericCast(counter(for: .mainThreadUpdates)) }
   }
 }
-extension Graph {
+extension AttributeGraph.Graph {
+  #if compiler(>=5.3) && $NonescapableTypes
   @_silgen_name("AGGraphGetOutputValue")
   @inline(__always) @inlinable public static func outputValue<Value>() -> Swift.UnsafePointer<Value>?
+  #endif
   @_silgen_name("AGGraphSetOutputValue")
   @inline(__always) @inlinable public static func setOutputValue<Value>(_ value: Swift.UnsafePointer<Value>)
 }
-extension Graph {
-  @_transparent public static func anyInputsChanged(excluding excludedInputs: [AnyAttribute]) -> Swift.Bool {
+extension AttributeGraph.Graph {
+  @_transparent public static func anyInputsChanged(excluding excludedInputs: [AttributeGraph.AnyAttribute]) -> Swift.Bool {
         return __AGGraphAnyInputsChanged(excludedInputs, excludedInputs.count)
     }
 }
-extension Graph {
+extension AttributeGraph.Graph {
+  #if compiler(>=5.3) && $NonescapableTypes
   public func archiveJSON(name: Swift.String?)
-}
-extension Subgraph {
-  public typealias Flags = AnyAttribute.Flags
-  public typealias ChildFlags = AnyAttribute.Flags
-}
-extension Subgraph {
-  public func addObserver(_ observer: @escaping () -> Swift.Void) -> Swift.Int
-  public func apply<Value>(_ body: () -> Value) -> Value
-  public func forEach(_ flags: Subgraph.Flags, _ callback: (AnyAttribute) -> Swift.Void)
-}
-extension Subgraph {
-  public static func beginTreeElement<Value>(value: AttributeGraph.Attribute<Value>, flags: Swift.UInt32)
-  public static func addTreeValue<Value>(_ value: AttributeGraph.Attribute<Value>, forKey key: Swift.UnsafePointer<Swift.Int8>, flags: Swift.UInt32)
-  public static func endTreeElement<Value>(value: AttributeGraph.Attribute<Value>)
-}
-public func compareValues<Value>(_ lhs: Value, _ rhs: Value, mode: ComparisonMode = .equatableAlways) -> Swift.Bool
-public func compareValues<Value>(_ lhs: Value, _ rhs: Value, options: ComparisonOptions) -> Swift.Bool
-extension ComparisonOptions {
-  public init(mode: ComparisonMode)
+  #endif
 }
 public func forEachField(of type: any Any.Type, do body: (Swift.UnsafePointer<Swift.Int8>, Swift.Int, any Any.Type) -> Swift.Void)
-extension Metadata : Swift.Hashable, Swift.CustomStringConvertible {
+extension AttributeGraph.Metadata : Swift.Hashable, Swift.CustomStringConvertible {
   public init(_ type: any Any.Type)
   public var type: any Any.Type {
     get
@@ -564,16 +635,12 @@ extension Metadata : Swift.Hashable, Swift.CustomStringConvertible {
   public var description: Swift.String {
     get
   }
-  public func forEachField(options: Metadata.ApplyOptions, do body: (Swift.UnsafePointer<Swift.Int8>, Swift.Int, any Any.Type) -> Swift.Bool) -> Swift.Bool
+  public func forEachField(options: AttributeGraph.Metadata.ApplyOptions, do body: (Swift.UnsafePointer<Swift.Int8>, Swift.Int, any Any.Type) -> Swift.Bool) -> Swift.Bool
 }
-extension Signature : Swift.Equatable {
-  public static func == (lhs: Signature, rhs: Signature) -> Swift.Bool
+extension AttributeGraph.Signature : Swift.Equatable {
+  public static func == (lhs: AttributeGraph.Signature, rhs: AttributeGraph.Signature) -> Swift.Bool
 }
-@discardableResult
-public func withUnsafePointerToEnumCase<T>(of value: Swift.UnsafeMutablePointer<T>, do body: (Swift.Int, any Any.Type, Swift.UnsafeRawPointer) -> ()) -> Swift.Bool
-@discardableResult
-public func withUnsafeMutablePointerToEnumCase<T>(of value: Swift.UnsafeMutablePointer<T>, do body: (Swift.Int, any Any.Type, Swift.UnsafeMutableRawPointer) -> ()) -> Swift.Bool
-extension TupleType {
+extension AttributeGraph.TupleType {
   @_transparent public init(_ types: [any Any.Type]) {
         self.init(count: types.count, elements: types.map(Metadata.init))
     }
@@ -597,16 +664,16 @@ extension TupleType {
   @_transparent public func offset<T>(at index: Swift.Int, as type: T.Type) -> Swift.Int {
         elementOffset(at: index, type: Metadata(type))
     }
-  @_transparent public func setElement<T>(in tupleValue: Swift.UnsafeMutableRawPointer, at index: Swift.Int, from srcValue: Swift.UnsafePointer<T>, options: TupleType.CopyOptions) {
+  @_transparent public func setElement<T>(in tupleValue: Swift.UnsafeMutableRawPointer, at index: Swift.Int, from srcValue: Swift.UnsafePointer<T>, options: AttributeGraph.TupleType.CopyOptions) {
         __AGTupleSetElement(self, tupleValue, index, srcValue, Metadata(T.self), options)
     }
-  @_transparent public func getElement<T>(in tupleValue: Swift.UnsafeMutableRawPointer, at index: Swift.Int, to dstValue: Swift.UnsafeMutablePointer<T>, options: TupleType.CopyOptions) {
+  @_transparent public func getElement<T>(in tupleValue: Swift.UnsafeMutableRawPointer, at index: Swift.Int, to dstValue: Swift.UnsafeMutablePointer<T>, options: AttributeGraph.TupleType.CopyOptions) {
         __AGTupleGetElement(self, tupleValue, index, dstValue, Metadata(T.self), options)
     }
 }
 @_silgen_name("AGTupleWithBuffer")
-public func withUnsafeTuple(of type: TupleType, count: Swift.Int, _ body: (UnsafeMutableTuple) -> Swift.Void)
-extension UnsafeTuple {
+public func withUnsafeTuple(of type: AttributeGraph.TupleType, count: Swift.Int, _ body: (AttributeGraph.UnsafeMutableTuple) -> Swift.Void)
+extension AttributeGraph.UnsafeTuple {
   @_transparent public var count: Swift.Int {
     @_transparent get { type.count }
   }
@@ -633,8 +700,8 @@ extension UnsafeTuple {
     @_transparent unsafeAddress { address(of: index, as: T.self) }
   }
 }
-extension UnsafeMutableTuple {
-  @_transparent public init(with tupleType: TupleType) {
+extension AttributeGraph.UnsafeMutableTuple {
+  @_transparent public init(with tupleType: AttributeGraph.TupleType) {
         self.init(
             type: tupleType,
             value: UnsafeMutableRawPointer.allocate(
@@ -688,21 +755,30 @@ extension UnsafeMutableTuple {
     @_transparent nonmutating unsafeMutableAddress { address(of: index, as: T.self) }
   }
 }
-extension AttributeGraph.Attribute : Swift.Sendable {}
-extension AttributeGraph.Attribute : Swift.BitwiseCopyable {}
-extension AttributeGraph.External : Swift.Sendable {}
-extension AttributeGraph.External : Swift.BitwiseCopyable {}
+@discardableResult
+public func withUnsafePointerToEnumCase<T>(of value: Swift.UnsafeMutablePointer<T>, do body: (Swift.Int, any Any.Type, Swift.UnsafeRawPointer) -> ()) -> Swift.Bool
+@discardableResult
+public func withUnsafeMutablePointerToEnumCase<T>(of value: Swift.UnsafeMutablePointer<T>, do body: (Swift.Int, any Any.Type, Swift.UnsafeMutableRawPointer) -> ()) -> Swift.Bool
+public func compareValues<Value>(_ lhs: Value, _ rhs: Value, mode: AttributeGraph.ComparisonMode = .equatableAlways) -> Swift.Bool
+public func compareValues<Value>(_ lhs: Value, _ rhs: Value, options: AttributeGraph.ComparisonOptions) -> Swift.Bool
+extension AttributeGraph.ComparisonOptions {
+  public init(mode: AttributeGraph.ComparisonMode)
+}
 extension AttributeGraph.PointerOffset : Swift.Sendable {}
 extension AttributeGraph.PointerOffset : Swift.BitwiseCopyable {}
-extension AttributeGraph.IndirectAttribute : Swift.Sendable {}
-extension AttributeGraph.IndirectAttribute : Swift.BitwiseCopyable {}
-extension AttributeGraph.AnyOptionalAttribute : Swift.Sendable {}
-extension AttributeGraph.AnyOptionalAttribute : Swift.BitwiseCopyable {}
+extension AttributeGraph.External : Swift.Sendable {}
+extension AttributeGraph.External : Swift.BitwiseCopyable {}
+extension AttributeGraph.Attribute : Swift.Sendable {}
+extension AttributeGraph.Attribute : Swift.BitwiseCopyable {}
+extension AttributeGraph.WeakAttribute : Swift.Sendable {}
+extension AttributeGraph.WeakAttribute : Swift.BitwiseCopyable {}
 extension AttributeGraph.OptionalAttribute : Swift.Sendable {}
 extension AttributeGraph.OptionalAttribute : Swift.BitwiseCopyable {}
+extension AttributeGraph.AnyOptionalAttribute : Swift.Sendable {}
+extension AttributeGraph.AnyOptionalAttribute : Swift.BitwiseCopyable {}
+extension AttributeGraph.IndirectAttribute : Swift.Sendable {}
+extension AttributeGraph.IndirectAttribute : Swift.BitwiseCopyable {}
 extension AttributeGraph.AnyRuleContext : Swift.Sendable {}
 extension AttributeGraph.AnyRuleContext : Swift.BitwiseCopyable {}
 extension AttributeGraph.RuleContext : Swift.Sendable {}
 extension AttributeGraph.RuleContext : Swift.BitwiseCopyable {}
-extension AttributeGraph.WeakAttribute : Swift.Sendable {}
-extension AttributeGraph.WeakAttribute : Swift.BitwiseCopyable {}

--- a/AG/2024/AttributeGraph.xcframework/macos-arm64e-arm64-x86_64/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/x86_64-apple-macos.swiftinterface
+++ b/AG/2024/AttributeGraph.xcframework/macos-arm64e-arm64-x86_64/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/x86_64-apple-macos.swiftinterface
@@ -10,11 +10,9 @@ public import _SwiftConcurrencyShims
 extension AttributeGraph.AnyAttribute {
   public init<Value>(_ attribute: AttributeGraph.Attribute<Value>)
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.Attribute<Value>
-  #if compiler(>=5.3) && $NonescapableTypes
   public static var current: AttributeGraph.AnyAttribute? {
     get
   }
-  #endif
   public func unsafeOffset(at offset: Swift.Int) -> AttributeGraph.AnyAttribute
   public func setFlags(_ newFlags: AttributeGraph.AnyAttribute.Flags, mask: AttributeGraph.AnyAttribute.Flags)
   public func addInput(_ attribute: AttributeGraph.AnyAttribute, options: AttributeGraph.AGInputOptions = [], token: Swift.Int)
@@ -31,12 +29,10 @@ extension AttributeGraph.AnyAttribute {
   public var valueType: any Any.Type {
     get
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public var indirectDependency: AttributeGraph.AnyAttribute? {
     get
     nonmutating set
   }
-  #endif
 }
 extension AttributeGraph.AnyAttribute : Swift.CustomStringConvertible {
   @inlinable public var description: Swift.String {
@@ -95,9 +91,7 @@ extension AttributeGraph.External : Swift.CustomStringConvertible {
   public init(_ attribute: AttributeGraph.Attribute<Value>)
   public init(value: Value)
   public init(type _: Value.Type)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init<Body>(body: Swift.UnsafePointer<Body>, value: Swift.UnsafePointer<Value>?, flags: AttributeGraph._AttributeType.Flags = [], update: () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void) where Body : AttributeGraph._AttributeBody
-  #endif
   public var wrappedValue: Value {
     unsafeAddress
     nonmutating set
@@ -169,10 +163,8 @@ extension AttributeGraph.Attribute {
   public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.Rule
   public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.StatefulRule
 }
-#if compiler(>=5.3) && $NonescapableTypes
 @_silgen_name("AGGraphCreateAttribute")
 @inline(__always) @inlinable internal func AGGraphCreateAttribute(index: Swift.Int, body: Swift.UnsafeRawPointer, value: Swift.UnsafeRawPointer?) -> AttributeGraph.AnyAttribute
-#endif
 @_silgen_name("AGGraphGetValue")
 @inline(__always) @inlinable internal func AGGraphGetValue<Value>(_ attribute: AttributeGraph.AnyAttribute, options: AttributeGraph.AGValueOptions = [], type: Value.Type = Value.self) -> AttributeGraph.AGValue
 @_silgen_name("AGGraphSetValue")
@@ -215,40 +207,26 @@ extension AttributeGraph._AttributeBody {
   public init(base: AttributeGraph.AnyWeakAttribute)
   public init()
   public init(_ attribute: AttributeGraph.Attribute<Value>)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.Attribute<Value>?)
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var wrappedValue: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var projectedValue: AttributeGraph.Attribute<Value>? {
     get
     set
     _modify
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.Attribute<Value>? {
     get
     set
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var value: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
-  #endif
 }
 extension AttributeGraph.WeakAttribute : Swift.Hashable {
   public static func == (a: AttributeGraph.WeakAttribute<Value>, b: AttributeGraph.WeakAttribute<Value>) -> Swift.Bool
@@ -263,17 +241,13 @@ extension AttributeGraph.WeakAttribute : Swift.CustomStringConvertible {
   }
 }
 extension AttributeGraph.AnyWeakAttribute {
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.AnyAttribute?)
-  #endif
   public init<Value>(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.WeakAttribute<Value>
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.AnyAttribute? {
     get
     set
   }
-  #endif
 }
 extension AttributeGraph.AnyWeakAttribute : Swift.Hashable {
   public static func == (lhs: AttributeGraph.AnyWeakAttribute, rhs: AttributeGraph.AnyWeakAttribute) -> Swift.Bool
@@ -289,17 +263,13 @@ extension AttributeGraph.AnyWeakAttribute : Swift.CustomStringConvertible {
 }
 public protocol Rule : AttributeGraph._AttributeBody {
   associatedtype Value
-  #if compiler(>=5.3) && $NonescapableTypes
   static var initialValue: Self.Value? { get }
-  #endif
   var value: Self.Value { get }
 }
 extension AttributeGraph.Rule {
-  #if compiler(>=5.3) && $NonescapableTypes
   public static var initialValue: Self.Value? {
     get
   }
-  #endif
   public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AttributeGraph.AnyAttribute)
   public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
 }
@@ -312,15 +282,9 @@ extension AttributeGraph.Rule {
   }
 }
 extension AttributeGraph.Rule where Self : Swift.Hashable {
-  #if compiler(>=5.3) && $NonescapableTypes
   public func cachedValue(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?) -> Self.Value
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func cachedValueIfExists(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?) -> Self.Value?
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public static func _cachedValue(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?, hashValue: Swift.Int, bodyPtr: Swift.UnsafeRawPointer, update: () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void) -> Swift.UnsafePointer<Self.Value>
-  #endif
 }
 @frozen public struct Map<Source, Value> : AttributeGraph.Rule, Swift.CustomStringConvertible {
   public var arg: AttributeGraph.Attribute<Source>
@@ -338,17 +302,13 @@ extension AttributeGraph.Rule where Self : Swift.Hashable {
 }
 public protocol StatefulRule : AttributeGraph._AttributeBody {
   associatedtype Value
-  #if compiler(>=5.3) && $NonescapableTypes
   static var initialValue: Self.Value? { get }
-  #endif
   mutating func updateValue()
 }
 extension AttributeGraph.StatefulRule {
-  #if compiler(>=5.3) && $NonescapableTypes
   public static var initialValue: Self.Value? {
     get
   }
-  #endif
   public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AttributeGraph.AnyAttribute)
   public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
 }
@@ -386,44 +346,28 @@ extension AttributeGraph.StatefulRule {
   public init()
   public init(base: AttributeGraph.AnyOptionalAttribute)
   public init(_ attribute: AttributeGraph.Attribute<Value>)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.Attribute<Value>?)
-  #endif
   public init(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.Attribute<Value>? {
     get
     set
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var value: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func map<V>(_ body: (AttributeGraph.Attribute<Value>) -> V) -> V?
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var wrappedValue: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var projectedValue: AttributeGraph.Attribute<Value>? {
     get
     set
     _modify
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
     get
   }
-  #endif
 }
 extension AttributeGraph.OptionalAttribute : Swift.Hashable {
   public static func == (a: AttributeGraph.OptionalAttribute<Value>, b: AttributeGraph.OptionalAttribute<Value>) -> Swift.Bool
@@ -441,22 +385,16 @@ extension AttributeGraph.OptionalAttribute : Swift.CustomStringConvertible {
   public var identifier: AttributeGraph.AnyAttribute
   public init()
   public init(_ attribute: AttributeGraph.AnyAttribute)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.AnyAttribute?)
-  #endif
   public init<Value>(_ attribute: AttributeGraph.OptionalAttribute<Value>)
   public static var current: AttributeGraph.AnyOptionalAttribute {
     get
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.AnyAttribute? {
     get
     set
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func map<Value>(_ body: (AttributeGraph.AnyAttribute) -> Value) -> Value?
-  #endif
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.OptionalAttribute<Value>
 }
 extension AttributeGraph.AnyOptionalAttribute : Swift.Hashable {
@@ -478,12 +416,10 @@ extension AttributeGraph.AnyOptionalAttribute : Swift.CustomStringConvertible {
     get
     nonmutating set
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public var dependency: AttributeGraph.AnyAttribute? {
     get
     nonmutating set
   }
-  #endif
   public var value: Value {
     get
     nonmutating set
@@ -516,16 +452,12 @@ extension AttributeGraph.IndirectAttribute : Swift.Hashable {
   public subscript<V>(attribute: AttributeGraph.Attribute<V>) -> V {
     unsafeAddress
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(weakAttribute: AttributeGraph.WeakAttribute<V>) -> V? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(optionalAttribute: AttributeGraph.OptionalAttribute<V>) -> V? {
     get
   }
-  #endif
   public func valueAndFlags<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, flags: AttributeGraph.AGChangedValueFlags)
   public func changedValue<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, changed: Swift.Bool)
   public func update(body: () -> Swift.Void)
@@ -538,16 +470,12 @@ extension AttributeGraph.IndirectAttribute : Swift.Hashable {
   public subscript<V>(attribute: AttributeGraph.Attribute<V>) -> V {
     unsafeAddress
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(weakAttribute: AttributeGraph.WeakAttribute<V>) -> V? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(optionalAttribute: AttributeGraph.OptionalAttribute<V>) -> V? {
     get
   }
-  #endif
   public var value: Value {
     unsafeAddress
     nonmutating set
@@ -609,10 +537,8 @@ extension AttributeGraph.Graph {
   }
 }
 extension AttributeGraph.Graph {
-  #if compiler(>=5.3) && $NonescapableTypes
   @_silgen_name("AGGraphGetOutputValue")
   @inline(__always) @inlinable public static func outputValue<Value>() -> Swift.UnsafePointer<Value>?
-  #endif
   @_silgen_name("AGGraphSetOutputValue")
   @inline(__always) @inlinable public static func setOutputValue<Value>(_ value: Swift.UnsafePointer<Value>)
 }
@@ -622,9 +548,7 @@ extension AttributeGraph.Graph {
     }
 }
 extension AttributeGraph.Graph {
-  #if compiler(>=5.3) && $NonescapableTypes
   public func archiveJSON(name: Swift.String?)
-  #endif
 }
 public func forEachField(of type: any Any.Type, do body: (Swift.UnsafePointer<Swift.Int8>, Swift.Int, any Any.Type) -> Swift.Void)
 extension AttributeGraph.Metadata : Swift.Hashable, Swift.CustomStringConvertible {

--- a/AG/2024/AttributeGraph.xcframework/xros-arm64-x86_64-simulator/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/arm64-apple-xros-simulator.swiftinterface
+++ b/AG/2024/AttributeGraph.xcframework/xros-arm64-x86_64-simulator/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/arm64-apple-xros-simulator.swiftinterface
@@ -7,19 +7,21 @@ public import Swift
 public import _Concurrency
 public import _StringProcessing
 public import _SwiftConcurrencyShims
-extension AnyAttribute {
+extension AttributeGraph.AnyAttribute {
   public init<Value>(_ attribute: AttributeGraph.Attribute<Value>)
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.Attribute<Value>
-  public static var current: AnyAttribute? {
+  #if compiler(>=5.3) && $NonescapableTypes
+  public static var current: AttributeGraph.AnyAttribute? {
     get
   }
-  public func unsafeOffset(at offset: Swift.Int) -> AnyAttribute
-  public func setFlags(_ newFlags: AnyAttribute.Flags, mask: AnyAttribute.Flags)
-  public func addInput(_ attribute: AnyAttribute, options: AGInputOptions = [], token: Swift.Int)
-  public func addInput<Value>(_ attribute: AttributeGraph.Attribute<Value>, options: AGInputOptions = [], token: Swift.Int)
+  #endif
+  public func unsafeOffset(at offset: Swift.Int) -> AttributeGraph.AnyAttribute
+  public func setFlags(_ newFlags: AttributeGraph.AnyAttribute.Flags, mask: AttributeGraph.AnyAttribute.Flags)
+  public func addInput(_ attribute: AttributeGraph.AnyAttribute, options: AttributeGraph.AGInputOptions = [], token: Swift.Int)
+  public func addInput<Value>(_ attribute: AttributeGraph.Attribute<Value>, options: AttributeGraph.AGInputOptions = [], token: Swift.Int)
   public func visitBody<Body>(_ visitor: inout Body) where Body : AttributeGraph.AttributeBodyVisitor
   public func mutateBody<Value>(as type: Value.Type, invalidating: Swift.Bool, _ body: (inout Value) -> Swift.Void)
-  public func breadthFirstSearch(options _: SearchOptions = [], _: (AnyAttribute) -> Swift.Bool) -> Swift.Bool
+  public func breadthFirstSearch(options _: AttributeGraph.SearchOptions = [], _: (AttributeGraph.AnyAttribute) -> Swift.Bool) -> Swift.Bool
   public var _bodyType: any Any.Type {
     get
   }
@@ -29,118 +31,19 @@ extension AnyAttribute {
   public var valueType: any Any.Type {
     get
   }
-  public var indirectDependency: AnyAttribute? {
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var indirectDependency: AttributeGraph.AnyAttribute? {
     get
     nonmutating set
   }
+  #endif
 }
-extension AnyAttribute : Swift.CustomStringConvertible {
+extension AttributeGraph.AnyAttribute : Swift.CustomStringConvertible {
   @inlinable public var description: Swift.String {
     get { "#\(rawValue)" }
   }
 }
-public typealias AttributeUpdateBlock = () -> (Swift.UnsafeMutableRawPointer, AnyAttribute) -> Swift.Void
-@frozen @propertyWrapper @dynamicMemberLookup public struct Attribute<Value> {
-  public var identifier: AnyAttribute
-  public init(identifier: AnyAttribute)
-  public init(_ attribute: AttributeGraph.Attribute<Value>)
-  public init(value: Value)
-  public init(type _: Value.Type)
-  public init<Body>(body: Swift.UnsafePointer<Body>, value: Swift.UnsafePointer<Value>?, flags: _AttributeType.Flags = [], update: () -> (Swift.UnsafeMutableRawPointer, AnyAttribute) -> Swift.Void) where Body : AttributeGraph._AttributeBody
-  public var wrappedValue: Value {
-    unsafeAddress
-    nonmutating set
-  }
-  public var projectedValue: AttributeGraph.Attribute<Value> {
-    get
-    set
-  }
-  public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member> {
-    get
-  }
-  public subscript<Member>(keyPath keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member> {
-    get
-  }
-  public subscript<Member>(offset body: (inout Value) -> AttributeGraph.PointerOffset<Value, Member>) -> AttributeGraph.Attribute<Member> {
-    get
-  }
-  public func unsafeCast<V>(to type: V.Type) -> AttributeGraph.Attribute<V>
-  public func unsafeOffset<Member>(at offset: Swift.Int, as _: Member.Type) -> AttributeGraph.Attribute<Member>
-  public func applying<Member>(offset: AttributeGraph.PointerOffset<Value, Member>) -> AttributeGraph.Attribute<Member>
-  public func visitBody<Body>(_ visitor: inout Body) where Body : AttributeGraph.AttributeBodyVisitor
-  public func mutateBody<V>(as type: V.Type, invalidating: Swift.Bool, _ body: (inout V) -> Swift.Void)
-  public func breadthFirstSearch(options: SearchOptions = [], _ body: (AnyAttribute) -> Swift.Bool) -> Swift.Bool
-  public var graph: Graph {
-    get
-  }
-  public var subgraph: Subgraph {
-    get
-  }
-  public var value: Value {
-    unsafeAddress
-    nonmutating set
-  }
-  public var valueState: ValueState {
-    get
-  }
-  public func valueAndFlags(options: AGValueOptions = []) -> (value: Value, flags: AGChangedValueFlags)
-  public func changedValue(options: AGValueOptions = []) -> (value: Value, changed: Swift.Bool)
-  public func setValue(_ value: Value) -> Swift.Bool
-  public var hasValue: Swift.Bool {
-    get
-  }
-  public func updateValue()
-  public func prefetchValue()
-  public func invalidateValue()
-  public func validate()
-  public func addInput(_ attribute: AnyAttribute, options: AGInputOptions = [], token: Swift.Int)
-  public func addInput<V>(_ attribute: AttributeGraph.Attribute<V>, options: AGInputOptions = [], token: Swift.Int)
-  public typealias Flags = AnyAttribute.Flags
-  public var flags: AttributeGraph.Attribute<Value>.Flags {
-    get
-    nonmutating set
-  }
-  public func setFlags(_ newFlags: AttributeGraph.Attribute<Value>.Flags, mask: AttributeGraph.Attribute<Value>.Flags)
-}
-extension AttributeGraph.Attribute : Swift.Hashable {
-  public static func == (a: AttributeGraph.Attribute<Value>, b: AttributeGraph.Attribute<Value>) -> Swift.Bool
-  public func hash(into hasher: inout Swift.Hasher)
-  public var hashValue: Swift.Int {
-    get
-  }
-}
-extension AttributeGraph.Attribute : Swift.CustomStringConvertible {
-  public var description: Swift.String {
-    get
-  }
-}
-extension AttributeGraph.Attribute {
-  public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.Rule
-  public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.StatefulRule
-}
-@_silgen_name("AGGraphCreateAttribute")
-@inline(__always) @inlinable internal func AGGraphCreateAttribute(index: Swift.Int, body: Swift.UnsafeRawPointer, value: Swift.UnsafeRawPointer?) -> AnyAttribute
-@_silgen_name("AGGraphGetValue")
-@inline(__always) @inlinable internal func AGGraphGetValue<Value>(_ attribute: AnyAttribute, options: AGValueOptions = [], type: Value.Type = Value.self) -> AGValue
-@_silgen_name("AGGraphSetValue")
-@inline(__always) @inlinable internal func AGGraphSetValue<Value>(_ attribute: AnyAttribute, valuePointer: Swift.UnsafePointer<Value>) -> Swift.Bool
-@frozen public struct External<Value> {
-  public init()
-}
-extension AttributeGraph.External : AttributeGraph._AttributeBody {
-  public static var comparisonMode: ComparisonMode {
-    get
-  }
-  public static var flags: AttributeGraph.External<Value>.Flags {
-    get
-  }
-  public static func _update(_: Swift.UnsafeMutableRawPointer, attribute _: AnyAttribute)
-}
-extension AttributeGraph.External : Swift.CustomStringConvertible {
-  public var description: Swift.String {
-    get
-  }
-}
+public typealias AttributeUpdateBlock = () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void
 @frozen public struct PointerOffset<Base, Member> {
   public var byteOffset: Swift.Int
   public init(byteOffset: Swift.Int)
@@ -169,27 +72,111 @@ extension Swift.UnsafeMutablePointer {
   }
   public static func + <Member>(lhs: Swift.UnsafeMutablePointer<Pointee>, rhs: AttributeGraph.PointerOffset<Pointee, Member>) -> Swift.UnsafeMutablePointer<Member>
 }
-public protocol _AttributeBody {
-  static func _destroySelf(_ pointer: Swift.UnsafeMutableRawPointer)
-  static var _hasDestroySelf: Swift.Bool { get }
-  static func _updateDefault(_ pointer: Swift.UnsafeMutableRawPointer)
-  static var comparisonMode: ComparisonMode { get }
-  typealias Flags = _AttributeType.Flags
-  static var flags: Self.Flags { get }
+@frozen public struct External<Value> {
+  public init()
 }
-extension AttributeGraph._AttributeBody {
-  public static func _destroySelf(_ pointer: Swift.UnsafeMutableRawPointer)
-  public static var _hasDestroySelf: Swift.Bool {
+extension AttributeGraph.External : AttributeGraph._AttributeBody {
+  public static var comparisonMode: AttributeGraph.ComparisonMode {
     get
   }
-  public static func _updateDefault(_ pointer: Swift.UnsafeMutableRawPointer)
-  public static var comparisonMode: ComparisonMode {
+  public static var flags: AttributeGraph.External<Value>.Flags {
     get
   }
-  public static var flags: Self.Flags {
+  public static func _update(_: Swift.UnsafeMutableRawPointer, attribute _: AttributeGraph.AnyAttribute)
+}
+extension AttributeGraph.External : Swift.CustomStringConvertible {
+  public var description: Swift.String {
     get
   }
 }
+@frozen @propertyWrapper @dynamicMemberLookup public struct Attribute<Value> {
+  public var identifier: AttributeGraph.AnyAttribute
+  public init(identifier: AttributeGraph.AnyAttribute)
+  public init(_ attribute: AttributeGraph.Attribute<Value>)
+  public init(value: Value)
+  public init(type _: Value.Type)
+  #if compiler(>=5.3) && $NonescapableTypes
+  public init<Body>(body: Swift.UnsafePointer<Body>, value: Swift.UnsafePointer<Value>?, flags: AttributeGraph._AttributeType.Flags = [], update: () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void) where Body : AttributeGraph._AttributeBody
+  #endif
+  public var wrappedValue: Value {
+    unsafeAddress
+    nonmutating set
+  }
+  public var projectedValue: AttributeGraph.Attribute<Value> {
+    get
+    set
+  }
+  public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member> {
+    get
+  }
+  public subscript<Member>(keyPath keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member> {
+    get
+  }
+  public subscript<Member>(offset body: (inout Value) -> AttributeGraph.PointerOffset<Value, Member>) -> AttributeGraph.Attribute<Member> {
+    get
+  }
+  public func unsafeCast<V>(to type: V.Type) -> AttributeGraph.Attribute<V>
+  public func unsafeOffset<Member>(at offset: Swift.Int, as _: Member.Type) -> AttributeGraph.Attribute<Member>
+  public func applying<Member>(offset: AttributeGraph.PointerOffset<Value, Member>) -> AttributeGraph.Attribute<Member>
+  public func visitBody<Body>(_ visitor: inout Body) where Body : AttributeGraph.AttributeBodyVisitor
+  public func mutateBody<V>(as type: V.Type, invalidating: Swift.Bool, _ body: (inout V) -> Swift.Void)
+  public func breadthFirstSearch(options: AttributeGraph.SearchOptions = [], _ body: (AttributeGraph.AnyAttribute) -> Swift.Bool) -> Swift.Bool
+  public var graph: AttributeGraph.Graph {
+    get
+  }
+  public var subgraph: AttributeGraph.Subgraph {
+    get
+  }
+  public var value: Value {
+    unsafeAddress
+    nonmutating set
+  }
+  public var valueState: AttributeGraph.ValueState {
+    get
+  }
+  public func valueAndFlags(options: AttributeGraph.AGValueOptions = []) -> (value: Value, flags: AttributeGraph.AGChangedValueFlags)
+  public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)
+  public func setValue(_ value: Value) -> Swift.Bool
+  public var hasValue: Swift.Bool {
+    get
+  }
+  public func updateValue()
+  public func prefetchValue()
+  public func invalidateValue()
+  public func validate()
+  public func addInput(_ attribute: AttributeGraph.AnyAttribute, options: AttributeGraph.AGInputOptions = [], token: Swift.Int)
+  public func addInput<V>(_ attribute: AttributeGraph.Attribute<V>, options: AttributeGraph.AGInputOptions = [], token: Swift.Int)
+  public typealias Flags = AttributeGraph.AnyAttribute.Flags
+  public var flags: AttributeGraph.Attribute<Value>.Flags {
+    get
+    nonmutating set
+  }
+  public func setFlags(_ newFlags: AttributeGraph.Attribute<Value>.Flags, mask: AttributeGraph.Attribute<Value>.Flags)
+}
+extension AttributeGraph.Attribute : Swift.Hashable {
+  public static func == (a: AttributeGraph.Attribute<Value>, b: AttributeGraph.Attribute<Value>) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+extension AttributeGraph.Attribute : Swift.CustomStringConvertible {
+  public var description: Swift.String {
+    get
+  }
+}
+extension AttributeGraph.Attribute {
+  public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.Rule
+  public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.StatefulRule
+}
+#if compiler(>=5.3) && $NonescapableTypes
+@_silgen_name("AGGraphCreateAttribute")
+@inline(__always) @inlinable internal func AGGraphCreateAttribute(index: Swift.Int, body: Swift.UnsafeRawPointer, value: Swift.UnsafeRawPointer?) -> AttributeGraph.AnyAttribute
+#endif
+@_silgen_name("AGGraphGetValue")
+@inline(__always) @inlinable internal func AGGraphGetValue<Value>(_ attribute: AttributeGraph.AnyAttribute, options: AttributeGraph.AGValueOptions = [], type: Value.Type = Value.self) -> AttributeGraph.AGValue
+@_silgen_name("AGGraphSetValue")
+@inline(__always) @inlinable internal func AGGraphSetValue<Value>(_ attribute: AttributeGraph.AnyAttribute, valuePointer: Swift.UnsafePointer<Value>) -> Swift.Bool
 public protocol AttributeBodyVisitor {
   func visit<Body>(body: Swift.UnsafePointer<Body>) where Body : AttributeGraph._AttributeBody
 }
@@ -202,23 +189,307 @@ extension AttributeGraph.ObservedAttribute {
     get
   }
 }
+public protocol _AttributeBody {
+  static func _destroySelf(_ pointer: Swift.UnsafeMutableRawPointer)
+  static var _hasDestroySelf: Swift.Bool { get }
+  static func _updateDefault(_ pointer: Swift.UnsafeMutableRawPointer)
+  static var comparisonMode: AttributeGraph.ComparisonMode { get }
+  typealias Flags = AttributeGraph._AttributeType.Flags
+  static var flags: Self.Flags { get }
+}
+extension AttributeGraph._AttributeBody {
+  public static func _destroySelf(_ pointer: Swift.UnsafeMutableRawPointer)
+  public static var _hasDestroySelf: Swift.Bool {
+    get
+  }
+  public static func _updateDefault(_ pointer: Swift.UnsafeMutableRawPointer)
+  public static var comparisonMode: AttributeGraph.ComparisonMode {
+    get
+  }
+  public static var flags: Self.Flags {
+    get
+  }
+}
+@frozen @propertyWrapper @dynamicMemberLookup public struct WeakAttribute<Value> {
+  internal var base: AttributeGraph.AnyWeakAttribute
+  public init(base: AttributeGraph.AnyWeakAttribute)
+  public init()
+  public init(_ attribute: AttributeGraph.Attribute<Value>)
+  #if compiler(>=5.3) && $NonescapableTypes
+  public init(_ attribute: AttributeGraph.Attribute<Value>?)
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var wrappedValue: Value? {
+    get
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var projectedValue: AttributeGraph.Attribute<Value>? {
+    get
+    set
+    _modify
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
+    get
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var attribute: AttributeGraph.Attribute<Value>? {
+    get
+    set
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var value: Value? {
+    get
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
+  #endif
+}
+extension AttributeGraph.WeakAttribute : Swift.Hashable {
+  public static func == (a: AttributeGraph.WeakAttribute<Value>, b: AttributeGraph.WeakAttribute<Value>) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+extension AttributeGraph.WeakAttribute : Swift.CustomStringConvertible {
+  public var description: Swift.String {
+    get
+  }
+}
+extension AttributeGraph.AnyWeakAttribute {
+  #if compiler(>=5.3) && $NonescapableTypes
+  public init(_ attribute: AttributeGraph.AnyAttribute?)
+  #endif
+  public init<Value>(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
+  public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.WeakAttribute<Value>
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var attribute: AttributeGraph.AnyAttribute? {
+    get
+    set
+  }
+  #endif
+}
+extension AttributeGraph.AnyWeakAttribute : Swift.Hashable {
+  public static func == (lhs: AttributeGraph.AnyWeakAttribute, rhs: AttributeGraph.AnyWeakAttribute) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+extension AttributeGraph.AnyWeakAttribute : Swift.CustomStringConvertible {
+  @_alwaysEmitIntoClient public var description: Swift.String {
+    get { attribute?.description ?? "nil" }
+  }
+}
+public protocol Rule : AttributeGraph._AttributeBody {
+  associatedtype Value
+  #if compiler(>=5.3) && $NonescapableTypes
+  static var initialValue: Self.Value? { get }
+  #endif
+  var value: Self.Value { get }
+}
+extension AttributeGraph.Rule {
+  #if compiler(>=5.3) && $NonescapableTypes
+  public static var initialValue: Self.Value? {
+    get
+  }
+  #endif
+  public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AttributeGraph.AnyAttribute)
+  public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
+}
+extension AttributeGraph.Rule {
+  public var attribute: AttributeGraph.Attribute<Self.Value> {
+    get
+  }
+  public var context: AttributeGraph.RuleContext<Self.Value> {
+    get
+  }
+}
+extension AttributeGraph.Rule where Self : Swift.Hashable {
+  #if compiler(>=5.3) && $NonescapableTypes
+  public func cachedValue(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?) -> Self.Value
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public func cachedValueIfExists(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?) -> Self.Value?
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public static func _cachedValue(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?, hashValue: Swift.Int, bodyPtr: Swift.UnsafeRawPointer, update: () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void) -> Swift.UnsafePointer<Self.Value>
+  #endif
+}
+@frozen public struct Map<Source, Value> : AttributeGraph.Rule, Swift.CustomStringConvertible {
+  public var arg: AttributeGraph.Attribute<Source>
+  public let body: (Source) -> Value
+  public init(_ arg: AttributeGraph.Attribute<Source>, _ body: @escaping (Source) -> Value)
+  public var value: Value {
+    get
+  }
+  public static var flags: AttributeGraph.Map<Source, Value>.Flags {
+    get
+  }
+  public var description: Swift.String {
+    get
+  }
+}
+public protocol StatefulRule : AttributeGraph._AttributeBody {
+  associatedtype Value
+  #if compiler(>=5.3) && $NonescapableTypes
+  static var initialValue: Self.Value? { get }
+  #endif
+  mutating func updateValue()
+}
+extension AttributeGraph.StatefulRule {
+  #if compiler(>=5.3) && $NonescapableTypes
+  public static var initialValue: Self.Value? {
+    get
+  }
+  #endif
+  public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AttributeGraph.AnyAttribute)
+  public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
+}
+extension AttributeGraph.StatefulRule {
+  public var attribute: AttributeGraph.Attribute<Self.Value> {
+    get
+  }
+  public var context: AttributeGraph.RuleContext<Self.Value> {
+    get
+  }
+  public var value: Self.Value {
+    unsafeAddress
+    nonmutating set
+  }
+  public var hasValue: Swift.Bool {
+    get
+  }
+}
+@frozen public struct Focus<Root, Value> : AttributeGraph.Rule, Swift.CustomStringConvertible {
+  public var root: AttributeGraph.Attribute<Root>
+  public var keyPath: Swift.KeyPath<Root, Value>
+  public init(root: AttributeGraph.Attribute<Root>, keyPath: Swift.KeyPath<Root, Value>)
+  public var value: Value {
+    get
+  }
+  public static var flags: AttributeGraph.Focus<Root, Value>.Flags {
+    get
+  }
+  public var description: Swift.String {
+    get
+  }
+}
+@frozen @propertyWrapper @dynamicMemberLookup public struct OptionalAttribute<Value> {
+  public var base: AttributeGraph.AnyOptionalAttribute
+  public init()
+  public init(base: AttributeGraph.AnyOptionalAttribute)
+  public init(_ attribute: AttributeGraph.Attribute<Value>)
+  #if compiler(>=5.3) && $NonescapableTypes
+  public init(_ attribute: AttributeGraph.Attribute<Value>?)
+  #endif
+  public init(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var attribute: AttributeGraph.Attribute<Value>? {
+    get
+    set
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var value: Value? {
+    get
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public func map<V>(_ body: (AttributeGraph.Attribute<Value>) -> V) -> V?
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var wrappedValue: Value? {
+    get
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var projectedValue: AttributeGraph.Attribute<Value>? {
+    get
+    set
+    _modify
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
+    get
+  }
+  #endif
+}
+extension AttributeGraph.OptionalAttribute : Swift.Hashable {
+  public static func == (a: AttributeGraph.OptionalAttribute<Value>, b: AttributeGraph.OptionalAttribute<Value>) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+extension AttributeGraph.OptionalAttribute : Swift.CustomStringConvertible {
+  public var description: Swift.String {
+    get
+  }
+}
+@frozen public struct AnyOptionalAttribute {
+  public var identifier: AttributeGraph.AnyAttribute
+  public init()
+  public init(_ attribute: AttributeGraph.AnyAttribute)
+  #if compiler(>=5.3) && $NonescapableTypes
+  public init(_ attribute: AttributeGraph.AnyAttribute?)
+  #endif
+  public init<Value>(_ attribute: AttributeGraph.OptionalAttribute<Value>)
+  public static var current: AttributeGraph.AnyOptionalAttribute {
+    get
+  }
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var attribute: AttributeGraph.AnyAttribute? {
+    get
+    set
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public func map<Value>(_ body: (AttributeGraph.AnyAttribute) -> Value) -> Value?
+  #endif
+  public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.OptionalAttribute<Value>
+}
+extension AttributeGraph.AnyOptionalAttribute : Swift.Hashable {
+  public static func == (a: AttributeGraph.AnyOptionalAttribute, b: AttributeGraph.AnyOptionalAttribute) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+extension AttributeGraph.AnyOptionalAttribute : Swift.CustomStringConvertible {
+  public var description: Swift.String {
+    get
+  }
+}
 @frozen @propertyWrapper @dynamicMemberLookup public struct IndirectAttribute<Value> {
-  public let identifier: AnyAttribute
+  public let identifier: AttributeGraph.AnyAttribute
   public init(source: AttributeGraph.Attribute<Value>)
   public var source: AttributeGraph.Attribute<Value> {
     get
     nonmutating set
   }
-  public var dependency: AnyAttribute? {
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var dependency: AttributeGraph.AnyAttribute? {
     get
     nonmutating set
   }
+  #endif
   public var value: Value {
     get
     nonmutating set
     nonmutating _modify
   }
-  public func changedValue(options: AGValueOptions = []) -> (value: Value, changed: Swift.Bool)
+  public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)
   public var wrappedValue: Value {
     get
     nonmutating set
@@ -238,169 +509,25 @@ extension AttributeGraph.IndirectAttribute : Swift.Hashable {
     get
   }
 }
-@frozen public struct AnyOptionalAttribute {
-  public var identifier: AnyAttribute
-  public init()
-  public init(_ attribute: AnyAttribute)
-  public init(_ attribute: AnyAttribute?)
-  public init<Value>(_ attribute: AttributeGraph.OptionalAttribute<Value>)
-  public static var current: AttributeGraph.AnyOptionalAttribute {
-    get
-  }
-  public var attribute: AnyAttribute? {
-    get
-    set
-  }
-  public func map<Value>(_ body: (AnyAttribute) -> Value) -> Value?
-  public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.OptionalAttribute<Value>
-}
-extension AttributeGraph.AnyOptionalAttribute : Swift.Hashable {
-  public static func == (a: AttributeGraph.AnyOptionalAttribute, b: AttributeGraph.AnyOptionalAttribute) -> Swift.Bool
-  public func hash(into hasher: inout Swift.Hasher)
-  public var hashValue: Swift.Int {
-    get
-  }
-}
-extension AttributeGraph.AnyOptionalAttribute : Swift.CustomStringConvertible {
-  public var description: Swift.String {
-    get
-  }
-}
-@frozen @propertyWrapper @dynamicMemberLookup public struct OptionalAttribute<Value> {
-  public var base: AttributeGraph.AnyOptionalAttribute
-  public init()
-  public init(base: AttributeGraph.AnyOptionalAttribute)
-  public init(_ attribute: AttributeGraph.Attribute<Value>)
-  public init(_ attribute: AttributeGraph.Attribute<Value>?)
-  public init(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
-  public var attribute: AttributeGraph.Attribute<Value>? {
-    get
-    set
-  }
-  public var value: Value? {
-    get
-  }
-  public func changedValue(options: AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
-  public func map<V>(_ body: (AttributeGraph.Attribute<Value>) -> V) -> V?
-  public var wrappedValue: Value? {
-    get
-  }
-  public var projectedValue: AttributeGraph.Attribute<Value>? {
-    get
-    set
-    _modify
-  }
-  public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
-    get
-  }
-}
-extension AttributeGraph.OptionalAttribute : Swift.Hashable {
-  public static func == (a: AttributeGraph.OptionalAttribute<Value>, b: AttributeGraph.OptionalAttribute<Value>) -> Swift.Bool
-  public func hash(into hasher: inout Swift.Hasher)
-  public var hashValue: Swift.Int {
-    get
-  }
-}
-extension AttributeGraph.OptionalAttribute : Swift.CustomStringConvertible {
-  public var description: Swift.String {
-    get
-  }
-}
-@frozen public struct Focus<Root, Value> : AttributeGraph.Rule, Swift.CustomStringConvertible {
-  public var root: AttributeGraph.Attribute<Root>
-  public var keyPath: Swift.KeyPath<Root, Value>
-  public init(root: AttributeGraph.Attribute<Root>, keyPath: Swift.KeyPath<Root, Value>)
-  public var value: Value {
-    get
-  }
-  public static var flags: AttributeGraph.Focus<Root, Value>.Flags {
-    get
-  }
-  public var description: Swift.String {
-    get
-  }
-}
-@frozen public struct Map<Source, Value> : AttributeGraph.Rule, Swift.CustomStringConvertible {
-  public var arg: AttributeGraph.Attribute<Source>
-  public let body: (Source) -> Value
-  public init(_ arg: AttributeGraph.Attribute<Source>, _ body: @escaping (Source) -> Value)
-  public var value: Value {
-    get
-  }
-  public static var flags: AttributeGraph.Map<Source, Value>.Flags {
-    get
-  }
-  public var description: Swift.String {
-    get
-  }
-}
-public protocol Rule : AttributeGraph._AttributeBody {
-  associatedtype Value
-  static var initialValue: Self.Value? { get }
-  var value: Self.Value { get }
-}
-extension AttributeGraph.Rule {
-  public static var initialValue: Self.Value? {
-    get
-  }
-  public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AnyAttribute)
-  public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
-}
-extension AttributeGraph.Rule {
-  public var attribute: AttributeGraph.Attribute<Self.Value> {
-    get
-  }
-  public var context: AttributeGraph.RuleContext<Self.Value> {
-    get
-  }
-}
-extension AttributeGraph.Rule where Self : Swift.Hashable {
-  public func cachedValue(options: AGCachedValueOptions = [], owner: AnyAttribute?) -> Self.Value
-  public func cachedValueIfExists(options: AGCachedValueOptions = [], owner: AnyAttribute?) -> Self.Value?
-  public static func _cachedValue(options: AGCachedValueOptions = [], owner: AnyAttribute?, hashValue: Swift.Int, bodyPtr: Swift.UnsafeRawPointer, update: () -> (Swift.UnsafeMutableRawPointer, AnyAttribute) -> Swift.Void) -> Swift.UnsafePointer<Self.Value>
-}
-public protocol StatefulRule : AttributeGraph._AttributeBody {
-  associatedtype Value
-  static var initialValue: Self.Value? { get }
-  mutating func updateValue()
-}
-extension AttributeGraph.StatefulRule {
-  public static var initialValue: Self.Value? {
-    get
-  }
-  public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AnyAttribute)
-  public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
-}
-extension AttributeGraph.StatefulRule {
-  public var attribute: AttributeGraph.Attribute<Self.Value> {
-    get
-  }
-  public var context: AttributeGraph.RuleContext<Self.Value> {
-    get
-  }
-  public var value: Self.Value {
-    unsafeAddress
-    nonmutating set
-  }
-  public var hasValue: Swift.Bool {
-    get
-  }
-}
 @frozen public struct AnyRuleContext : Swift.Equatable {
-  public var attribute: AnyAttribute
-  public init(attribute: AnyAttribute)
+  public var attribute: AttributeGraph.AnyAttribute
+  public init(attribute: AttributeGraph.AnyAttribute)
   public init<V>(_ context: AttributeGraph.RuleContext<V>)
   public subscript<V>(attribute: AttributeGraph.Attribute<V>) -> V {
     unsafeAddress
   }
+  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(weakAttribute: AttributeGraph.WeakAttribute<V>) -> V? {
     get
   }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(optionalAttribute: AttributeGraph.OptionalAttribute<V>) -> V? {
     get
   }
-  public func valueAndFlags<V>(of input: AttributeGraph.Attribute<V>, options: AGValueOptions = []) -> (value: V, flags: AGChangedValueFlags)
-  public func changedValue<V>(of input: AttributeGraph.Attribute<V>, options: AGValueOptions = []) -> (value: V, changed: Swift.Bool)
+  #endif
+  public func valueAndFlags<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, flags: AttributeGraph.AGChangedValueFlags)
+  public func changedValue<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, changed: Swift.Bool)
   public func update(body: () -> Swift.Void)
   public func unsafeCast<V>(to _: V.Type) -> AttributeGraph.RuleContext<V>
   public static func == (a: AttributeGraph.AnyRuleContext, b: AttributeGraph.AnyRuleContext) -> Swift.Bool
@@ -411,12 +538,16 @@ extension AttributeGraph.StatefulRule {
   public subscript<V>(attribute: AttributeGraph.Attribute<V>) -> V {
     unsafeAddress
   }
+  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(weakAttribute: AttributeGraph.WeakAttribute<V>) -> V? {
     get
   }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(optionalAttribute: AttributeGraph.OptionalAttribute<V>) -> V? {
     get
   }
+  #endif
   public var value: Value {
     unsafeAddress
     nonmutating set
@@ -424,86 +555,41 @@ extension AttributeGraph.StatefulRule {
   public var hasValue: Swift.Bool {
     get
   }
-  public func valueAndFlags<V>(of input: AttributeGraph.Attribute<V>, options: AGValueOptions = []) -> (value: V, flags: AGChangedValueFlags)
-  public func changedValue<V>(of input: AttributeGraph.Attribute<V>, options: AGValueOptions = []) -> (value: V, changed: Swift.Bool)
+  public func valueAndFlags<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, flags: AttributeGraph.AGChangedValueFlags)
+  public func changedValue<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, changed: Swift.Bool)
   public func update(body: () -> Swift.Void)
   public static func == (a: AttributeGraph.RuleContext<Value>, b: AttributeGraph.RuleContext<Value>) -> Swift.Bool
 }
 @_silgen_name("AGGraphGetInputValue")
-@inline(__always) @inlinable internal func AGGraphGetInputValue<Value>(_ attribute: AnyAttribute, input: AnyAttribute, options: AGValueOptions = [], type: Value.Type = Value.self) -> AGValue
+@inline(__always) @inlinable internal func AGGraphGetInputValue<Value>(_ attribute: AttributeGraph.AnyAttribute, input: AttributeGraph.AnyAttribute, options: AttributeGraph.AGValueOptions = [], type: Value.Type = Value.self) -> AttributeGraph.AGValue
 @_silgen_name("AGGraphWithUpdate")
-@inline(__always) @inlinable internal func AGGraphWithUpdate(_ attribute: AnyAttribute, body: () -> Swift.Void)
-extension AnyWeakAttribute {
-  public init(_ attribute: AnyAttribute?)
-  public init<Value>(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
-  public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.WeakAttribute<Value>
-  public var attribute: AnyAttribute? {
-    get
-    set
-  }
+@inline(__always) @inlinable internal func AGGraphWithUpdate(_ attribute: AttributeGraph.AnyAttribute, body: () -> Swift.Void)
+extension AttributeGraph.Subgraph {
+  public typealias Flags = AttributeGraph.AnyAttribute.Flags
+  public typealias ChildFlags = AttributeGraph.AnyAttribute.Flags
 }
-extension AnyWeakAttribute : Swift.Hashable {
-  public static func == (lhs: AnyWeakAttribute, rhs: AnyWeakAttribute) -> Swift.Bool
-  public func hash(into hasher: inout Swift.Hasher)
-  public var hashValue: Swift.Int {
-    get
-  }
+extension AttributeGraph.Subgraph {
+  public func addObserver(_ observer: @escaping () -> Swift.Void) -> Swift.Int
+  public func apply<Value>(_ body: () -> Value) -> Value
+  public func forEach(_ flags: AttributeGraph.Subgraph.Flags, _ callback: (AttributeGraph.AnyAttribute) -> Swift.Void)
 }
-extension AnyWeakAttribute : Swift.CustomStringConvertible {
-  @_alwaysEmitIntoClient public var description: Swift.String {
-    get { attribute?.description ?? "nil" }
-  }
+extension AttributeGraph.Subgraph {
+  public static func beginTreeElement<Value>(value: AttributeGraph.Attribute<Value>, flags: Swift.UInt32)
+  public static func addTreeValue<Value>(_ value: AttributeGraph.Attribute<Value>, forKey key: Swift.UnsafePointer<Swift.Int8>, flags: Swift.UInt32)
+  public static func endTreeElement<Value>(value: AttributeGraph.Attribute<Value>)
 }
-@frozen @propertyWrapper @dynamicMemberLookup public struct WeakAttribute<Value> {
-  internal var base: AnyWeakAttribute
-  public init(base: AnyWeakAttribute)
-  public init()
-  public init(_ attribute: AttributeGraph.Attribute<Value>)
-  public init(_ attribute: AttributeGraph.Attribute<Value>?)
-  public var wrappedValue: Value? {
-    get
-  }
-  public var projectedValue: AttributeGraph.Attribute<Value>? {
-    get
-    set
-    _modify
-  }
-  public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
-    get
-  }
-  public var attribute: AttributeGraph.Attribute<Value>? {
-    get
-    set
-  }
-  public var value: Value? {
-    get
-  }
-  public func changedValue(options: AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
+extension AttributeGraph.Graph {
+  public static func typeIndex(ctx: AttributeGraph.GraphContext, body: any AttributeGraph._AttributeBody.Type, valueType: AttributeGraph.Metadata, flags: AttributeGraph._AttributeType.Flags, update: () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void) -> Swift.Int
 }
-extension AttributeGraph.WeakAttribute : Swift.Hashable {
-  public static func == (a: AttributeGraph.WeakAttribute<Value>, b: AttributeGraph.WeakAttribute<Value>) -> Swift.Bool
-  public func hash(into hasher: inout Swift.Hasher)
-  public var hashValue: Swift.Int {
-    get
-  }
-}
-extension AttributeGraph.WeakAttribute : Swift.CustomStringConvertible {
-  public var description: Swift.String {
-    get
-  }
-}
-extension Graph {
-  public static func typeIndex(ctx: GraphContext, body: any AttributeGraph._AttributeBody.Type, valueType: Metadata, flags: _AttributeType.Flags, update: () -> (Swift.UnsafeMutableRawPointer, AnyAttribute) -> Swift.Void) -> Swift.Int
-}
-extension Graph {
+extension AttributeGraph.Graph {
   public static func withoutUpdate<V>(_ body: () -> V) -> V
   public func withoutSubgraphInvalidation<V>(_ body: () -> V) -> V
   public func withDeadline<V>(_: Swift.UInt64, _: () -> V) -> V
-  public func onInvalidation(_ callback: @escaping (AnyAttribute) -> Swift.Void)
+  public func onInvalidation(_ callback: @escaping (AttributeGraph.AnyAttribute) -> Swift.Void)
   public func onUpdate(_ callback: @escaping () -> Swift.Void)
   public func withMainThreadHandler(_: (() -> Swift.Void) -> Swift.Void, do: () -> Swift.Void)
 }
-extension Graph {
+extension AttributeGraph.Graph {
   @_transparent public func startProfiling() {
         __AGGraphStartProfiling(self)
     }
@@ -517,46 +603,31 @@ extension Graph {
   public static func stopProfiling()
   public static func resetProfile()
 }
-extension Graph {
+extension AttributeGraph.Graph {
   @_transparent public var mainUpdates: Swift.Int {
     @_transparent get { numericCast(counter(for: .mainThreadUpdates)) }
   }
 }
-extension Graph {
+extension AttributeGraph.Graph {
+  #if compiler(>=5.3) && $NonescapableTypes
   @_silgen_name("AGGraphGetOutputValue")
   @inline(__always) @inlinable public static func outputValue<Value>() -> Swift.UnsafePointer<Value>?
+  #endif
   @_silgen_name("AGGraphSetOutputValue")
   @inline(__always) @inlinable public static func setOutputValue<Value>(_ value: Swift.UnsafePointer<Value>)
 }
-extension Graph {
-  @_transparent public static func anyInputsChanged(excluding excludedInputs: [AnyAttribute]) -> Swift.Bool {
+extension AttributeGraph.Graph {
+  @_transparent public static func anyInputsChanged(excluding excludedInputs: [AttributeGraph.AnyAttribute]) -> Swift.Bool {
         return __AGGraphAnyInputsChanged(excludedInputs, excludedInputs.count)
     }
 }
-extension Graph {
+extension AttributeGraph.Graph {
+  #if compiler(>=5.3) && $NonescapableTypes
   public func archiveJSON(name: Swift.String?)
-}
-extension Subgraph {
-  public typealias Flags = AnyAttribute.Flags
-  public typealias ChildFlags = AnyAttribute.Flags
-}
-extension Subgraph {
-  public func addObserver(_ observer: @escaping () -> Swift.Void) -> Swift.Int
-  public func apply<Value>(_ body: () -> Value) -> Value
-  public func forEach(_ flags: Subgraph.Flags, _ callback: (AnyAttribute) -> Swift.Void)
-}
-extension Subgraph {
-  public static func beginTreeElement<Value>(value: AttributeGraph.Attribute<Value>, flags: Swift.UInt32)
-  public static func addTreeValue<Value>(_ value: AttributeGraph.Attribute<Value>, forKey key: Swift.UnsafePointer<Swift.Int8>, flags: Swift.UInt32)
-  public static func endTreeElement<Value>(value: AttributeGraph.Attribute<Value>)
-}
-public func compareValues<Value>(_ lhs: Value, _ rhs: Value, mode: ComparisonMode = .equatableAlways) -> Swift.Bool
-public func compareValues<Value>(_ lhs: Value, _ rhs: Value, options: ComparisonOptions) -> Swift.Bool
-extension ComparisonOptions {
-  public init(mode: ComparisonMode)
+  #endif
 }
 public func forEachField(of type: any Any.Type, do body: (Swift.UnsafePointer<Swift.Int8>, Swift.Int, any Any.Type) -> Swift.Void)
-extension Metadata : Swift.Hashable, Swift.CustomStringConvertible {
+extension AttributeGraph.Metadata : Swift.Hashable, Swift.CustomStringConvertible {
   public init(_ type: any Any.Type)
   public var type: any Any.Type {
     get
@@ -564,16 +635,12 @@ extension Metadata : Swift.Hashable, Swift.CustomStringConvertible {
   public var description: Swift.String {
     get
   }
-  public func forEachField(options: Metadata.ApplyOptions, do body: (Swift.UnsafePointer<Swift.Int8>, Swift.Int, any Any.Type) -> Swift.Bool) -> Swift.Bool
+  public func forEachField(options: AttributeGraph.Metadata.ApplyOptions, do body: (Swift.UnsafePointer<Swift.Int8>, Swift.Int, any Any.Type) -> Swift.Bool) -> Swift.Bool
 }
-extension Signature : Swift.Equatable {
-  public static func == (lhs: Signature, rhs: Signature) -> Swift.Bool
+extension AttributeGraph.Signature : Swift.Equatable {
+  public static func == (lhs: AttributeGraph.Signature, rhs: AttributeGraph.Signature) -> Swift.Bool
 }
-@discardableResult
-public func withUnsafePointerToEnumCase<T>(of value: Swift.UnsafeMutablePointer<T>, do body: (Swift.Int, any Any.Type, Swift.UnsafeRawPointer) -> ()) -> Swift.Bool
-@discardableResult
-public func withUnsafeMutablePointerToEnumCase<T>(of value: Swift.UnsafeMutablePointer<T>, do body: (Swift.Int, any Any.Type, Swift.UnsafeMutableRawPointer) -> ()) -> Swift.Bool
-extension TupleType {
+extension AttributeGraph.TupleType {
   @_transparent public init(_ types: [any Any.Type]) {
         self.init(count: types.count, elements: types.map(Metadata.init))
     }
@@ -597,16 +664,16 @@ extension TupleType {
   @_transparent public func offset<T>(at index: Swift.Int, as type: T.Type) -> Swift.Int {
         elementOffset(at: index, type: Metadata(type))
     }
-  @_transparent public func setElement<T>(in tupleValue: Swift.UnsafeMutableRawPointer, at index: Swift.Int, from srcValue: Swift.UnsafePointer<T>, options: TupleType.CopyOptions) {
+  @_transparent public func setElement<T>(in tupleValue: Swift.UnsafeMutableRawPointer, at index: Swift.Int, from srcValue: Swift.UnsafePointer<T>, options: AttributeGraph.TupleType.CopyOptions) {
         __AGTupleSetElement(self, tupleValue, index, srcValue, Metadata(T.self), options)
     }
-  @_transparent public func getElement<T>(in tupleValue: Swift.UnsafeMutableRawPointer, at index: Swift.Int, to dstValue: Swift.UnsafeMutablePointer<T>, options: TupleType.CopyOptions) {
+  @_transparent public func getElement<T>(in tupleValue: Swift.UnsafeMutableRawPointer, at index: Swift.Int, to dstValue: Swift.UnsafeMutablePointer<T>, options: AttributeGraph.TupleType.CopyOptions) {
         __AGTupleGetElement(self, tupleValue, index, dstValue, Metadata(T.self), options)
     }
 }
 @_silgen_name("AGTupleWithBuffer")
-public func withUnsafeTuple(of type: TupleType, count: Swift.Int, _ body: (UnsafeMutableTuple) -> Swift.Void)
-extension UnsafeTuple {
+public func withUnsafeTuple(of type: AttributeGraph.TupleType, count: Swift.Int, _ body: (AttributeGraph.UnsafeMutableTuple) -> Swift.Void)
+extension AttributeGraph.UnsafeTuple {
   @_transparent public var count: Swift.Int {
     @_transparent get { type.count }
   }
@@ -633,8 +700,8 @@ extension UnsafeTuple {
     @_transparent unsafeAddress { address(of: index, as: T.self) }
   }
 }
-extension UnsafeMutableTuple {
-  @_transparent public init(with tupleType: TupleType) {
+extension AttributeGraph.UnsafeMutableTuple {
+  @_transparent public init(with tupleType: AttributeGraph.TupleType) {
         self.init(
             type: tupleType,
             value: UnsafeMutableRawPointer.allocate(
@@ -688,21 +755,30 @@ extension UnsafeMutableTuple {
     @_transparent nonmutating unsafeMutableAddress { address(of: index, as: T.self) }
   }
 }
-extension AttributeGraph.Attribute : Swift.Sendable {}
-extension AttributeGraph.Attribute : Swift.BitwiseCopyable {}
-extension AttributeGraph.External : Swift.Sendable {}
-extension AttributeGraph.External : Swift.BitwiseCopyable {}
+@discardableResult
+public func withUnsafePointerToEnumCase<T>(of value: Swift.UnsafeMutablePointer<T>, do body: (Swift.Int, any Any.Type, Swift.UnsafeRawPointer) -> ()) -> Swift.Bool
+@discardableResult
+public func withUnsafeMutablePointerToEnumCase<T>(of value: Swift.UnsafeMutablePointer<T>, do body: (Swift.Int, any Any.Type, Swift.UnsafeMutableRawPointer) -> ()) -> Swift.Bool
+public func compareValues<Value>(_ lhs: Value, _ rhs: Value, mode: AttributeGraph.ComparisonMode = .equatableAlways) -> Swift.Bool
+public func compareValues<Value>(_ lhs: Value, _ rhs: Value, options: AttributeGraph.ComparisonOptions) -> Swift.Bool
+extension AttributeGraph.ComparisonOptions {
+  public init(mode: AttributeGraph.ComparisonMode)
+}
 extension AttributeGraph.PointerOffset : Swift.Sendable {}
 extension AttributeGraph.PointerOffset : Swift.BitwiseCopyable {}
-extension AttributeGraph.IndirectAttribute : Swift.Sendable {}
-extension AttributeGraph.IndirectAttribute : Swift.BitwiseCopyable {}
-extension AttributeGraph.AnyOptionalAttribute : Swift.Sendable {}
-extension AttributeGraph.AnyOptionalAttribute : Swift.BitwiseCopyable {}
+extension AttributeGraph.External : Swift.Sendable {}
+extension AttributeGraph.External : Swift.BitwiseCopyable {}
+extension AttributeGraph.Attribute : Swift.Sendable {}
+extension AttributeGraph.Attribute : Swift.BitwiseCopyable {}
+extension AttributeGraph.WeakAttribute : Swift.Sendable {}
+extension AttributeGraph.WeakAttribute : Swift.BitwiseCopyable {}
 extension AttributeGraph.OptionalAttribute : Swift.Sendable {}
 extension AttributeGraph.OptionalAttribute : Swift.BitwiseCopyable {}
+extension AttributeGraph.AnyOptionalAttribute : Swift.Sendable {}
+extension AttributeGraph.AnyOptionalAttribute : Swift.BitwiseCopyable {}
+extension AttributeGraph.IndirectAttribute : Swift.Sendable {}
+extension AttributeGraph.IndirectAttribute : Swift.BitwiseCopyable {}
 extension AttributeGraph.AnyRuleContext : Swift.Sendable {}
 extension AttributeGraph.AnyRuleContext : Swift.BitwiseCopyable {}
 extension AttributeGraph.RuleContext : Swift.Sendable {}
 extension AttributeGraph.RuleContext : Swift.BitwiseCopyable {}
-extension AttributeGraph.WeakAttribute : Swift.Sendable {}
-extension AttributeGraph.WeakAttribute : Swift.BitwiseCopyable {}

--- a/AG/2024/AttributeGraph.xcframework/xros-arm64-x86_64-simulator/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/arm64-apple-xros-simulator.swiftinterface
+++ b/AG/2024/AttributeGraph.xcframework/xros-arm64-x86_64-simulator/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/arm64-apple-xros-simulator.swiftinterface
@@ -10,11 +10,9 @@ public import _SwiftConcurrencyShims
 extension AttributeGraph.AnyAttribute {
   public init<Value>(_ attribute: AttributeGraph.Attribute<Value>)
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.Attribute<Value>
-  #if compiler(>=5.3) && $NonescapableTypes
   public static var current: AttributeGraph.AnyAttribute? {
     get
   }
-  #endif
   public func unsafeOffset(at offset: Swift.Int) -> AttributeGraph.AnyAttribute
   public func setFlags(_ newFlags: AttributeGraph.AnyAttribute.Flags, mask: AttributeGraph.AnyAttribute.Flags)
   public func addInput(_ attribute: AttributeGraph.AnyAttribute, options: AttributeGraph.AGInputOptions = [], token: Swift.Int)
@@ -31,12 +29,10 @@ extension AttributeGraph.AnyAttribute {
   public var valueType: any Any.Type {
     get
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public var indirectDependency: AttributeGraph.AnyAttribute? {
     get
     nonmutating set
   }
-  #endif
 }
 extension AttributeGraph.AnyAttribute : Swift.CustomStringConvertible {
   @inlinable public var description: Swift.String {
@@ -95,9 +91,7 @@ extension AttributeGraph.External : Swift.CustomStringConvertible {
   public init(_ attribute: AttributeGraph.Attribute<Value>)
   public init(value: Value)
   public init(type _: Value.Type)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init<Body>(body: Swift.UnsafePointer<Body>, value: Swift.UnsafePointer<Value>?, flags: AttributeGraph._AttributeType.Flags = [], update: () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void) where Body : AttributeGraph._AttributeBody
-  #endif
   public var wrappedValue: Value {
     unsafeAddress
     nonmutating set
@@ -169,10 +163,8 @@ extension AttributeGraph.Attribute {
   public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.Rule
   public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.StatefulRule
 }
-#if compiler(>=5.3) && $NonescapableTypes
 @_silgen_name("AGGraphCreateAttribute")
 @inline(__always) @inlinable internal func AGGraphCreateAttribute(index: Swift.Int, body: Swift.UnsafeRawPointer, value: Swift.UnsafeRawPointer?) -> AttributeGraph.AnyAttribute
-#endif
 @_silgen_name("AGGraphGetValue")
 @inline(__always) @inlinable internal func AGGraphGetValue<Value>(_ attribute: AttributeGraph.AnyAttribute, options: AttributeGraph.AGValueOptions = [], type: Value.Type = Value.self) -> AttributeGraph.AGValue
 @_silgen_name("AGGraphSetValue")
@@ -215,40 +207,26 @@ extension AttributeGraph._AttributeBody {
   public init(base: AttributeGraph.AnyWeakAttribute)
   public init()
   public init(_ attribute: AttributeGraph.Attribute<Value>)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.Attribute<Value>?)
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var wrappedValue: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var projectedValue: AttributeGraph.Attribute<Value>? {
     get
     set
     _modify
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.Attribute<Value>? {
     get
     set
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var value: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
-  #endif
 }
 extension AttributeGraph.WeakAttribute : Swift.Hashable {
   public static func == (a: AttributeGraph.WeakAttribute<Value>, b: AttributeGraph.WeakAttribute<Value>) -> Swift.Bool
@@ -263,17 +241,13 @@ extension AttributeGraph.WeakAttribute : Swift.CustomStringConvertible {
   }
 }
 extension AttributeGraph.AnyWeakAttribute {
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.AnyAttribute?)
-  #endif
   public init<Value>(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.WeakAttribute<Value>
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.AnyAttribute? {
     get
     set
   }
-  #endif
 }
 extension AttributeGraph.AnyWeakAttribute : Swift.Hashable {
   public static func == (lhs: AttributeGraph.AnyWeakAttribute, rhs: AttributeGraph.AnyWeakAttribute) -> Swift.Bool
@@ -289,17 +263,13 @@ extension AttributeGraph.AnyWeakAttribute : Swift.CustomStringConvertible {
 }
 public protocol Rule : AttributeGraph._AttributeBody {
   associatedtype Value
-  #if compiler(>=5.3) && $NonescapableTypes
   static var initialValue: Self.Value? { get }
-  #endif
   var value: Self.Value { get }
 }
 extension AttributeGraph.Rule {
-  #if compiler(>=5.3) && $NonescapableTypes
   public static var initialValue: Self.Value? {
     get
   }
-  #endif
   public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AttributeGraph.AnyAttribute)
   public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
 }
@@ -312,15 +282,9 @@ extension AttributeGraph.Rule {
   }
 }
 extension AttributeGraph.Rule where Self : Swift.Hashable {
-  #if compiler(>=5.3) && $NonescapableTypes
   public func cachedValue(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?) -> Self.Value
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func cachedValueIfExists(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?) -> Self.Value?
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public static func _cachedValue(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?, hashValue: Swift.Int, bodyPtr: Swift.UnsafeRawPointer, update: () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void) -> Swift.UnsafePointer<Self.Value>
-  #endif
 }
 @frozen public struct Map<Source, Value> : AttributeGraph.Rule, Swift.CustomStringConvertible {
   public var arg: AttributeGraph.Attribute<Source>
@@ -338,17 +302,13 @@ extension AttributeGraph.Rule where Self : Swift.Hashable {
 }
 public protocol StatefulRule : AttributeGraph._AttributeBody {
   associatedtype Value
-  #if compiler(>=5.3) && $NonescapableTypes
   static var initialValue: Self.Value? { get }
-  #endif
   mutating func updateValue()
 }
 extension AttributeGraph.StatefulRule {
-  #if compiler(>=5.3) && $NonescapableTypes
   public static var initialValue: Self.Value? {
     get
   }
-  #endif
   public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AttributeGraph.AnyAttribute)
   public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
 }
@@ -386,44 +346,28 @@ extension AttributeGraph.StatefulRule {
   public init()
   public init(base: AttributeGraph.AnyOptionalAttribute)
   public init(_ attribute: AttributeGraph.Attribute<Value>)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.Attribute<Value>?)
-  #endif
   public init(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.Attribute<Value>? {
     get
     set
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var value: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func map<V>(_ body: (AttributeGraph.Attribute<Value>) -> V) -> V?
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var wrappedValue: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var projectedValue: AttributeGraph.Attribute<Value>? {
     get
     set
     _modify
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
     get
   }
-  #endif
 }
 extension AttributeGraph.OptionalAttribute : Swift.Hashable {
   public static func == (a: AttributeGraph.OptionalAttribute<Value>, b: AttributeGraph.OptionalAttribute<Value>) -> Swift.Bool
@@ -441,22 +385,16 @@ extension AttributeGraph.OptionalAttribute : Swift.CustomStringConvertible {
   public var identifier: AttributeGraph.AnyAttribute
   public init()
   public init(_ attribute: AttributeGraph.AnyAttribute)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.AnyAttribute?)
-  #endif
   public init<Value>(_ attribute: AttributeGraph.OptionalAttribute<Value>)
   public static var current: AttributeGraph.AnyOptionalAttribute {
     get
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.AnyAttribute? {
     get
     set
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func map<Value>(_ body: (AttributeGraph.AnyAttribute) -> Value) -> Value?
-  #endif
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.OptionalAttribute<Value>
 }
 extension AttributeGraph.AnyOptionalAttribute : Swift.Hashable {
@@ -478,12 +416,10 @@ extension AttributeGraph.AnyOptionalAttribute : Swift.CustomStringConvertible {
     get
     nonmutating set
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public var dependency: AttributeGraph.AnyAttribute? {
     get
     nonmutating set
   }
-  #endif
   public var value: Value {
     get
     nonmutating set
@@ -516,16 +452,12 @@ extension AttributeGraph.IndirectAttribute : Swift.Hashable {
   public subscript<V>(attribute: AttributeGraph.Attribute<V>) -> V {
     unsafeAddress
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(weakAttribute: AttributeGraph.WeakAttribute<V>) -> V? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(optionalAttribute: AttributeGraph.OptionalAttribute<V>) -> V? {
     get
   }
-  #endif
   public func valueAndFlags<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, flags: AttributeGraph.AGChangedValueFlags)
   public func changedValue<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, changed: Swift.Bool)
   public func update(body: () -> Swift.Void)
@@ -538,16 +470,12 @@ extension AttributeGraph.IndirectAttribute : Swift.Hashable {
   public subscript<V>(attribute: AttributeGraph.Attribute<V>) -> V {
     unsafeAddress
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(weakAttribute: AttributeGraph.WeakAttribute<V>) -> V? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(optionalAttribute: AttributeGraph.OptionalAttribute<V>) -> V? {
     get
   }
-  #endif
   public var value: Value {
     unsafeAddress
     nonmutating set
@@ -609,10 +537,8 @@ extension AttributeGraph.Graph {
   }
 }
 extension AttributeGraph.Graph {
-  #if compiler(>=5.3) && $NonescapableTypes
   @_silgen_name("AGGraphGetOutputValue")
   @inline(__always) @inlinable public static func outputValue<Value>() -> Swift.UnsafePointer<Value>?
-  #endif
   @_silgen_name("AGGraphSetOutputValue")
   @inline(__always) @inlinable public static func setOutputValue<Value>(_ value: Swift.UnsafePointer<Value>)
 }
@@ -622,9 +548,7 @@ extension AttributeGraph.Graph {
     }
 }
 extension AttributeGraph.Graph {
-  #if compiler(>=5.3) && $NonescapableTypes
   public func archiveJSON(name: Swift.String?)
-  #endif
 }
 public func forEachField(of type: any Any.Type, do body: (Swift.UnsafePointer<Swift.Int8>, Swift.Int, any Any.Type) -> Swift.Void)
 extension AttributeGraph.Metadata : Swift.Hashable, Swift.CustomStringConvertible {

--- a/AG/2024/AttributeGraph.xcframework/xros-arm64-x86_64-simulator/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/x86_64-apple-xros-simulator.swiftinterface
+++ b/AG/2024/AttributeGraph.xcframework/xros-arm64-x86_64-simulator/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/x86_64-apple-xros-simulator.swiftinterface
@@ -7,19 +7,21 @@ public import Swift
 public import _Concurrency
 public import _StringProcessing
 public import _SwiftConcurrencyShims
-extension AnyAttribute {
+extension AttributeGraph.AnyAttribute {
   public init<Value>(_ attribute: AttributeGraph.Attribute<Value>)
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.Attribute<Value>
-  public static var current: AnyAttribute? {
+  #if compiler(>=5.3) && $NonescapableTypes
+  public static var current: AttributeGraph.AnyAttribute? {
     get
   }
-  public func unsafeOffset(at offset: Swift.Int) -> AnyAttribute
-  public func setFlags(_ newFlags: AnyAttribute.Flags, mask: AnyAttribute.Flags)
-  public func addInput(_ attribute: AnyAttribute, options: AGInputOptions = [], token: Swift.Int)
-  public func addInput<Value>(_ attribute: AttributeGraph.Attribute<Value>, options: AGInputOptions = [], token: Swift.Int)
+  #endif
+  public func unsafeOffset(at offset: Swift.Int) -> AttributeGraph.AnyAttribute
+  public func setFlags(_ newFlags: AttributeGraph.AnyAttribute.Flags, mask: AttributeGraph.AnyAttribute.Flags)
+  public func addInput(_ attribute: AttributeGraph.AnyAttribute, options: AttributeGraph.AGInputOptions = [], token: Swift.Int)
+  public func addInput<Value>(_ attribute: AttributeGraph.Attribute<Value>, options: AttributeGraph.AGInputOptions = [], token: Swift.Int)
   public func visitBody<Body>(_ visitor: inout Body) where Body : AttributeGraph.AttributeBodyVisitor
   public func mutateBody<Value>(as type: Value.Type, invalidating: Swift.Bool, _ body: (inout Value) -> Swift.Void)
-  public func breadthFirstSearch(options _: SearchOptions = [], _: (AnyAttribute) -> Swift.Bool) -> Swift.Bool
+  public func breadthFirstSearch(options _: AttributeGraph.SearchOptions = [], _: (AttributeGraph.AnyAttribute) -> Swift.Bool) -> Swift.Bool
   public var _bodyType: any Any.Type {
     get
   }
@@ -29,118 +31,19 @@ extension AnyAttribute {
   public var valueType: any Any.Type {
     get
   }
-  public var indirectDependency: AnyAttribute? {
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var indirectDependency: AttributeGraph.AnyAttribute? {
     get
     nonmutating set
   }
+  #endif
 }
-extension AnyAttribute : Swift.CustomStringConvertible {
+extension AttributeGraph.AnyAttribute : Swift.CustomStringConvertible {
   @inlinable public var description: Swift.String {
     get { "#\(rawValue)" }
   }
 }
-public typealias AttributeUpdateBlock = () -> (Swift.UnsafeMutableRawPointer, AnyAttribute) -> Swift.Void
-@frozen @propertyWrapper @dynamicMemberLookup public struct Attribute<Value> {
-  public var identifier: AnyAttribute
-  public init(identifier: AnyAttribute)
-  public init(_ attribute: AttributeGraph.Attribute<Value>)
-  public init(value: Value)
-  public init(type _: Value.Type)
-  public init<Body>(body: Swift.UnsafePointer<Body>, value: Swift.UnsafePointer<Value>?, flags: _AttributeType.Flags = [], update: () -> (Swift.UnsafeMutableRawPointer, AnyAttribute) -> Swift.Void) where Body : AttributeGraph._AttributeBody
-  public var wrappedValue: Value {
-    unsafeAddress
-    nonmutating set
-  }
-  public var projectedValue: AttributeGraph.Attribute<Value> {
-    get
-    set
-  }
-  public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member> {
-    get
-  }
-  public subscript<Member>(keyPath keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member> {
-    get
-  }
-  public subscript<Member>(offset body: (inout Value) -> AttributeGraph.PointerOffset<Value, Member>) -> AttributeGraph.Attribute<Member> {
-    get
-  }
-  public func unsafeCast<V>(to type: V.Type) -> AttributeGraph.Attribute<V>
-  public func unsafeOffset<Member>(at offset: Swift.Int, as _: Member.Type) -> AttributeGraph.Attribute<Member>
-  public func applying<Member>(offset: AttributeGraph.PointerOffset<Value, Member>) -> AttributeGraph.Attribute<Member>
-  public func visitBody<Body>(_ visitor: inout Body) where Body : AttributeGraph.AttributeBodyVisitor
-  public func mutateBody<V>(as type: V.Type, invalidating: Swift.Bool, _ body: (inout V) -> Swift.Void)
-  public func breadthFirstSearch(options: SearchOptions = [], _ body: (AnyAttribute) -> Swift.Bool) -> Swift.Bool
-  public var graph: Graph {
-    get
-  }
-  public var subgraph: Subgraph {
-    get
-  }
-  public var value: Value {
-    unsafeAddress
-    nonmutating set
-  }
-  public var valueState: ValueState {
-    get
-  }
-  public func valueAndFlags(options: AGValueOptions = []) -> (value: Value, flags: AGChangedValueFlags)
-  public func changedValue(options: AGValueOptions = []) -> (value: Value, changed: Swift.Bool)
-  public func setValue(_ value: Value) -> Swift.Bool
-  public var hasValue: Swift.Bool {
-    get
-  }
-  public func updateValue()
-  public func prefetchValue()
-  public func invalidateValue()
-  public func validate()
-  public func addInput(_ attribute: AnyAttribute, options: AGInputOptions = [], token: Swift.Int)
-  public func addInput<V>(_ attribute: AttributeGraph.Attribute<V>, options: AGInputOptions = [], token: Swift.Int)
-  public typealias Flags = AnyAttribute.Flags
-  public var flags: AttributeGraph.Attribute<Value>.Flags {
-    get
-    nonmutating set
-  }
-  public func setFlags(_ newFlags: AttributeGraph.Attribute<Value>.Flags, mask: AttributeGraph.Attribute<Value>.Flags)
-}
-extension AttributeGraph.Attribute : Swift.Hashable {
-  public static func == (a: AttributeGraph.Attribute<Value>, b: AttributeGraph.Attribute<Value>) -> Swift.Bool
-  public func hash(into hasher: inout Swift.Hasher)
-  public var hashValue: Swift.Int {
-    get
-  }
-}
-extension AttributeGraph.Attribute : Swift.CustomStringConvertible {
-  public var description: Swift.String {
-    get
-  }
-}
-extension AttributeGraph.Attribute {
-  public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.Rule
-  public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.StatefulRule
-}
-@_silgen_name("AGGraphCreateAttribute")
-@inline(__always) @inlinable internal func AGGraphCreateAttribute(index: Swift.Int, body: Swift.UnsafeRawPointer, value: Swift.UnsafeRawPointer?) -> AnyAttribute
-@_silgen_name("AGGraphGetValue")
-@inline(__always) @inlinable internal func AGGraphGetValue<Value>(_ attribute: AnyAttribute, options: AGValueOptions = [], type: Value.Type = Value.self) -> AGValue
-@_silgen_name("AGGraphSetValue")
-@inline(__always) @inlinable internal func AGGraphSetValue<Value>(_ attribute: AnyAttribute, valuePointer: Swift.UnsafePointer<Value>) -> Swift.Bool
-@frozen public struct External<Value> {
-  public init()
-}
-extension AttributeGraph.External : AttributeGraph._AttributeBody {
-  public static var comparisonMode: ComparisonMode {
-    get
-  }
-  public static var flags: AttributeGraph.External<Value>.Flags {
-    get
-  }
-  public static func _update(_: Swift.UnsafeMutableRawPointer, attribute _: AnyAttribute)
-}
-extension AttributeGraph.External : Swift.CustomStringConvertible {
-  public var description: Swift.String {
-    get
-  }
-}
+public typealias AttributeUpdateBlock = () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void
 @frozen public struct PointerOffset<Base, Member> {
   public var byteOffset: Swift.Int
   public init(byteOffset: Swift.Int)
@@ -169,27 +72,111 @@ extension Swift.UnsafeMutablePointer {
   }
   public static func + <Member>(lhs: Swift.UnsafeMutablePointer<Pointee>, rhs: AttributeGraph.PointerOffset<Pointee, Member>) -> Swift.UnsafeMutablePointer<Member>
 }
-public protocol _AttributeBody {
-  static func _destroySelf(_ pointer: Swift.UnsafeMutableRawPointer)
-  static var _hasDestroySelf: Swift.Bool { get }
-  static func _updateDefault(_ pointer: Swift.UnsafeMutableRawPointer)
-  static var comparisonMode: ComparisonMode { get }
-  typealias Flags = _AttributeType.Flags
-  static var flags: Self.Flags { get }
+@frozen public struct External<Value> {
+  public init()
 }
-extension AttributeGraph._AttributeBody {
-  public static func _destroySelf(_ pointer: Swift.UnsafeMutableRawPointer)
-  public static var _hasDestroySelf: Swift.Bool {
+extension AttributeGraph.External : AttributeGraph._AttributeBody {
+  public static var comparisonMode: AttributeGraph.ComparisonMode {
     get
   }
-  public static func _updateDefault(_ pointer: Swift.UnsafeMutableRawPointer)
-  public static var comparisonMode: ComparisonMode {
+  public static var flags: AttributeGraph.External<Value>.Flags {
     get
   }
-  public static var flags: Self.Flags {
+  public static func _update(_: Swift.UnsafeMutableRawPointer, attribute _: AttributeGraph.AnyAttribute)
+}
+extension AttributeGraph.External : Swift.CustomStringConvertible {
+  public var description: Swift.String {
     get
   }
 }
+@frozen @propertyWrapper @dynamicMemberLookup public struct Attribute<Value> {
+  public var identifier: AttributeGraph.AnyAttribute
+  public init(identifier: AttributeGraph.AnyAttribute)
+  public init(_ attribute: AttributeGraph.Attribute<Value>)
+  public init(value: Value)
+  public init(type _: Value.Type)
+  #if compiler(>=5.3) && $NonescapableTypes
+  public init<Body>(body: Swift.UnsafePointer<Body>, value: Swift.UnsafePointer<Value>?, flags: AttributeGraph._AttributeType.Flags = [], update: () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void) where Body : AttributeGraph._AttributeBody
+  #endif
+  public var wrappedValue: Value {
+    unsafeAddress
+    nonmutating set
+  }
+  public var projectedValue: AttributeGraph.Attribute<Value> {
+    get
+    set
+  }
+  public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member> {
+    get
+  }
+  public subscript<Member>(keyPath keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member> {
+    get
+  }
+  public subscript<Member>(offset body: (inout Value) -> AttributeGraph.PointerOffset<Value, Member>) -> AttributeGraph.Attribute<Member> {
+    get
+  }
+  public func unsafeCast<V>(to type: V.Type) -> AttributeGraph.Attribute<V>
+  public func unsafeOffset<Member>(at offset: Swift.Int, as _: Member.Type) -> AttributeGraph.Attribute<Member>
+  public func applying<Member>(offset: AttributeGraph.PointerOffset<Value, Member>) -> AttributeGraph.Attribute<Member>
+  public func visitBody<Body>(_ visitor: inout Body) where Body : AttributeGraph.AttributeBodyVisitor
+  public func mutateBody<V>(as type: V.Type, invalidating: Swift.Bool, _ body: (inout V) -> Swift.Void)
+  public func breadthFirstSearch(options: AttributeGraph.SearchOptions = [], _ body: (AttributeGraph.AnyAttribute) -> Swift.Bool) -> Swift.Bool
+  public var graph: AttributeGraph.Graph {
+    get
+  }
+  public var subgraph: AttributeGraph.Subgraph {
+    get
+  }
+  public var value: Value {
+    unsafeAddress
+    nonmutating set
+  }
+  public var valueState: AttributeGraph.ValueState {
+    get
+  }
+  public func valueAndFlags(options: AttributeGraph.AGValueOptions = []) -> (value: Value, flags: AttributeGraph.AGChangedValueFlags)
+  public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)
+  public func setValue(_ value: Value) -> Swift.Bool
+  public var hasValue: Swift.Bool {
+    get
+  }
+  public func updateValue()
+  public func prefetchValue()
+  public func invalidateValue()
+  public func validate()
+  public func addInput(_ attribute: AttributeGraph.AnyAttribute, options: AttributeGraph.AGInputOptions = [], token: Swift.Int)
+  public func addInput<V>(_ attribute: AttributeGraph.Attribute<V>, options: AttributeGraph.AGInputOptions = [], token: Swift.Int)
+  public typealias Flags = AttributeGraph.AnyAttribute.Flags
+  public var flags: AttributeGraph.Attribute<Value>.Flags {
+    get
+    nonmutating set
+  }
+  public func setFlags(_ newFlags: AttributeGraph.Attribute<Value>.Flags, mask: AttributeGraph.Attribute<Value>.Flags)
+}
+extension AttributeGraph.Attribute : Swift.Hashable {
+  public static func == (a: AttributeGraph.Attribute<Value>, b: AttributeGraph.Attribute<Value>) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+extension AttributeGraph.Attribute : Swift.CustomStringConvertible {
+  public var description: Swift.String {
+    get
+  }
+}
+extension AttributeGraph.Attribute {
+  public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.Rule
+  public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.StatefulRule
+}
+#if compiler(>=5.3) && $NonescapableTypes
+@_silgen_name("AGGraphCreateAttribute")
+@inline(__always) @inlinable internal func AGGraphCreateAttribute(index: Swift.Int, body: Swift.UnsafeRawPointer, value: Swift.UnsafeRawPointer?) -> AttributeGraph.AnyAttribute
+#endif
+@_silgen_name("AGGraphGetValue")
+@inline(__always) @inlinable internal func AGGraphGetValue<Value>(_ attribute: AttributeGraph.AnyAttribute, options: AttributeGraph.AGValueOptions = [], type: Value.Type = Value.self) -> AttributeGraph.AGValue
+@_silgen_name("AGGraphSetValue")
+@inline(__always) @inlinable internal func AGGraphSetValue<Value>(_ attribute: AttributeGraph.AnyAttribute, valuePointer: Swift.UnsafePointer<Value>) -> Swift.Bool
 public protocol AttributeBodyVisitor {
   func visit<Body>(body: Swift.UnsafePointer<Body>) where Body : AttributeGraph._AttributeBody
 }
@@ -202,23 +189,307 @@ extension AttributeGraph.ObservedAttribute {
     get
   }
 }
+public protocol _AttributeBody {
+  static func _destroySelf(_ pointer: Swift.UnsafeMutableRawPointer)
+  static var _hasDestroySelf: Swift.Bool { get }
+  static func _updateDefault(_ pointer: Swift.UnsafeMutableRawPointer)
+  static var comparisonMode: AttributeGraph.ComparisonMode { get }
+  typealias Flags = AttributeGraph._AttributeType.Flags
+  static var flags: Self.Flags { get }
+}
+extension AttributeGraph._AttributeBody {
+  public static func _destroySelf(_ pointer: Swift.UnsafeMutableRawPointer)
+  public static var _hasDestroySelf: Swift.Bool {
+    get
+  }
+  public static func _updateDefault(_ pointer: Swift.UnsafeMutableRawPointer)
+  public static var comparisonMode: AttributeGraph.ComparisonMode {
+    get
+  }
+  public static var flags: Self.Flags {
+    get
+  }
+}
+@frozen @propertyWrapper @dynamicMemberLookup public struct WeakAttribute<Value> {
+  internal var base: AttributeGraph.AnyWeakAttribute
+  public init(base: AttributeGraph.AnyWeakAttribute)
+  public init()
+  public init(_ attribute: AttributeGraph.Attribute<Value>)
+  #if compiler(>=5.3) && $NonescapableTypes
+  public init(_ attribute: AttributeGraph.Attribute<Value>?)
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var wrappedValue: Value? {
+    get
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var projectedValue: AttributeGraph.Attribute<Value>? {
+    get
+    set
+    _modify
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
+    get
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var attribute: AttributeGraph.Attribute<Value>? {
+    get
+    set
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var value: Value? {
+    get
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
+  #endif
+}
+extension AttributeGraph.WeakAttribute : Swift.Hashable {
+  public static func == (a: AttributeGraph.WeakAttribute<Value>, b: AttributeGraph.WeakAttribute<Value>) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+extension AttributeGraph.WeakAttribute : Swift.CustomStringConvertible {
+  public var description: Swift.String {
+    get
+  }
+}
+extension AttributeGraph.AnyWeakAttribute {
+  #if compiler(>=5.3) && $NonescapableTypes
+  public init(_ attribute: AttributeGraph.AnyAttribute?)
+  #endif
+  public init<Value>(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
+  public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.WeakAttribute<Value>
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var attribute: AttributeGraph.AnyAttribute? {
+    get
+    set
+  }
+  #endif
+}
+extension AttributeGraph.AnyWeakAttribute : Swift.Hashable {
+  public static func == (lhs: AttributeGraph.AnyWeakAttribute, rhs: AttributeGraph.AnyWeakAttribute) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+extension AttributeGraph.AnyWeakAttribute : Swift.CustomStringConvertible {
+  @_alwaysEmitIntoClient public var description: Swift.String {
+    get { attribute?.description ?? "nil" }
+  }
+}
+public protocol Rule : AttributeGraph._AttributeBody {
+  associatedtype Value
+  #if compiler(>=5.3) && $NonescapableTypes
+  static var initialValue: Self.Value? { get }
+  #endif
+  var value: Self.Value { get }
+}
+extension AttributeGraph.Rule {
+  #if compiler(>=5.3) && $NonescapableTypes
+  public static var initialValue: Self.Value? {
+    get
+  }
+  #endif
+  public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AttributeGraph.AnyAttribute)
+  public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
+}
+extension AttributeGraph.Rule {
+  public var attribute: AttributeGraph.Attribute<Self.Value> {
+    get
+  }
+  public var context: AttributeGraph.RuleContext<Self.Value> {
+    get
+  }
+}
+extension AttributeGraph.Rule where Self : Swift.Hashable {
+  #if compiler(>=5.3) && $NonescapableTypes
+  public func cachedValue(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?) -> Self.Value
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public func cachedValueIfExists(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?) -> Self.Value?
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public static func _cachedValue(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?, hashValue: Swift.Int, bodyPtr: Swift.UnsafeRawPointer, update: () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void) -> Swift.UnsafePointer<Self.Value>
+  #endif
+}
+@frozen public struct Map<Source, Value> : AttributeGraph.Rule, Swift.CustomStringConvertible {
+  public var arg: AttributeGraph.Attribute<Source>
+  public let body: (Source) -> Value
+  public init(_ arg: AttributeGraph.Attribute<Source>, _ body: @escaping (Source) -> Value)
+  public var value: Value {
+    get
+  }
+  public static var flags: AttributeGraph.Map<Source, Value>.Flags {
+    get
+  }
+  public var description: Swift.String {
+    get
+  }
+}
+public protocol StatefulRule : AttributeGraph._AttributeBody {
+  associatedtype Value
+  #if compiler(>=5.3) && $NonescapableTypes
+  static var initialValue: Self.Value? { get }
+  #endif
+  mutating func updateValue()
+}
+extension AttributeGraph.StatefulRule {
+  #if compiler(>=5.3) && $NonescapableTypes
+  public static var initialValue: Self.Value? {
+    get
+  }
+  #endif
+  public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AttributeGraph.AnyAttribute)
+  public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
+}
+extension AttributeGraph.StatefulRule {
+  public var attribute: AttributeGraph.Attribute<Self.Value> {
+    get
+  }
+  public var context: AttributeGraph.RuleContext<Self.Value> {
+    get
+  }
+  public var value: Self.Value {
+    unsafeAddress
+    nonmutating set
+  }
+  public var hasValue: Swift.Bool {
+    get
+  }
+}
+@frozen public struct Focus<Root, Value> : AttributeGraph.Rule, Swift.CustomStringConvertible {
+  public var root: AttributeGraph.Attribute<Root>
+  public var keyPath: Swift.KeyPath<Root, Value>
+  public init(root: AttributeGraph.Attribute<Root>, keyPath: Swift.KeyPath<Root, Value>)
+  public var value: Value {
+    get
+  }
+  public static var flags: AttributeGraph.Focus<Root, Value>.Flags {
+    get
+  }
+  public var description: Swift.String {
+    get
+  }
+}
+@frozen @propertyWrapper @dynamicMemberLookup public struct OptionalAttribute<Value> {
+  public var base: AttributeGraph.AnyOptionalAttribute
+  public init()
+  public init(base: AttributeGraph.AnyOptionalAttribute)
+  public init(_ attribute: AttributeGraph.Attribute<Value>)
+  #if compiler(>=5.3) && $NonescapableTypes
+  public init(_ attribute: AttributeGraph.Attribute<Value>?)
+  #endif
+  public init(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var attribute: AttributeGraph.Attribute<Value>? {
+    get
+    set
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var value: Value? {
+    get
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public func map<V>(_ body: (AttributeGraph.Attribute<Value>) -> V) -> V?
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var wrappedValue: Value? {
+    get
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var projectedValue: AttributeGraph.Attribute<Value>? {
+    get
+    set
+    _modify
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
+    get
+  }
+  #endif
+}
+extension AttributeGraph.OptionalAttribute : Swift.Hashable {
+  public static func == (a: AttributeGraph.OptionalAttribute<Value>, b: AttributeGraph.OptionalAttribute<Value>) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+extension AttributeGraph.OptionalAttribute : Swift.CustomStringConvertible {
+  public var description: Swift.String {
+    get
+  }
+}
+@frozen public struct AnyOptionalAttribute {
+  public var identifier: AttributeGraph.AnyAttribute
+  public init()
+  public init(_ attribute: AttributeGraph.AnyAttribute)
+  #if compiler(>=5.3) && $NonescapableTypes
+  public init(_ attribute: AttributeGraph.AnyAttribute?)
+  #endif
+  public init<Value>(_ attribute: AttributeGraph.OptionalAttribute<Value>)
+  public static var current: AttributeGraph.AnyOptionalAttribute {
+    get
+  }
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var attribute: AttributeGraph.AnyAttribute? {
+    get
+    set
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public func map<Value>(_ body: (AttributeGraph.AnyAttribute) -> Value) -> Value?
+  #endif
+  public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.OptionalAttribute<Value>
+}
+extension AttributeGraph.AnyOptionalAttribute : Swift.Hashable {
+  public static func == (a: AttributeGraph.AnyOptionalAttribute, b: AttributeGraph.AnyOptionalAttribute) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+extension AttributeGraph.AnyOptionalAttribute : Swift.CustomStringConvertible {
+  public var description: Swift.String {
+    get
+  }
+}
 @frozen @propertyWrapper @dynamicMemberLookup public struct IndirectAttribute<Value> {
-  public let identifier: AnyAttribute
+  public let identifier: AttributeGraph.AnyAttribute
   public init(source: AttributeGraph.Attribute<Value>)
   public var source: AttributeGraph.Attribute<Value> {
     get
     nonmutating set
   }
-  public var dependency: AnyAttribute? {
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var dependency: AttributeGraph.AnyAttribute? {
     get
     nonmutating set
   }
+  #endif
   public var value: Value {
     get
     nonmutating set
     nonmutating _modify
   }
-  public func changedValue(options: AGValueOptions = []) -> (value: Value, changed: Swift.Bool)
+  public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)
   public var wrappedValue: Value {
     get
     nonmutating set
@@ -238,169 +509,25 @@ extension AttributeGraph.IndirectAttribute : Swift.Hashable {
     get
   }
 }
-@frozen public struct AnyOptionalAttribute {
-  public var identifier: AnyAttribute
-  public init()
-  public init(_ attribute: AnyAttribute)
-  public init(_ attribute: AnyAttribute?)
-  public init<Value>(_ attribute: AttributeGraph.OptionalAttribute<Value>)
-  public static var current: AttributeGraph.AnyOptionalAttribute {
-    get
-  }
-  public var attribute: AnyAttribute? {
-    get
-    set
-  }
-  public func map<Value>(_ body: (AnyAttribute) -> Value) -> Value?
-  public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.OptionalAttribute<Value>
-}
-extension AttributeGraph.AnyOptionalAttribute : Swift.Hashable {
-  public static func == (a: AttributeGraph.AnyOptionalAttribute, b: AttributeGraph.AnyOptionalAttribute) -> Swift.Bool
-  public func hash(into hasher: inout Swift.Hasher)
-  public var hashValue: Swift.Int {
-    get
-  }
-}
-extension AttributeGraph.AnyOptionalAttribute : Swift.CustomStringConvertible {
-  public var description: Swift.String {
-    get
-  }
-}
-@frozen @propertyWrapper @dynamicMemberLookup public struct OptionalAttribute<Value> {
-  public var base: AttributeGraph.AnyOptionalAttribute
-  public init()
-  public init(base: AttributeGraph.AnyOptionalAttribute)
-  public init(_ attribute: AttributeGraph.Attribute<Value>)
-  public init(_ attribute: AttributeGraph.Attribute<Value>?)
-  public init(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
-  public var attribute: AttributeGraph.Attribute<Value>? {
-    get
-    set
-  }
-  public var value: Value? {
-    get
-  }
-  public func changedValue(options: AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
-  public func map<V>(_ body: (AttributeGraph.Attribute<Value>) -> V) -> V?
-  public var wrappedValue: Value? {
-    get
-  }
-  public var projectedValue: AttributeGraph.Attribute<Value>? {
-    get
-    set
-    _modify
-  }
-  public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
-    get
-  }
-}
-extension AttributeGraph.OptionalAttribute : Swift.Hashable {
-  public static func == (a: AttributeGraph.OptionalAttribute<Value>, b: AttributeGraph.OptionalAttribute<Value>) -> Swift.Bool
-  public func hash(into hasher: inout Swift.Hasher)
-  public var hashValue: Swift.Int {
-    get
-  }
-}
-extension AttributeGraph.OptionalAttribute : Swift.CustomStringConvertible {
-  public var description: Swift.String {
-    get
-  }
-}
-@frozen public struct Focus<Root, Value> : AttributeGraph.Rule, Swift.CustomStringConvertible {
-  public var root: AttributeGraph.Attribute<Root>
-  public var keyPath: Swift.KeyPath<Root, Value>
-  public init(root: AttributeGraph.Attribute<Root>, keyPath: Swift.KeyPath<Root, Value>)
-  public var value: Value {
-    get
-  }
-  public static var flags: AttributeGraph.Focus<Root, Value>.Flags {
-    get
-  }
-  public var description: Swift.String {
-    get
-  }
-}
-@frozen public struct Map<Source, Value> : AttributeGraph.Rule, Swift.CustomStringConvertible {
-  public var arg: AttributeGraph.Attribute<Source>
-  public let body: (Source) -> Value
-  public init(_ arg: AttributeGraph.Attribute<Source>, _ body: @escaping (Source) -> Value)
-  public var value: Value {
-    get
-  }
-  public static var flags: AttributeGraph.Map<Source, Value>.Flags {
-    get
-  }
-  public var description: Swift.String {
-    get
-  }
-}
-public protocol Rule : AttributeGraph._AttributeBody {
-  associatedtype Value
-  static var initialValue: Self.Value? { get }
-  var value: Self.Value { get }
-}
-extension AttributeGraph.Rule {
-  public static var initialValue: Self.Value? {
-    get
-  }
-  public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AnyAttribute)
-  public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
-}
-extension AttributeGraph.Rule {
-  public var attribute: AttributeGraph.Attribute<Self.Value> {
-    get
-  }
-  public var context: AttributeGraph.RuleContext<Self.Value> {
-    get
-  }
-}
-extension AttributeGraph.Rule where Self : Swift.Hashable {
-  public func cachedValue(options: AGCachedValueOptions = [], owner: AnyAttribute?) -> Self.Value
-  public func cachedValueIfExists(options: AGCachedValueOptions = [], owner: AnyAttribute?) -> Self.Value?
-  public static func _cachedValue(options: AGCachedValueOptions = [], owner: AnyAttribute?, hashValue: Swift.Int, bodyPtr: Swift.UnsafeRawPointer, update: () -> (Swift.UnsafeMutableRawPointer, AnyAttribute) -> Swift.Void) -> Swift.UnsafePointer<Self.Value>
-}
-public protocol StatefulRule : AttributeGraph._AttributeBody {
-  associatedtype Value
-  static var initialValue: Self.Value? { get }
-  mutating func updateValue()
-}
-extension AttributeGraph.StatefulRule {
-  public static var initialValue: Self.Value? {
-    get
-  }
-  public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AnyAttribute)
-  public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
-}
-extension AttributeGraph.StatefulRule {
-  public var attribute: AttributeGraph.Attribute<Self.Value> {
-    get
-  }
-  public var context: AttributeGraph.RuleContext<Self.Value> {
-    get
-  }
-  public var value: Self.Value {
-    unsafeAddress
-    nonmutating set
-  }
-  public var hasValue: Swift.Bool {
-    get
-  }
-}
 @frozen public struct AnyRuleContext : Swift.Equatable {
-  public var attribute: AnyAttribute
-  public init(attribute: AnyAttribute)
+  public var attribute: AttributeGraph.AnyAttribute
+  public init(attribute: AttributeGraph.AnyAttribute)
   public init<V>(_ context: AttributeGraph.RuleContext<V>)
   public subscript<V>(attribute: AttributeGraph.Attribute<V>) -> V {
     unsafeAddress
   }
+  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(weakAttribute: AttributeGraph.WeakAttribute<V>) -> V? {
     get
   }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(optionalAttribute: AttributeGraph.OptionalAttribute<V>) -> V? {
     get
   }
-  public func valueAndFlags<V>(of input: AttributeGraph.Attribute<V>, options: AGValueOptions = []) -> (value: V, flags: AGChangedValueFlags)
-  public func changedValue<V>(of input: AttributeGraph.Attribute<V>, options: AGValueOptions = []) -> (value: V, changed: Swift.Bool)
+  #endif
+  public func valueAndFlags<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, flags: AttributeGraph.AGChangedValueFlags)
+  public func changedValue<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, changed: Swift.Bool)
   public func update(body: () -> Swift.Void)
   public func unsafeCast<V>(to _: V.Type) -> AttributeGraph.RuleContext<V>
   public static func == (a: AttributeGraph.AnyRuleContext, b: AttributeGraph.AnyRuleContext) -> Swift.Bool
@@ -411,12 +538,16 @@ extension AttributeGraph.StatefulRule {
   public subscript<V>(attribute: AttributeGraph.Attribute<V>) -> V {
     unsafeAddress
   }
+  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(weakAttribute: AttributeGraph.WeakAttribute<V>) -> V? {
     get
   }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(optionalAttribute: AttributeGraph.OptionalAttribute<V>) -> V? {
     get
   }
+  #endif
   public var value: Value {
     unsafeAddress
     nonmutating set
@@ -424,86 +555,41 @@ extension AttributeGraph.StatefulRule {
   public var hasValue: Swift.Bool {
     get
   }
-  public func valueAndFlags<V>(of input: AttributeGraph.Attribute<V>, options: AGValueOptions = []) -> (value: V, flags: AGChangedValueFlags)
-  public func changedValue<V>(of input: AttributeGraph.Attribute<V>, options: AGValueOptions = []) -> (value: V, changed: Swift.Bool)
+  public func valueAndFlags<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, flags: AttributeGraph.AGChangedValueFlags)
+  public func changedValue<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, changed: Swift.Bool)
   public func update(body: () -> Swift.Void)
   public static func == (a: AttributeGraph.RuleContext<Value>, b: AttributeGraph.RuleContext<Value>) -> Swift.Bool
 }
 @_silgen_name("AGGraphGetInputValue")
-@inline(__always) @inlinable internal func AGGraphGetInputValue<Value>(_ attribute: AnyAttribute, input: AnyAttribute, options: AGValueOptions = [], type: Value.Type = Value.self) -> AGValue
+@inline(__always) @inlinable internal func AGGraphGetInputValue<Value>(_ attribute: AttributeGraph.AnyAttribute, input: AttributeGraph.AnyAttribute, options: AttributeGraph.AGValueOptions = [], type: Value.Type = Value.self) -> AttributeGraph.AGValue
 @_silgen_name("AGGraphWithUpdate")
-@inline(__always) @inlinable internal func AGGraphWithUpdate(_ attribute: AnyAttribute, body: () -> Swift.Void)
-extension AnyWeakAttribute {
-  public init(_ attribute: AnyAttribute?)
-  public init<Value>(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
-  public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.WeakAttribute<Value>
-  public var attribute: AnyAttribute? {
-    get
-    set
-  }
+@inline(__always) @inlinable internal func AGGraphWithUpdate(_ attribute: AttributeGraph.AnyAttribute, body: () -> Swift.Void)
+extension AttributeGraph.Subgraph {
+  public typealias Flags = AttributeGraph.AnyAttribute.Flags
+  public typealias ChildFlags = AttributeGraph.AnyAttribute.Flags
 }
-extension AnyWeakAttribute : Swift.Hashable {
-  public static func == (lhs: AnyWeakAttribute, rhs: AnyWeakAttribute) -> Swift.Bool
-  public func hash(into hasher: inout Swift.Hasher)
-  public var hashValue: Swift.Int {
-    get
-  }
+extension AttributeGraph.Subgraph {
+  public func addObserver(_ observer: @escaping () -> Swift.Void) -> Swift.Int
+  public func apply<Value>(_ body: () -> Value) -> Value
+  public func forEach(_ flags: AttributeGraph.Subgraph.Flags, _ callback: (AttributeGraph.AnyAttribute) -> Swift.Void)
 }
-extension AnyWeakAttribute : Swift.CustomStringConvertible {
-  @_alwaysEmitIntoClient public var description: Swift.String {
-    get { attribute?.description ?? "nil" }
-  }
+extension AttributeGraph.Subgraph {
+  public static func beginTreeElement<Value>(value: AttributeGraph.Attribute<Value>, flags: Swift.UInt32)
+  public static func addTreeValue<Value>(_ value: AttributeGraph.Attribute<Value>, forKey key: Swift.UnsafePointer<Swift.Int8>, flags: Swift.UInt32)
+  public static func endTreeElement<Value>(value: AttributeGraph.Attribute<Value>)
 }
-@frozen @propertyWrapper @dynamicMemberLookup public struct WeakAttribute<Value> {
-  internal var base: AnyWeakAttribute
-  public init(base: AnyWeakAttribute)
-  public init()
-  public init(_ attribute: AttributeGraph.Attribute<Value>)
-  public init(_ attribute: AttributeGraph.Attribute<Value>?)
-  public var wrappedValue: Value? {
-    get
-  }
-  public var projectedValue: AttributeGraph.Attribute<Value>? {
-    get
-    set
-    _modify
-  }
-  public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
-    get
-  }
-  public var attribute: AttributeGraph.Attribute<Value>? {
-    get
-    set
-  }
-  public var value: Value? {
-    get
-  }
-  public func changedValue(options: AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
+extension AttributeGraph.Graph {
+  public static func typeIndex(ctx: AttributeGraph.GraphContext, body: any AttributeGraph._AttributeBody.Type, valueType: AttributeGraph.Metadata, flags: AttributeGraph._AttributeType.Flags, update: () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void) -> Swift.Int
 }
-extension AttributeGraph.WeakAttribute : Swift.Hashable {
-  public static func == (a: AttributeGraph.WeakAttribute<Value>, b: AttributeGraph.WeakAttribute<Value>) -> Swift.Bool
-  public func hash(into hasher: inout Swift.Hasher)
-  public var hashValue: Swift.Int {
-    get
-  }
-}
-extension AttributeGraph.WeakAttribute : Swift.CustomStringConvertible {
-  public var description: Swift.String {
-    get
-  }
-}
-extension Graph {
-  public static func typeIndex(ctx: GraphContext, body: any AttributeGraph._AttributeBody.Type, valueType: Metadata, flags: _AttributeType.Flags, update: () -> (Swift.UnsafeMutableRawPointer, AnyAttribute) -> Swift.Void) -> Swift.Int
-}
-extension Graph {
+extension AttributeGraph.Graph {
   public static func withoutUpdate<V>(_ body: () -> V) -> V
   public func withoutSubgraphInvalidation<V>(_ body: () -> V) -> V
   public func withDeadline<V>(_: Swift.UInt64, _: () -> V) -> V
-  public func onInvalidation(_ callback: @escaping (AnyAttribute) -> Swift.Void)
+  public func onInvalidation(_ callback: @escaping (AttributeGraph.AnyAttribute) -> Swift.Void)
   public func onUpdate(_ callback: @escaping () -> Swift.Void)
   public func withMainThreadHandler(_: (() -> Swift.Void) -> Swift.Void, do: () -> Swift.Void)
 }
-extension Graph {
+extension AttributeGraph.Graph {
   @_transparent public func startProfiling() {
         __AGGraphStartProfiling(self)
     }
@@ -517,46 +603,31 @@ extension Graph {
   public static func stopProfiling()
   public static func resetProfile()
 }
-extension Graph {
+extension AttributeGraph.Graph {
   @_transparent public var mainUpdates: Swift.Int {
     @_transparent get { numericCast(counter(for: .mainThreadUpdates)) }
   }
 }
-extension Graph {
+extension AttributeGraph.Graph {
+  #if compiler(>=5.3) && $NonescapableTypes
   @_silgen_name("AGGraphGetOutputValue")
   @inline(__always) @inlinable public static func outputValue<Value>() -> Swift.UnsafePointer<Value>?
+  #endif
   @_silgen_name("AGGraphSetOutputValue")
   @inline(__always) @inlinable public static func setOutputValue<Value>(_ value: Swift.UnsafePointer<Value>)
 }
-extension Graph {
-  @_transparent public static func anyInputsChanged(excluding excludedInputs: [AnyAttribute]) -> Swift.Bool {
+extension AttributeGraph.Graph {
+  @_transparent public static func anyInputsChanged(excluding excludedInputs: [AttributeGraph.AnyAttribute]) -> Swift.Bool {
         return __AGGraphAnyInputsChanged(excludedInputs, excludedInputs.count)
     }
 }
-extension Graph {
+extension AttributeGraph.Graph {
+  #if compiler(>=5.3) && $NonescapableTypes
   public func archiveJSON(name: Swift.String?)
-}
-extension Subgraph {
-  public typealias Flags = AnyAttribute.Flags
-  public typealias ChildFlags = AnyAttribute.Flags
-}
-extension Subgraph {
-  public func addObserver(_ observer: @escaping () -> Swift.Void) -> Swift.Int
-  public func apply<Value>(_ body: () -> Value) -> Value
-  public func forEach(_ flags: Subgraph.Flags, _ callback: (AnyAttribute) -> Swift.Void)
-}
-extension Subgraph {
-  public static func beginTreeElement<Value>(value: AttributeGraph.Attribute<Value>, flags: Swift.UInt32)
-  public static func addTreeValue<Value>(_ value: AttributeGraph.Attribute<Value>, forKey key: Swift.UnsafePointer<Swift.Int8>, flags: Swift.UInt32)
-  public static func endTreeElement<Value>(value: AttributeGraph.Attribute<Value>)
-}
-public func compareValues<Value>(_ lhs: Value, _ rhs: Value, mode: ComparisonMode = .equatableAlways) -> Swift.Bool
-public func compareValues<Value>(_ lhs: Value, _ rhs: Value, options: ComparisonOptions) -> Swift.Bool
-extension ComparisonOptions {
-  public init(mode: ComparisonMode)
+  #endif
 }
 public func forEachField(of type: any Any.Type, do body: (Swift.UnsafePointer<Swift.Int8>, Swift.Int, any Any.Type) -> Swift.Void)
-extension Metadata : Swift.Hashable, Swift.CustomStringConvertible {
+extension AttributeGraph.Metadata : Swift.Hashable, Swift.CustomStringConvertible {
   public init(_ type: any Any.Type)
   public var type: any Any.Type {
     get
@@ -564,16 +635,12 @@ extension Metadata : Swift.Hashable, Swift.CustomStringConvertible {
   public var description: Swift.String {
     get
   }
-  public func forEachField(options: Metadata.ApplyOptions, do body: (Swift.UnsafePointer<Swift.Int8>, Swift.Int, any Any.Type) -> Swift.Bool) -> Swift.Bool
+  public func forEachField(options: AttributeGraph.Metadata.ApplyOptions, do body: (Swift.UnsafePointer<Swift.Int8>, Swift.Int, any Any.Type) -> Swift.Bool) -> Swift.Bool
 }
-extension Signature : Swift.Equatable {
-  public static func == (lhs: Signature, rhs: Signature) -> Swift.Bool
+extension AttributeGraph.Signature : Swift.Equatable {
+  public static func == (lhs: AttributeGraph.Signature, rhs: AttributeGraph.Signature) -> Swift.Bool
 }
-@discardableResult
-public func withUnsafePointerToEnumCase<T>(of value: Swift.UnsafeMutablePointer<T>, do body: (Swift.Int, any Any.Type, Swift.UnsafeRawPointer) -> ()) -> Swift.Bool
-@discardableResult
-public func withUnsafeMutablePointerToEnumCase<T>(of value: Swift.UnsafeMutablePointer<T>, do body: (Swift.Int, any Any.Type, Swift.UnsafeMutableRawPointer) -> ()) -> Swift.Bool
-extension TupleType {
+extension AttributeGraph.TupleType {
   @_transparent public init(_ types: [any Any.Type]) {
         self.init(count: types.count, elements: types.map(Metadata.init))
     }
@@ -597,16 +664,16 @@ extension TupleType {
   @_transparent public func offset<T>(at index: Swift.Int, as type: T.Type) -> Swift.Int {
         elementOffset(at: index, type: Metadata(type))
     }
-  @_transparent public func setElement<T>(in tupleValue: Swift.UnsafeMutableRawPointer, at index: Swift.Int, from srcValue: Swift.UnsafePointer<T>, options: TupleType.CopyOptions) {
+  @_transparent public func setElement<T>(in tupleValue: Swift.UnsafeMutableRawPointer, at index: Swift.Int, from srcValue: Swift.UnsafePointer<T>, options: AttributeGraph.TupleType.CopyOptions) {
         __AGTupleSetElement(self, tupleValue, index, srcValue, Metadata(T.self), options)
     }
-  @_transparent public func getElement<T>(in tupleValue: Swift.UnsafeMutableRawPointer, at index: Swift.Int, to dstValue: Swift.UnsafeMutablePointer<T>, options: TupleType.CopyOptions) {
+  @_transparent public func getElement<T>(in tupleValue: Swift.UnsafeMutableRawPointer, at index: Swift.Int, to dstValue: Swift.UnsafeMutablePointer<T>, options: AttributeGraph.TupleType.CopyOptions) {
         __AGTupleGetElement(self, tupleValue, index, dstValue, Metadata(T.self), options)
     }
 }
 @_silgen_name("AGTupleWithBuffer")
-public func withUnsafeTuple(of type: TupleType, count: Swift.Int, _ body: (UnsafeMutableTuple) -> Swift.Void)
-extension UnsafeTuple {
+public func withUnsafeTuple(of type: AttributeGraph.TupleType, count: Swift.Int, _ body: (AttributeGraph.UnsafeMutableTuple) -> Swift.Void)
+extension AttributeGraph.UnsafeTuple {
   @_transparent public var count: Swift.Int {
     @_transparent get { type.count }
   }
@@ -633,8 +700,8 @@ extension UnsafeTuple {
     @_transparent unsafeAddress { address(of: index, as: T.self) }
   }
 }
-extension UnsafeMutableTuple {
-  @_transparent public init(with tupleType: TupleType) {
+extension AttributeGraph.UnsafeMutableTuple {
+  @_transparent public init(with tupleType: AttributeGraph.TupleType) {
         self.init(
             type: tupleType,
             value: UnsafeMutableRawPointer.allocate(
@@ -688,21 +755,30 @@ extension UnsafeMutableTuple {
     @_transparent nonmutating unsafeMutableAddress { address(of: index, as: T.self) }
   }
 }
-extension AttributeGraph.Attribute : Swift.Sendable {}
-extension AttributeGraph.Attribute : Swift.BitwiseCopyable {}
-extension AttributeGraph.External : Swift.Sendable {}
-extension AttributeGraph.External : Swift.BitwiseCopyable {}
+@discardableResult
+public func withUnsafePointerToEnumCase<T>(of value: Swift.UnsafeMutablePointer<T>, do body: (Swift.Int, any Any.Type, Swift.UnsafeRawPointer) -> ()) -> Swift.Bool
+@discardableResult
+public func withUnsafeMutablePointerToEnumCase<T>(of value: Swift.UnsafeMutablePointer<T>, do body: (Swift.Int, any Any.Type, Swift.UnsafeMutableRawPointer) -> ()) -> Swift.Bool
+public func compareValues<Value>(_ lhs: Value, _ rhs: Value, mode: AttributeGraph.ComparisonMode = .equatableAlways) -> Swift.Bool
+public func compareValues<Value>(_ lhs: Value, _ rhs: Value, options: AttributeGraph.ComparisonOptions) -> Swift.Bool
+extension AttributeGraph.ComparisonOptions {
+  public init(mode: AttributeGraph.ComparisonMode)
+}
 extension AttributeGraph.PointerOffset : Swift.Sendable {}
 extension AttributeGraph.PointerOffset : Swift.BitwiseCopyable {}
-extension AttributeGraph.IndirectAttribute : Swift.Sendable {}
-extension AttributeGraph.IndirectAttribute : Swift.BitwiseCopyable {}
-extension AttributeGraph.AnyOptionalAttribute : Swift.Sendable {}
-extension AttributeGraph.AnyOptionalAttribute : Swift.BitwiseCopyable {}
+extension AttributeGraph.External : Swift.Sendable {}
+extension AttributeGraph.External : Swift.BitwiseCopyable {}
+extension AttributeGraph.Attribute : Swift.Sendable {}
+extension AttributeGraph.Attribute : Swift.BitwiseCopyable {}
+extension AttributeGraph.WeakAttribute : Swift.Sendable {}
+extension AttributeGraph.WeakAttribute : Swift.BitwiseCopyable {}
 extension AttributeGraph.OptionalAttribute : Swift.Sendable {}
 extension AttributeGraph.OptionalAttribute : Swift.BitwiseCopyable {}
+extension AttributeGraph.AnyOptionalAttribute : Swift.Sendable {}
+extension AttributeGraph.AnyOptionalAttribute : Swift.BitwiseCopyable {}
+extension AttributeGraph.IndirectAttribute : Swift.Sendable {}
+extension AttributeGraph.IndirectAttribute : Swift.BitwiseCopyable {}
 extension AttributeGraph.AnyRuleContext : Swift.Sendable {}
 extension AttributeGraph.AnyRuleContext : Swift.BitwiseCopyable {}
 extension AttributeGraph.RuleContext : Swift.Sendable {}
 extension AttributeGraph.RuleContext : Swift.BitwiseCopyable {}
-extension AttributeGraph.WeakAttribute : Swift.Sendable {}
-extension AttributeGraph.WeakAttribute : Swift.BitwiseCopyable {}

--- a/AG/2024/AttributeGraph.xcframework/xros-arm64-x86_64-simulator/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/x86_64-apple-xros-simulator.swiftinterface
+++ b/AG/2024/AttributeGraph.xcframework/xros-arm64-x86_64-simulator/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/x86_64-apple-xros-simulator.swiftinterface
@@ -10,11 +10,9 @@ public import _SwiftConcurrencyShims
 extension AttributeGraph.AnyAttribute {
   public init<Value>(_ attribute: AttributeGraph.Attribute<Value>)
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.Attribute<Value>
-  #if compiler(>=5.3) && $NonescapableTypes
   public static var current: AttributeGraph.AnyAttribute? {
     get
   }
-  #endif
   public func unsafeOffset(at offset: Swift.Int) -> AttributeGraph.AnyAttribute
   public func setFlags(_ newFlags: AttributeGraph.AnyAttribute.Flags, mask: AttributeGraph.AnyAttribute.Flags)
   public func addInput(_ attribute: AttributeGraph.AnyAttribute, options: AttributeGraph.AGInputOptions = [], token: Swift.Int)
@@ -31,12 +29,10 @@ extension AttributeGraph.AnyAttribute {
   public var valueType: any Any.Type {
     get
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public var indirectDependency: AttributeGraph.AnyAttribute? {
     get
     nonmutating set
   }
-  #endif
 }
 extension AttributeGraph.AnyAttribute : Swift.CustomStringConvertible {
   @inlinable public var description: Swift.String {
@@ -95,9 +91,7 @@ extension AttributeGraph.External : Swift.CustomStringConvertible {
   public init(_ attribute: AttributeGraph.Attribute<Value>)
   public init(value: Value)
   public init(type _: Value.Type)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init<Body>(body: Swift.UnsafePointer<Body>, value: Swift.UnsafePointer<Value>?, flags: AttributeGraph._AttributeType.Flags = [], update: () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void) where Body : AttributeGraph._AttributeBody
-  #endif
   public var wrappedValue: Value {
     unsafeAddress
     nonmutating set
@@ -169,10 +163,8 @@ extension AttributeGraph.Attribute {
   public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.Rule
   public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.StatefulRule
 }
-#if compiler(>=5.3) && $NonescapableTypes
 @_silgen_name("AGGraphCreateAttribute")
 @inline(__always) @inlinable internal func AGGraphCreateAttribute(index: Swift.Int, body: Swift.UnsafeRawPointer, value: Swift.UnsafeRawPointer?) -> AttributeGraph.AnyAttribute
-#endif
 @_silgen_name("AGGraphGetValue")
 @inline(__always) @inlinable internal func AGGraphGetValue<Value>(_ attribute: AttributeGraph.AnyAttribute, options: AttributeGraph.AGValueOptions = [], type: Value.Type = Value.self) -> AttributeGraph.AGValue
 @_silgen_name("AGGraphSetValue")
@@ -215,40 +207,26 @@ extension AttributeGraph._AttributeBody {
   public init(base: AttributeGraph.AnyWeakAttribute)
   public init()
   public init(_ attribute: AttributeGraph.Attribute<Value>)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.Attribute<Value>?)
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var wrappedValue: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var projectedValue: AttributeGraph.Attribute<Value>? {
     get
     set
     _modify
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.Attribute<Value>? {
     get
     set
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var value: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
-  #endif
 }
 extension AttributeGraph.WeakAttribute : Swift.Hashable {
   public static func == (a: AttributeGraph.WeakAttribute<Value>, b: AttributeGraph.WeakAttribute<Value>) -> Swift.Bool
@@ -263,17 +241,13 @@ extension AttributeGraph.WeakAttribute : Swift.CustomStringConvertible {
   }
 }
 extension AttributeGraph.AnyWeakAttribute {
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.AnyAttribute?)
-  #endif
   public init<Value>(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.WeakAttribute<Value>
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.AnyAttribute? {
     get
     set
   }
-  #endif
 }
 extension AttributeGraph.AnyWeakAttribute : Swift.Hashable {
   public static func == (lhs: AttributeGraph.AnyWeakAttribute, rhs: AttributeGraph.AnyWeakAttribute) -> Swift.Bool
@@ -289,17 +263,13 @@ extension AttributeGraph.AnyWeakAttribute : Swift.CustomStringConvertible {
 }
 public protocol Rule : AttributeGraph._AttributeBody {
   associatedtype Value
-  #if compiler(>=5.3) && $NonescapableTypes
   static var initialValue: Self.Value? { get }
-  #endif
   var value: Self.Value { get }
 }
 extension AttributeGraph.Rule {
-  #if compiler(>=5.3) && $NonescapableTypes
   public static var initialValue: Self.Value? {
     get
   }
-  #endif
   public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AttributeGraph.AnyAttribute)
   public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
 }
@@ -312,15 +282,9 @@ extension AttributeGraph.Rule {
   }
 }
 extension AttributeGraph.Rule where Self : Swift.Hashable {
-  #if compiler(>=5.3) && $NonescapableTypes
   public func cachedValue(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?) -> Self.Value
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func cachedValueIfExists(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?) -> Self.Value?
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public static func _cachedValue(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?, hashValue: Swift.Int, bodyPtr: Swift.UnsafeRawPointer, update: () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void) -> Swift.UnsafePointer<Self.Value>
-  #endif
 }
 @frozen public struct Map<Source, Value> : AttributeGraph.Rule, Swift.CustomStringConvertible {
   public var arg: AttributeGraph.Attribute<Source>
@@ -338,17 +302,13 @@ extension AttributeGraph.Rule where Self : Swift.Hashable {
 }
 public protocol StatefulRule : AttributeGraph._AttributeBody {
   associatedtype Value
-  #if compiler(>=5.3) && $NonescapableTypes
   static var initialValue: Self.Value? { get }
-  #endif
   mutating func updateValue()
 }
 extension AttributeGraph.StatefulRule {
-  #if compiler(>=5.3) && $NonescapableTypes
   public static var initialValue: Self.Value? {
     get
   }
-  #endif
   public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AttributeGraph.AnyAttribute)
   public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
 }
@@ -386,44 +346,28 @@ extension AttributeGraph.StatefulRule {
   public init()
   public init(base: AttributeGraph.AnyOptionalAttribute)
   public init(_ attribute: AttributeGraph.Attribute<Value>)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.Attribute<Value>?)
-  #endif
   public init(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.Attribute<Value>? {
     get
     set
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var value: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func map<V>(_ body: (AttributeGraph.Attribute<Value>) -> V) -> V?
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var wrappedValue: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var projectedValue: AttributeGraph.Attribute<Value>? {
     get
     set
     _modify
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
     get
   }
-  #endif
 }
 extension AttributeGraph.OptionalAttribute : Swift.Hashable {
   public static func == (a: AttributeGraph.OptionalAttribute<Value>, b: AttributeGraph.OptionalAttribute<Value>) -> Swift.Bool
@@ -441,22 +385,16 @@ extension AttributeGraph.OptionalAttribute : Swift.CustomStringConvertible {
   public var identifier: AttributeGraph.AnyAttribute
   public init()
   public init(_ attribute: AttributeGraph.AnyAttribute)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.AnyAttribute?)
-  #endif
   public init<Value>(_ attribute: AttributeGraph.OptionalAttribute<Value>)
   public static var current: AttributeGraph.AnyOptionalAttribute {
     get
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.AnyAttribute? {
     get
     set
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func map<Value>(_ body: (AttributeGraph.AnyAttribute) -> Value) -> Value?
-  #endif
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.OptionalAttribute<Value>
 }
 extension AttributeGraph.AnyOptionalAttribute : Swift.Hashable {
@@ -478,12 +416,10 @@ extension AttributeGraph.AnyOptionalAttribute : Swift.CustomStringConvertible {
     get
     nonmutating set
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public var dependency: AttributeGraph.AnyAttribute? {
     get
     nonmutating set
   }
-  #endif
   public var value: Value {
     get
     nonmutating set
@@ -516,16 +452,12 @@ extension AttributeGraph.IndirectAttribute : Swift.Hashable {
   public subscript<V>(attribute: AttributeGraph.Attribute<V>) -> V {
     unsafeAddress
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(weakAttribute: AttributeGraph.WeakAttribute<V>) -> V? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(optionalAttribute: AttributeGraph.OptionalAttribute<V>) -> V? {
     get
   }
-  #endif
   public func valueAndFlags<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, flags: AttributeGraph.AGChangedValueFlags)
   public func changedValue<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, changed: Swift.Bool)
   public func update(body: () -> Swift.Void)
@@ -538,16 +470,12 @@ extension AttributeGraph.IndirectAttribute : Swift.Hashable {
   public subscript<V>(attribute: AttributeGraph.Attribute<V>) -> V {
     unsafeAddress
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(weakAttribute: AttributeGraph.WeakAttribute<V>) -> V? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(optionalAttribute: AttributeGraph.OptionalAttribute<V>) -> V? {
     get
   }
-  #endif
   public var value: Value {
     unsafeAddress
     nonmutating set
@@ -609,10 +537,8 @@ extension AttributeGraph.Graph {
   }
 }
 extension AttributeGraph.Graph {
-  #if compiler(>=5.3) && $NonescapableTypes
   @_silgen_name("AGGraphGetOutputValue")
   @inline(__always) @inlinable public static func outputValue<Value>() -> Swift.UnsafePointer<Value>?
-  #endif
   @_silgen_name("AGGraphSetOutputValue")
   @inline(__always) @inlinable public static func setOutputValue<Value>(_ value: Swift.UnsafePointer<Value>)
 }
@@ -622,9 +548,7 @@ extension AttributeGraph.Graph {
     }
 }
 extension AttributeGraph.Graph {
-  #if compiler(>=5.3) && $NonescapableTypes
   public func archiveJSON(name: Swift.String?)
-  #endif
 }
 public func forEachField(of type: any Any.Type, do body: (Swift.UnsafePointer<Swift.Int8>, Swift.Int, any Any.Type) -> Swift.Void)
 extension AttributeGraph.Metadata : Swift.Hashable, Swift.CustomStringConvertible {

--- a/AG/2024/Sources/Modules/AttributeGraph.swiftmodule/template.swiftinterface
+++ b/AG/2024/Sources/Modules/AttributeGraph.swiftmodule/template.swiftinterface
@@ -6,11 +6,9 @@ public import _SwiftConcurrencyShims
 extension AttributeGraph.AnyAttribute {
   public init<Value>(_ attribute: AttributeGraph.Attribute<Value>)
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.Attribute<Value>
-  #if compiler(>=5.3) && $NonescapableTypes
   public static var current: AttributeGraph.AnyAttribute? {
     get
   }
-  #endif
   public func unsafeOffset(at offset: Swift.Int) -> AttributeGraph.AnyAttribute
   public func setFlags(_ newFlags: AttributeGraph.AnyAttribute.Flags, mask: AttributeGraph.AnyAttribute.Flags)
   public func addInput(_ attribute: AttributeGraph.AnyAttribute, options: AttributeGraph.AGInputOptions = [], token: Swift.Int)
@@ -27,12 +25,10 @@ extension AttributeGraph.AnyAttribute {
   public var valueType: any Any.Type {
     get
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public var indirectDependency: AttributeGraph.AnyAttribute? {
     get
     nonmutating set
   }
-  #endif
 }
 extension AttributeGraph.AnyAttribute : Swift.CustomStringConvertible {
   @inlinable public var description: Swift.String {
@@ -91,9 +87,7 @@ extension AttributeGraph.External : Swift.CustomStringConvertible {
   public init(_ attribute: AttributeGraph.Attribute<Value>)
   public init(value: Value)
   public init(type _: Value.Type)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init<Body>(body: Swift.UnsafePointer<Body>, value: Swift.UnsafePointer<Value>?, flags: AttributeGraph._AttributeType.Flags = [], update: () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void) where Body : AttributeGraph._AttributeBody
-  #endif
   public var wrappedValue: Value {
     unsafeAddress
     nonmutating set
@@ -165,10 +159,8 @@ extension AttributeGraph.Attribute {
   public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.Rule
   public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.StatefulRule
 }
-#if compiler(>=5.3) && $NonescapableTypes
 @_silgen_name("AGGraphCreateAttribute")
 @inline(__always) @inlinable internal func AGGraphCreateAttribute(index: Swift.Int, body: Swift.UnsafeRawPointer, value: Swift.UnsafeRawPointer?) -> AttributeGraph.AnyAttribute
-#endif
 @_silgen_name("AGGraphGetValue")
 @inline(__always) @inlinable internal func AGGraphGetValue<Value>(_ attribute: AttributeGraph.AnyAttribute, options: AttributeGraph.AGValueOptions = [], type: Value.Type = Value.self) -> AttributeGraph.AGValue
 @_silgen_name("AGGraphSetValue")
@@ -211,40 +203,26 @@ extension AttributeGraph._AttributeBody {
   public init(base: AttributeGraph.AnyWeakAttribute)
   public init()
   public init(_ attribute: AttributeGraph.Attribute<Value>)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.Attribute<Value>?)
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var wrappedValue: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var projectedValue: AttributeGraph.Attribute<Value>? {
     get
     set
     _modify
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.Attribute<Value>? {
     get
     set
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var value: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
-  #endif
 }
 extension AttributeGraph.WeakAttribute : Swift.Hashable {
   public static func == (a: AttributeGraph.WeakAttribute<Value>, b: AttributeGraph.WeakAttribute<Value>) -> Swift.Bool
@@ -259,17 +237,13 @@ extension AttributeGraph.WeakAttribute : Swift.CustomStringConvertible {
   }
 }
 extension AttributeGraph.AnyWeakAttribute {
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.AnyAttribute?)
-  #endif
   public init<Value>(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.WeakAttribute<Value>
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.AnyAttribute? {
     get
     set
   }
-  #endif
 }
 extension AttributeGraph.AnyWeakAttribute : Swift.Hashable {
   public static func == (lhs: AttributeGraph.AnyWeakAttribute, rhs: AttributeGraph.AnyWeakAttribute) -> Swift.Bool
@@ -285,17 +259,13 @@ extension AttributeGraph.AnyWeakAttribute : Swift.CustomStringConvertible {
 }
 public protocol Rule : AttributeGraph._AttributeBody {
   associatedtype Value
-  #if compiler(>=5.3) && $NonescapableTypes
   static var initialValue: Self.Value? { get }
-  #endif
   var value: Self.Value { get }
 }
 extension AttributeGraph.Rule {
-  #if compiler(>=5.3) && $NonescapableTypes
   public static var initialValue: Self.Value? {
     get
   }
-  #endif
   public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AttributeGraph.AnyAttribute)
   public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
 }
@@ -308,15 +278,9 @@ extension AttributeGraph.Rule {
   }
 }
 extension AttributeGraph.Rule where Self : Swift.Hashable {
-  #if compiler(>=5.3) && $NonescapableTypes
   public func cachedValue(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?) -> Self.Value
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func cachedValueIfExists(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?) -> Self.Value?
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public static func _cachedValue(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?, hashValue: Swift.Int, bodyPtr: Swift.UnsafeRawPointer, update: () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void) -> Swift.UnsafePointer<Self.Value>
-  #endif
 }
 @frozen public struct Map<Source, Value> : AttributeGraph.Rule, Swift.CustomStringConvertible {
   public var arg: AttributeGraph.Attribute<Source>
@@ -334,17 +298,13 @@ extension AttributeGraph.Rule where Self : Swift.Hashable {
 }
 public protocol StatefulRule : AttributeGraph._AttributeBody {
   associatedtype Value
-  #if compiler(>=5.3) && $NonescapableTypes
   static var initialValue: Self.Value? { get }
-  #endif
   mutating func updateValue()
 }
 extension AttributeGraph.StatefulRule {
-  #if compiler(>=5.3) && $NonescapableTypes
   public static var initialValue: Self.Value? {
     get
   }
-  #endif
   public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AttributeGraph.AnyAttribute)
   public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
 }
@@ -382,44 +342,28 @@ extension AttributeGraph.StatefulRule {
   public init()
   public init(base: AttributeGraph.AnyOptionalAttribute)
   public init(_ attribute: AttributeGraph.Attribute<Value>)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.Attribute<Value>?)
-  #endif
   public init(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.Attribute<Value>? {
     get
     set
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var value: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func map<V>(_ body: (AttributeGraph.Attribute<Value>) -> V) -> V?
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var wrappedValue: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var projectedValue: AttributeGraph.Attribute<Value>? {
     get
     set
     _modify
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
     get
   }
-  #endif
 }
 extension AttributeGraph.OptionalAttribute : Swift.Hashable {
   public static func == (a: AttributeGraph.OptionalAttribute<Value>, b: AttributeGraph.OptionalAttribute<Value>) -> Swift.Bool
@@ -437,22 +381,16 @@ extension AttributeGraph.OptionalAttribute : Swift.CustomStringConvertible {
   public var identifier: AttributeGraph.AnyAttribute
   public init()
   public init(_ attribute: AttributeGraph.AnyAttribute)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.AnyAttribute?)
-  #endif
   public init<Value>(_ attribute: AttributeGraph.OptionalAttribute<Value>)
   public static var current: AttributeGraph.AnyOptionalAttribute {
     get
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.AnyAttribute? {
     get
     set
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func map<Value>(_ body: (AttributeGraph.AnyAttribute) -> Value) -> Value?
-  #endif
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.OptionalAttribute<Value>
 }
 extension AttributeGraph.AnyOptionalAttribute : Swift.Hashable {
@@ -474,12 +412,10 @@ extension AttributeGraph.AnyOptionalAttribute : Swift.CustomStringConvertible {
     get
     nonmutating set
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public var dependency: AttributeGraph.AnyAttribute? {
     get
     nonmutating set
   }
-  #endif
   public var value: Value {
     get
     nonmutating set
@@ -512,16 +448,12 @@ extension AttributeGraph.IndirectAttribute : Swift.Hashable {
   public subscript<V>(attribute: AttributeGraph.Attribute<V>) -> V {
     unsafeAddress
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(weakAttribute: AttributeGraph.WeakAttribute<V>) -> V? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(optionalAttribute: AttributeGraph.OptionalAttribute<V>) -> V? {
     get
   }
-  #endif
   public func valueAndFlags<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, flags: AttributeGraph.AGChangedValueFlags)
   public func changedValue<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, changed: Swift.Bool)
   public func update(body: () -> Swift.Void)
@@ -534,16 +466,12 @@ extension AttributeGraph.IndirectAttribute : Swift.Hashable {
   public subscript<V>(attribute: AttributeGraph.Attribute<V>) -> V {
     unsafeAddress
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(weakAttribute: AttributeGraph.WeakAttribute<V>) -> V? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(optionalAttribute: AttributeGraph.OptionalAttribute<V>) -> V? {
     get
   }
-  #endif
   public var value: Value {
     unsafeAddress
     nonmutating set
@@ -605,10 +533,8 @@ extension AttributeGraph.Graph {
   }
 }
 extension AttributeGraph.Graph {
-  #if compiler(>=5.3) && $NonescapableTypes
   @_silgen_name("AGGraphGetOutputValue")
   @inline(__always) @inlinable public static func outputValue<Value>() -> Swift.UnsafePointer<Value>?
-  #endif
   @_silgen_name("AGGraphSetOutputValue")
   @inline(__always) @inlinable public static func setOutputValue<Value>(_ value: Swift.UnsafePointer<Value>)
 }
@@ -618,9 +544,7 @@ extension AttributeGraph.Graph {
     }
 }
 extension AttributeGraph.Graph {
-  #if compiler(>=5.3) && $NonescapableTypes
   public func archiveJSON(name: Swift.String?)
-  #endif
 }
 public func forEachField(of type: any Any.Type, do body: (Swift.UnsafePointer<Swift.Int8>, Swift.Int, any Any.Type) -> Swift.Void)
 extension AttributeGraph.Metadata : Swift.Hashable, Swift.CustomStringConvertible {

--- a/AG/2024/Sources/Modules/AttributeGraph.swiftmodule/template.swiftinterface
+++ b/AG/2024/Sources/Modules/AttributeGraph.swiftmodule/template.swiftinterface
@@ -3,19 +3,21 @@ public import Swift
 public import _Concurrency
 public import _StringProcessing
 public import _SwiftConcurrencyShims
-extension AnyAttribute {
+extension AttributeGraph.AnyAttribute {
   public init<Value>(_ attribute: AttributeGraph.Attribute<Value>)
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.Attribute<Value>
-  public static var current: AnyAttribute? {
+  #if compiler(>=5.3) && $NonescapableTypes
+  public static var current: AttributeGraph.AnyAttribute? {
     get
   }
-  public func unsafeOffset(at offset: Swift.Int) -> AnyAttribute
-  public func setFlags(_ newFlags: AnyAttribute.Flags, mask: AnyAttribute.Flags)
-  public func addInput(_ attribute: AnyAttribute, options: AGInputOptions = [], token: Swift.Int)
-  public func addInput<Value>(_ attribute: AttributeGraph.Attribute<Value>, options: AGInputOptions = [], token: Swift.Int)
+  #endif
+  public func unsafeOffset(at offset: Swift.Int) -> AttributeGraph.AnyAttribute
+  public func setFlags(_ newFlags: AttributeGraph.AnyAttribute.Flags, mask: AttributeGraph.AnyAttribute.Flags)
+  public func addInput(_ attribute: AttributeGraph.AnyAttribute, options: AttributeGraph.AGInputOptions = [], token: Swift.Int)
+  public func addInput<Value>(_ attribute: AttributeGraph.Attribute<Value>, options: AttributeGraph.AGInputOptions = [], token: Swift.Int)
   public func visitBody<Body>(_ visitor: inout Body) where Body : AttributeGraph.AttributeBodyVisitor
   public func mutateBody<Value>(as type: Value.Type, invalidating: Swift.Bool, _ body: (inout Value) -> Swift.Void)
-  public func breadthFirstSearch(options _: SearchOptions = [], _: (AnyAttribute) -> Swift.Bool) -> Swift.Bool
+  public func breadthFirstSearch(options _: AttributeGraph.SearchOptions = [], _: (AttributeGraph.AnyAttribute) -> Swift.Bool) -> Swift.Bool
   public var _bodyType: any Any.Type {
     get
   }
@@ -25,118 +27,19 @@ extension AnyAttribute {
   public var valueType: any Any.Type {
     get
   }
-  public var indirectDependency: AnyAttribute? {
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var indirectDependency: AttributeGraph.AnyAttribute? {
     get
     nonmutating set
   }
+  #endif
 }
-extension AnyAttribute : Swift.CustomStringConvertible {
+extension AttributeGraph.AnyAttribute : Swift.CustomStringConvertible {
   @inlinable public var description: Swift.String {
     get { "#\(rawValue)" }
   }
 }
-public typealias AttributeUpdateBlock = () -> (Swift.UnsafeMutableRawPointer, AnyAttribute) -> Swift.Void
-@frozen @propertyWrapper @dynamicMemberLookup public struct Attribute<Value> {
-  public var identifier: AnyAttribute
-  public init(identifier: AnyAttribute)
-  public init(_ attribute: AttributeGraph.Attribute<Value>)
-  public init(value: Value)
-  public init(type _: Value.Type)
-  public init<Body>(body: Swift.UnsafePointer<Body>, value: Swift.UnsafePointer<Value>?, flags: _AttributeType.Flags = [], update: () -> (Swift.UnsafeMutableRawPointer, AnyAttribute) -> Swift.Void) where Body : AttributeGraph._AttributeBody
-  public var wrappedValue: Value {
-    unsafeAddress
-    nonmutating set
-  }
-  public var projectedValue: AttributeGraph.Attribute<Value> {
-    get
-    set
-  }
-  public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member> {
-    get
-  }
-  public subscript<Member>(keyPath keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member> {
-    get
-  }
-  public subscript<Member>(offset body: (inout Value) -> AttributeGraph.PointerOffset<Value, Member>) -> AttributeGraph.Attribute<Member> {
-    get
-  }
-  public func unsafeCast<V>(to type: V.Type) -> AttributeGraph.Attribute<V>
-  public func unsafeOffset<Member>(at offset: Swift.Int, as _: Member.Type) -> AttributeGraph.Attribute<Member>
-  public func applying<Member>(offset: AttributeGraph.PointerOffset<Value, Member>) -> AttributeGraph.Attribute<Member>
-  public func visitBody<Body>(_ visitor: inout Body) where Body : AttributeGraph.AttributeBodyVisitor
-  public func mutateBody<V>(as type: V.Type, invalidating: Swift.Bool, _ body: (inout V) -> Swift.Void)
-  public func breadthFirstSearch(options: SearchOptions = [], _ body: (AnyAttribute) -> Swift.Bool) -> Swift.Bool
-  public var graph: Graph {
-    get
-  }
-  public var subgraph: Subgraph {
-    get
-  }
-  public var value: Value {
-    unsafeAddress
-    nonmutating set
-  }
-  public var valueState: ValueState {
-    get
-  }
-  public func valueAndFlags(options: AGValueOptions = []) -> (value: Value, flags: AGChangedValueFlags)
-  public func changedValue(options: AGValueOptions = []) -> (value: Value, changed: Swift.Bool)
-  public func setValue(_ value: Value) -> Swift.Bool
-  public var hasValue: Swift.Bool {
-    get
-  }
-  public func updateValue()
-  public func prefetchValue()
-  public func invalidateValue()
-  public func validate()
-  public func addInput(_ attribute: AnyAttribute, options: AGInputOptions = [], token: Swift.Int)
-  public func addInput<V>(_ attribute: AttributeGraph.Attribute<V>, options: AGInputOptions = [], token: Swift.Int)
-  public typealias Flags = AnyAttribute.Flags
-  public var flags: AttributeGraph.Attribute<Value>.Flags {
-    get
-    nonmutating set
-  }
-  public func setFlags(_ newFlags: AttributeGraph.Attribute<Value>.Flags, mask: AttributeGraph.Attribute<Value>.Flags)
-}
-extension AttributeGraph.Attribute : Swift.Hashable {
-  public static func == (a: AttributeGraph.Attribute<Value>, b: AttributeGraph.Attribute<Value>) -> Swift.Bool
-  public func hash(into hasher: inout Swift.Hasher)
-  public var hashValue: Swift.Int {
-    get
-  }
-}
-extension AttributeGraph.Attribute : Swift.CustomStringConvertible {
-  public var description: Swift.String {
-    get
-  }
-}
-extension AttributeGraph.Attribute {
-  public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.Rule
-  public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.StatefulRule
-}
-@_silgen_name("AGGraphCreateAttribute")
-@inline(__always) @inlinable internal func AGGraphCreateAttribute(index: Swift.Int, body: Swift.UnsafeRawPointer, value: Swift.UnsafeRawPointer?) -> AnyAttribute
-@_silgen_name("AGGraphGetValue")
-@inline(__always) @inlinable internal func AGGraphGetValue<Value>(_ attribute: AnyAttribute, options: AGValueOptions = [], type: Value.Type = Value.self) -> AGValue
-@_silgen_name("AGGraphSetValue")
-@inline(__always) @inlinable internal func AGGraphSetValue<Value>(_ attribute: AnyAttribute, valuePointer: Swift.UnsafePointer<Value>) -> Swift.Bool
-@frozen public struct External<Value> {
-  public init()
-}
-extension AttributeGraph.External : AttributeGraph._AttributeBody {
-  public static var comparisonMode: ComparisonMode {
-    get
-  }
-  public static var flags: AttributeGraph.External<Value>.Flags {
-    get
-  }
-  public static func _update(_: Swift.UnsafeMutableRawPointer, attribute _: AnyAttribute)
-}
-extension AttributeGraph.External : Swift.CustomStringConvertible {
-  public var description: Swift.String {
-    get
-  }
-}
+public typealias AttributeUpdateBlock = () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void
 @frozen public struct PointerOffset<Base, Member> {
   public var byteOffset: Swift.Int
   public init(byteOffset: Swift.Int)
@@ -165,27 +68,111 @@ extension Swift.UnsafeMutablePointer {
   }
   public static func + <Member>(lhs: Swift.UnsafeMutablePointer<Pointee>, rhs: AttributeGraph.PointerOffset<Pointee, Member>) -> Swift.UnsafeMutablePointer<Member>
 }
-public protocol _AttributeBody {
-  static func _destroySelf(_ pointer: Swift.UnsafeMutableRawPointer)
-  static var _hasDestroySelf: Swift.Bool { get }
-  static func _updateDefault(_ pointer: Swift.UnsafeMutableRawPointer)
-  static var comparisonMode: ComparisonMode { get }
-  typealias Flags = _AttributeType.Flags
-  static var flags: Self.Flags { get }
+@frozen public struct External<Value> {
+  public init()
 }
-extension AttributeGraph._AttributeBody {
-  public static func _destroySelf(_ pointer: Swift.UnsafeMutableRawPointer)
-  public static var _hasDestroySelf: Swift.Bool {
+extension AttributeGraph.External : AttributeGraph._AttributeBody {
+  public static var comparisonMode: AttributeGraph.ComparisonMode {
     get
   }
-  public static func _updateDefault(_ pointer: Swift.UnsafeMutableRawPointer)
-  public static var comparisonMode: ComparisonMode {
+  public static var flags: AttributeGraph.External<Value>.Flags {
     get
   }
-  public static var flags: Self.Flags {
+  public static func _update(_: Swift.UnsafeMutableRawPointer, attribute _: AttributeGraph.AnyAttribute)
+}
+extension AttributeGraph.External : Swift.CustomStringConvertible {
+  public var description: Swift.String {
     get
   }
 }
+@frozen @propertyWrapper @dynamicMemberLookup public struct Attribute<Value> {
+  public var identifier: AttributeGraph.AnyAttribute
+  public init(identifier: AttributeGraph.AnyAttribute)
+  public init(_ attribute: AttributeGraph.Attribute<Value>)
+  public init(value: Value)
+  public init(type _: Value.Type)
+  #if compiler(>=5.3) && $NonescapableTypes
+  public init<Body>(body: Swift.UnsafePointer<Body>, value: Swift.UnsafePointer<Value>?, flags: AttributeGraph._AttributeType.Flags = [], update: () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void) where Body : AttributeGraph._AttributeBody
+  #endif
+  public var wrappedValue: Value {
+    unsafeAddress
+    nonmutating set
+  }
+  public var projectedValue: AttributeGraph.Attribute<Value> {
+    get
+    set
+  }
+  public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member> {
+    get
+  }
+  public subscript<Member>(keyPath keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member> {
+    get
+  }
+  public subscript<Member>(offset body: (inout Value) -> AttributeGraph.PointerOffset<Value, Member>) -> AttributeGraph.Attribute<Member> {
+    get
+  }
+  public func unsafeCast<V>(to type: V.Type) -> AttributeGraph.Attribute<V>
+  public func unsafeOffset<Member>(at offset: Swift.Int, as _: Member.Type) -> AttributeGraph.Attribute<Member>
+  public func applying<Member>(offset: AttributeGraph.PointerOffset<Value, Member>) -> AttributeGraph.Attribute<Member>
+  public func visitBody<Body>(_ visitor: inout Body) where Body : AttributeGraph.AttributeBodyVisitor
+  public func mutateBody<V>(as type: V.Type, invalidating: Swift.Bool, _ body: (inout V) -> Swift.Void)
+  public func breadthFirstSearch(options: AttributeGraph.SearchOptions = [], _ body: (AttributeGraph.AnyAttribute) -> Swift.Bool) -> Swift.Bool
+  public var graph: AttributeGraph.Graph {
+    get
+  }
+  public var subgraph: AttributeGraph.Subgraph {
+    get
+  }
+  public var value: Value {
+    unsafeAddress
+    nonmutating set
+  }
+  public var valueState: AttributeGraph.ValueState {
+    get
+  }
+  public func valueAndFlags(options: AttributeGraph.AGValueOptions = []) -> (value: Value, flags: AttributeGraph.AGChangedValueFlags)
+  public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)
+  public func setValue(_ value: Value) -> Swift.Bool
+  public var hasValue: Swift.Bool {
+    get
+  }
+  public func updateValue()
+  public func prefetchValue()
+  public func invalidateValue()
+  public func validate()
+  public func addInput(_ attribute: AttributeGraph.AnyAttribute, options: AttributeGraph.AGInputOptions = [], token: Swift.Int)
+  public func addInput<V>(_ attribute: AttributeGraph.Attribute<V>, options: AttributeGraph.AGInputOptions = [], token: Swift.Int)
+  public typealias Flags = AttributeGraph.AnyAttribute.Flags
+  public var flags: AttributeGraph.Attribute<Value>.Flags {
+    get
+    nonmutating set
+  }
+  public func setFlags(_ newFlags: AttributeGraph.Attribute<Value>.Flags, mask: AttributeGraph.Attribute<Value>.Flags)
+}
+extension AttributeGraph.Attribute : Swift.Hashable {
+  public static func == (a: AttributeGraph.Attribute<Value>, b: AttributeGraph.Attribute<Value>) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+extension AttributeGraph.Attribute : Swift.CustomStringConvertible {
+  public var description: Swift.String {
+    get
+  }
+}
+extension AttributeGraph.Attribute {
+  public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.Rule
+  public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.StatefulRule
+}
+#if compiler(>=5.3) && $NonescapableTypes
+@_silgen_name("AGGraphCreateAttribute")
+@inline(__always) @inlinable internal func AGGraphCreateAttribute(index: Swift.Int, body: Swift.UnsafeRawPointer, value: Swift.UnsafeRawPointer?) -> AttributeGraph.AnyAttribute
+#endif
+@_silgen_name("AGGraphGetValue")
+@inline(__always) @inlinable internal func AGGraphGetValue<Value>(_ attribute: AttributeGraph.AnyAttribute, options: AttributeGraph.AGValueOptions = [], type: Value.Type = Value.self) -> AttributeGraph.AGValue
+@_silgen_name("AGGraphSetValue")
+@inline(__always) @inlinable internal func AGGraphSetValue<Value>(_ attribute: AttributeGraph.AnyAttribute, valuePointer: Swift.UnsafePointer<Value>) -> Swift.Bool
 public protocol AttributeBodyVisitor {
   func visit<Body>(body: Swift.UnsafePointer<Body>) where Body : AttributeGraph._AttributeBody
 }
@@ -198,23 +185,307 @@ extension AttributeGraph.ObservedAttribute {
     get
   }
 }
+public protocol _AttributeBody {
+  static func _destroySelf(_ pointer: Swift.UnsafeMutableRawPointer)
+  static var _hasDestroySelf: Swift.Bool { get }
+  static func _updateDefault(_ pointer: Swift.UnsafeMutableRawPointer)
+  static var comparisonMode: AttributeGraph.ComparisonMode { get }
+  typealias Flags = AttributeGraph._AttributeType.Flags
+  static var flags: Self.Flags { get }
+}
+extension AttributeGraph._AttributeBody {
+  public static func _destroySelf(_ pointer: Swift.UnsafeMutableRawPointer)
+  public static var _hasDestroySelf: Swift.Bool {
+    get
+  }
+  public static func _updateDefault(_ pointer: Swift.UnsafeMutableRawPointer)
+  public static var comparisonMode: AttributeGraph.ComparisonMode {
+    get
+  }
+  public static var flags: Self.Flags {
+    get
+  }
+}
+@frozen @propertyWrapper @dynamicMemberLookup public struct WeakAttribute<Value> {
+  internal var base: AttributeGraph.AnyWeakAttribute
+  public init(base: AttributeGraph.AnyWeakAttribute)
+  public init()
+  public init(_ attribute: AttributeGraph.Attribute<Value>)
+  #if compiler(>=5.3) && $NonescapableTypes
+  public init(_ attribute: AttributeGraph.Attribute<Value>?)
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var wrappedValue: Value? {
+    get
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var projectedValue: AttributeGraph.Attribute<Value>? {
+    get
+    set
+    _modify
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
+    get
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var attribute: AttributeGraph.Attribute<Value>? {
+    get
+    set
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var value: Value? {
+    get
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
+  #endif
+}
+extension AttributeGraph.WeakAttribute : Swift.Hashable {
+  public static func == (a: AttributeGraph.WeakAttribute<Value>, b: AttributeGraph.WeakAttribute<Value>) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+extension AttributeGraph.WeakAttribute : Swift.CustomStringConvertible {
+  public var description: Swift.String {
+    get
+  }
+}
+extension AttributeGraph.AnyWeakAttribute {
+  #if compiler(>=5.3) && $NonescapableTypes
+  public init(_ attribute: AttributeGraph.AnyAttribute?)
+  #endif
+  public init<Value>(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
+  public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.WeakAttribute<Value>
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var attribute: AttributeGraph.AnyAttribute? {
+    get
+    set
+  }
+  #endif
+}
+extension AttributeGraph.AnyWeakAttribute : Swift.Hashable {
+  public static func == (lhs: AttributeGraph.AnyWeakAttribute, rhs: AttributeGraph.AnyWeakAttribute) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+extension AttributeGraph.AnyWeakAttribute : Swift.CustomStringConvertible {
+  @_alwaysEmitIntoClient public var description: Swift.String {
+    get { attribute?.description ?? "nil" }
+  }
+}
+public protocol Rule : AttributeGraph._AttributeBody {
+  associatedtype Value
+  #if compiler(>=5.3) && $NonescapableTypes
+  static var initialValue: Self.Value? { get }
+  #endif
+  var value: Self.Value { get }
+}
+extension AttributeGraph.Rule {
+  #if compiler(>=5.3) && $NonescapableTypes
+  public static var initialValue: Self.Value? {
+    get
+  }
+  #endif
+  public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AttributeGraph.AnyAttribute)
+  public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
+}
+extension AttributeGraph.Rule {
+  public var attribute: AttributeGraph.Attribute<Self.Value> {
+    get
+  }
+  public var context: AttributeGraph.RuleContext<Self.Value> {
+    get
+  }
+}
+extension AttributeGraph.Rule where Self : Swift.Hashable {
+  #if compiler(>=5.3) && $NonescapableTypes
+  public func cachedValue(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?) -> Self.Value
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public func cachedValueIfExists(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?) -> Self.Value?
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public static func _cachedValue(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?, hashValue: Swift.Int, bodyPtr: Swift.UnsafeRawPointer, update: () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void) -> Swift.UnsafePointer<Self.Value>
+  #endif
+}
+@frozen public struct Map<Source, Value> : AttributeGraph.Rule, Swift.CustomStringConvertible {
+  public var arg: AttributeGraph.Attribute<Source>
+  public let body: (Source) -> Value
+  public init(_ arg: AttributeGraph.Attribute<Source>, _ body: @escaping (Source) -> Value)
+  public var value: Value {
+    get
+  }
+  public static var flags: AttributeGraph.Map<Source, Value>.Flags {
+    get
+  }
+  public var description: Swift.String {
+    get
+  }
+}
+public protocol StatefulRule : AttributeGraph._AttributeBody {
+  associatedtype Value
+  #if compiler(>=5.3) && $NonescapableTypes
+  static var initialValue: Self.Value? { get }
+  #endif
+  mutating func updateValue()
+}
+extension AttributeGraph.StatefulRule {
+  #if compiler(>=5.3) && $NonescapableTypes
+  public static var initialValue: Self.Value? {
+    get
+  }
+  #endif
+  public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AttributeGraph.AnyAttribute)
+  public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
+}
+extension AttributeGraph.StatefulRule {
+  public var attribute: AttributeGraph.Attribute<Self.Value> {
+    get
+  }
+  public var context: AttributeGraph.RuleContext<Self.Value> {
+    get
+  }
+  public var value: Self.Value {
+    unsafeAddress
+    nonmutating set
+  }
+  public var hasValue: Swift.Bool {
+    get
+  }
+}
+@frozen public struct Focus<Root, Value> : AttributeGraph.Rule, Swift.CustomStringConvertible {
+  public var root: AttributeGraph.Attribute<Root>
+  public var keyPath: Swift.KeyPath<Root, Value>
+  public init(root: AttributeGraph.Attribute<Root>, keyPath: Swift.KeyPath<Root, Value>)
+  public var value: Value {
+    get
+  }
+  public static var flags: AttributeGraph.Focus<Root, Value>.Flags {
+    get
+  }
+  public var description: Swift.String {
+    get
+  }
+}
+@frozen @propertyWrapper @dynamicMemberLookup public struct OptionalAttribute<Value> {
+  public var base: AttributeGraph.AnyOptionalAttribute
+  public init()
+  public init(base: AttributeGraph.AnyOptionalAttribute)
+  public init(_ attribute: AttributeGraph.Attribute<Value>)
+  #if compiler(>=5.3) && $NonescapableTypes
+  public init(_ attribute: AttributeGraph.Attribute<Value>?)
+  #endif
+  public init(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var attribute: AttributeGraph.Attribute<Value>? {
+    get
+    set
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var value: Value? {
+    get
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public func map<V>(_ body: (AttributeGraph.Attribute<Value>) -> V) -> V?
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var wrappedValue: Value? {
+    get
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var projectedValue: AttributeGraph.Attribute<Value>? {
+    get
+    set
+    _modify
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
+    get
+  }
+  #endif
+}
+extension AttributeGraph.OptionalAttribute : Swift.Hashable {
+  public static func == (a: AttributeGraph.OptionalAttribute<Value>, b: AttributeGraph.OptionalAttribute<Value>) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+extension AttributeGraph.OptionalAttribute : Swift.CustomStringConvertible {
+  public var description: Swift.String {
+    get
+  }
+}
+@frozen public struct AnyOptionalAttribute {
+  public var identifier: AttributeGraph.AnyAttribute
+  public init()
+  public init(_ attribute: AttributeGraph.AnyAttribute)
+  #if compiler(>=5.3) && $NonescapableTypes
+  public init(_ attribute: AttributeGraph.AnyAttribute?)
+  #endif
+  public init<Value>(_ attribute: AttributeGraph.OptionalAttribute<Value>)
+  public static var current: AttributeGraph.AnyOptionalAttribute {
+    get
+  }
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var attribute: AttributeGraph.AnyAttribute? {
+    get
+    set
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public func map<Value>(_ body: (AttributeGraph.AnyAttribute) -> Value) -> Value?
+  #endif
+  public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.OptionalAttribute<Value>
+}
+extension AttributeGraph.AnyOptionalAttribute : Swift.Hashable {
+  public static func == (a: AttributeGraph.AnyOptionalAttribute, b: AttributeGraph.AnyOptionalAttribute) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+extension AttributeGraph.AnyOptionalAttribute : Swift.CustomStringConvertible {
+  public var description: Swift.String {
+    get
+  }
+}
 @frozen @propertyWrapper @dynamicMemberLookup public struct IndirectAttribute<Value> {
-  public let identifier: AnyAttribute
+  public let identifier: AttributeGraph.AnyAttribute
   public init(source: AttributeGraph.Attribute<Value>)
   public var source: AttributeGraph.Attribute<Value> {
     get
     nonmutating set
   }
-  public var dependency: AnyAttribute? {
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var dependency: AttributeGraph.AnyAttribute? {
     get
     nonmutating set
   }
+  #endif
   public var value: Value {
     get
     nonmutating set
     nonmutating _modify
   }
-  public func changedValue(options: AGValueOptions = []) -> (value: Value, changed: Swift.Bool)
+  public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)
   public var wrappedValue: Value {
     get
     nonmutating set
@@ -234,169 +505,25 @@ extension AttributeGraph.IndirectAttribute : Swift.Hashable {
     get
   }
 }
-@frozen public struct AnyOptionalAttribute {
-  public var identifier: AnyAttribute
-  public init()
-  public init(_ attribute: AnyAttribute)
-  public init(_ attribute: AnyAttribute?)
-  public init<Value>(_ attribute: AttributeGraph.OptionalAttribute<Value>)
-  public static var current: AttributeGraph.AnyOptionalAttribute {
-    get
-  }
-  public var attribute: AnyAttribute? {
-    get
-    set
-  }
-  public func map<Value>(_ body: (AnyAttribute) -> Value) -> Value?
-  public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.OptionalAttribute<Value>
-}
-extension AttributeGraph.AnyOptionalAttribute : Swift.Hashable {
-  public static func == (a: AttributeGraph.AnyOptionalAttribute, b: AttributeGraph.AnyOptionalAttribute) -> Swift.Bool
-  public func hash(into hasher: inout Swift.Hasher)
-  public var hashValue: Swift.Int {
-    get
-  }
-}
-extension AttributeGraph.AnyOptionalAttribute : Swift.CustomStringConvertible {
-  public var description: Swift.String {
-    get
-  }
-}
-@frozen @propertyWrapper @dynamicMemberLookup public struct OptionalAttribute<Value> {
-  public var base: AttributeGraph.AnyOptionalAttribute
-  public init()
-  public init(base: AttributeGraph.AnyOptionalAttribute)
-  public init(_ attribute: AttributeGraph.Attribute<Value>)
-  public init(_ attribute: AttributeGraph.Attribute<Value>?)
-  public init(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
-  public var attribute: AttributeGraph.Attribute<Value>? {
-    get
-    set
-  }
-  public var value: Value? {
-    get
-  }
-  public func changedValue(options: AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
-  public func map<V>(_ body: (AttributeGraph.Attribute<Value>) -> V) -> V?
-  public var wrappedValue: Value? {
-    get
-  }
-  public var projectedValue: AttributeGraph.Attribute<Value>? {
-    get
-    set
-    _modify
-  }
-  public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
-    get
-  }
-}
-extension AttributeGraph.OptionalAttribute : Swift.Hashable {
-  public static func == (a: AttributeGraph.OptionalAttribute<Value>, b: AttributeGraph.OptionalAttribute<Value>) -> Swift.Bool
-  public func hash(into hasher: inout Swift.Hasher)
-  public var hashValue: Swift.Int {
-    get
-  }
-}
-extension AttributeGraph.OptionalAttribute : Swift.CustomStringConvertible {
-  public var description: Swift.String {
-    get
-  }
-}
-@frozen public struct Focus<Root, Value> : AttributeGraph.Rule, Swift.CustomStringConvertible {
-  public var root: AttributeGraph.Attribute<Root>
-  public var keyPath: Swift.KeyPath<Root, Value>
-  public init(root: AttributeGraph.Attribute<Root>, keyPath: Swift.KeyPath<Root, Value>)
-  public var value: Value {
-    get
-  }
-  public static var flags: AttributeGraph.Focus<Root, Value>.Flags {
-    get
-  }
-  public var description: Swift.String {
-    get
-  }
-}
-@frozen public struct Map<Source, Value> : AttributeGraph.Rule, Swift.CustomStringConvertible {
-  public var arg: AttributeGraph.Attribute<Source>
-  public let body: (Source) -> Value
-  public init(_ arg: AttributeGraph.Attribute<Source>, _ body: @escaping (Source) -> Value)
-  public var value: Value {
-    get
-  }
-  public static var flags: AttributeGraph.Map<Source, Value>.Flags {
-    get
-  }
-  public var description: Swift.String {
-    get
-  }
-}
-public protocol Rule : AttributeGraph._AttributeBody {
-  associatedtype Value
-  static var initialValue: Self.Value? { get }
-  var value: Self.Value { get }
-}
-extension AttributeGraph.Rule {
-  public static var initialValue: Self.Value? {
-    get
-  }
-  public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AnyAttribute)
-  public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
-}
-extension AttributeGraph.Rule {
-  public var attribute: AttributeGraph.Attribute<Self.Value> {
-    get
-  }
-  public var context: AttributeGraph.RuleContext<Self.Value> {
-    get
-  }
-}
-extension AttributeGraph.Rule where Self : Swift.Hashable {
-  public func cachedValue(options: AGCachedValueOptions = [], owner: AnyAttribute?) -> Self.Value
-  public func cachedValueIfExists(options: AGCachedValueOptions = [], owner: AnyAttribute?) -> Self.Value?
-  public static func _cachedValue(options: AGCachedValueOptions = [], owner: AnyAttribute?, hashValue: Swift.Int, bodyPtr: Swift.UnsafeRawPointer, update: () -> (Swift.UnsafeMutableRawPointer, AnyAttribute) -> Swift.Void) -> Swift.UnsafePointer<Self.Value>
-}
-public protocol StatefulRule : AttributeGraph._AttributeBody {
-  associatedtype Value
-  static var initialValue: Self.Value? { get }
-  mutating func updateValue()
-}
-extension AttributeGraph.StatefulRule {
-  public static var initialValue: Self.Value? {
-    get
-  }
-  public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AnyAttribute)
-  public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
-}
-extension AttributeGraph.StatefulRule {
-  public var attribute: AttributeGraph.Attribute<Self.Value> {
-    get
-  }
-  public var context: AttributeGraph.RuleContext<Self.Value> {
-    get
-  }
-  public var value: Self.Value {
-    unsafeAddress
-    nonmutating set
-  }
-  public var hasValue: Swift.Bool {
-    get
-  }
-}
 @frozen public struct AnyRuleContext : Swift.Equatable {
-  public var attribute: AnyAttribute
-  public init(attribute: AnyAttribute)
+  public var attribute: AttributeGraph.AnyAttribute
+  public init(attribute: AttributeGraph.AnyAttribute)
   public init<V>(_ context: AttributeGraph.RuleContext<V>)
   public subscript<V>(attribute: AttributeGraph.Attribute<V>) -> V {
     unsafeAddress
   }
+  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(weakAttribute: AttributeGraph.WeakAttribute<V>) -> V? {
     get
   }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(optionalAttribute: AttributeGraph.OptionalAttribute<V>) -> V? {
     get
   }
-  public func valueAndFlags<V>(of input: AttributeGraph.Attribute<V>, options: AGValueOptions = []) -> (value: V, flags: AGChangedValueFlags)
-  public func changedValue<V>(of input: AttributeGraph.Attribute<V>, options: AGValueOptions = []) -> (value: V, changed: Swift.Bool)
+  #endif
+  public func valueAndFlags<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, flags: AttributeGraph.AGChangedValueFlags)
+  public func changedValue<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, changed: Swift.Bool)
   public func update(body: () -> Swift.Void)
   public func unsafeCast<V>(to _: V.Type) -> AttributeGraph.RuleContext<V>
   public static func == (a: AttributeGraph.AnyRuleContext, b: AttributeGraph.AnyRuleContext) -> Swift.Bool
@@ -407,12 +534,16 @@ extension AttributeGraph.StatefulRule {
   public subscript<V>(attribute: AttributeGraph.Attribute<V>) -> V {
     unsafeAddress
   }
+  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(weakAttribute: AttributeGraph.WeakAttribute<V>) -> V? {
     get
   }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(optionalAttribute: AttributeGraph.OptionalAttribute<V>) -> V? {
     get
   }
+  #endif
   public var value: Value {
     unsafeAddress
     nonmutating set
@@ -420,86 +551,41 @@ extension AttributeGraph.StatefulRule {
   public var hasValue: Swift.Bool {
     get
   }
-  public func valueAndFlags<V>(of input: AttributeGraph.Attribute<V>, options: AGValueOptions = []) -> (value: V, flags: AGChangedValueFlags)
-  public func changedValue<V>(of input: AttributeGraph.Attribute<V>, options: AGValueOptions = []) -> (value: V, changed: Swift.Bool)
+  public func valueAndFlags<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, flags: AttributeGraph.AGChangedValueFlags)
+  public func changedValue<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, changed: Swift.Bool)
   public func update(body: () -> Swift.Void)
   public static func == (a: AttributeGraph.RuleContext<Value>, b: AttributeGraph.RuleContext<Value>) -> Swift.Bool
 }
 @_silgen_name("AGGraphGetInputValue")
-@inline(__always) @inlinable internal func AGGraphGetInputValue<Value>(_ attribute: AnyAttribute, input: AnyAttribute, options: AGValueOptions = [], type: Value.Type = Value.self) -> AGValue
+@inline(__always) @inlinable internal func AGGraphGetInputValue<Value>(_ attribute: AttributeGraph.AnyAttribute, input: AttributeGraph.AnyAttribute, options: AttributeGraph.AGValueOptions = [], type: Value.Type = Value.self) -> AttributeGraph.AGValue
 @_silgen_name("AGGraphWithUpdate")
-@inline(__always) @inlinable internal func AGGraphWithUpdate(_ attribute: AnyAttribute, body: () -> Swift.Void)
-extension AnyWeakAttribute {
-  public init(_ attribute: AnyAttribute?)
-  public init<Value>(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
-  public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.WeakAttribute<Value>
-  public var attribute: AnyAttribute? {
-    get
-    set
-  }
+@inline(__always) @inlinable internal func AGGraphWithUpdate(_ attribute: AttributeGraph.AnyAttribute, body: () -> Swift.Void)
+extension AttributeGraph.Subgraph {
+  public typealias Flags = AttributeGraph.AnyAttribute.Flags
+  public typealias ChildFlags = AttributeGraph.AnyAttribute.Flags
 }
-extension AnyWeakAttribute : Swift.Hashable {
-  public static func == (lhs: AnyWeakAttribute, rhs: AnyWeakAttribute) -> Swift.Bool
-  public func hash(into hasher: inout Swift.Hasher)
-  public var hashValue: Swift.Int {
-    get
-  }
+extension AttributeGraph.Subgraph {
+  public func addObserver(_ observer: @escaping () -> Swift.Void) -> Swift.Int
+  public func apply<Value>(_ body: () -> Value) -> Value
+  public func forEach(_ flags: AttributeGraph.Subgraph.Flags, _ callback: (AttributeGraph.AnyAttribute) -> Swift.Void)
 }
-extension AnyWeakAttribute : Swift.CustomStringConvertible {
-  @_alwaysEmitIntoClient public var description: Swift.String {
-    get { attribute?.description ?? "nil" }
-  }
+extension AttributeGraph.Subgraph {
+  public static func beginTreeElement<Value>(value: AttributeGraph.Attribute<Value>, flags: Swift.UInt32)
+  public static func addTreeValue<Value>(_ value: AttributeGraph.Attribute<Value>, forKey key: Swift.UnsafePointer<Swift.Int8>, flags: Swift.UInt32)
+  public static func endTreeElement<Value>(value: AttributeGraph.Attribute<Value>)
 }
-@frozen @propertyWrapper @dynamicMemberLookup public struct WeakAttribute<Value> {
-  internal var base: AnyWeakAttribute
-  public init(base: AnyWeakAttribute)
-  public init()
-  public init(_ attribute: AttributeGraph.Attribute<Value>)
-  public init(_ attribute: AttributeGraph.Attribute<Value>?)
-  public var wrappedValue: Value? {
-    get
-  }
-  public var projectedValue: AttributeGraph.Attribute<Value>? {
-    get
-    set
-    _modify
-  }
-  public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
-    get
-  }
-  public var attribute: AttributeGraph.Attribute<Value>? {
-    get
-    set
-  }
-  public var value: Value? {
-    get
-  }
-  public func changedValue(options: AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
+extension AttributeGraph.Graph {
+  public static func typeIndex(ctx: AttributeGraph.GraphContext, body: any AttributeGraph._AttributeBody.Type, valueType: AttributeGraph.Metadata, flags: AttributeGraph._AttributeType.Flags, update: () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void) -> Swift.Int
 }
-extension AttributeGraph.WeakAttribute : Swift.Hashable {
-  public static func == (a: AttributeGraph.WeakAttribute<Value>, b: AttributeGraph.WeakAttribute<Value>) -> Swift.Bool
-  public func hash(into hasher: inout Swift.Hasher)
-  public var hashValue: Swift.Int {
-    get
-  }
-}
-extension AttributeGraph.WeakAttribute : Swift.CustomStringConvertible {
-  public var description: Swift.String {
-    get
-  }
-}
-extension Graph {
-  public static func typeIndex(ctx: GraphContext, body: any AttributeGraph._AttributeBody.Type, valueType: Metadata, flags: _AttributeType.Flags, update: () -> (Swift.UnsafeMutableRawPointer, AnyAttribute) -> Swift.Void) -> Swift.Int
-}
-extension Graph {
+extension AttributeGraph.Graph {
   public static func withoutUpdate<V>(_ body: () -> V) -> V
   public func withoutSubgraphInvalidation<V>(_ body: () -> V) -> V
   public func withDeadline<V>(_: Swift.UInt64, _: () -> V) -> V
-  public func onInvalidation(_ callback: @escaping (AnyAttribute) -> Swift.Void)
+  public func onInvalidation(_ callback: @escaping (AttributeGraph.AnyAttribute) -> Swift.Void)
   public func onUpdate(_ callback: @escaping () -> Swift.Void)
   public func withMainThreadHandler(_: (() -> Swift.Void) -> Swift.Void, do: () -> Swift.Void)
 }
-extension Graph {
+extension AttributeGraph.Graph {
   @_transparent public func startProfiling() {
         __AGGraphStartProfiling(self)
     }
@@ -513,46 +599,31 @@ extension Graph {
   public static func stopProfiling()
   public static func resetProfile()
 }
-extension Graph {
+extension AttributeGraph.Graph {
   @_transparent public var mainUpdates: Swift.Int {
     @_transparent get { numericCast(counter(for: .mainThreadUpdates)) }
   }
 }
-extension Graph {
+extension AttributeGraph.Graph {
+  #if compiler(>=5.3) && $NonescapableTypes
   @_silgen_name("AGGraphGetOutputValue")
   @inline(__always) @inlinable public static func outputValue<Value>() -> Swift.UnsafePointer<Value>?
+  #endif
   @_silgen_name("AGGraphSetOutputValue")
   @inline(__always) @inlinable public static func setOutputValue<Value>(_ value: Swift.UnsafePointer<Value>)
 }
-extension Graph {
-  @_transparent public static func anyInputsChanged(excluding excludedInputs: [AnyAttribute]) -> Swift.Bool {
+extension AttributeGraph.Graph {
+  @_transparent public static func anyInputsChanged(excluding excludedInputs: [AttributeGraph.AnyAttribute]) -> Swift.Bool {
         return __AGGraphAnyInputsChanged(excludedInputs, excludedInputs.count)
     }
 }
-extension Graph {
+extension AttributeGraph.Graph {
+  #if compiler(>=5.3) && $NonescapableTypes
   public func archiveJSON(name: Swift.String?)
-}
-extension Subgraph {
-  public typealias Flags = AnyAttribute.Flags
-  public typealias ChildFlags = AnyAttribute.Flags
-}
-extension Subgraph {
-  public func addObserver(_ observer: @escaping () -> Swift.Void) -> Swift.Int
-  public func apply<Value>(_ body: () -> Value) -> Value
-  public func forEach(_ flags: Subgraph.Flags, _ callback: (AnyAttribute) -> Swift.Void)
-}
-extension Subgraph {
-  public static func beginTreeElement<Value>(value: AttributeGraph.Attribute<Value>, flags: Swift.UInt32)
-  public static func addTreeValue<Value>(_ value: AttributeGraph.Attribute<Value>, forKey key: Swift.UnsafePointer<Swift.Int8>, flags: Swift.UInt32)
-  public static func endTreeElement<Value>(value: AttributeGraph.Attribute<Value>)
-}
-public func compareValues<Value>(_ lhs: Value, _ rhs: Value, mode: ComparisonMode = .equatableAlways) -> Swift.Bool
-public func compareValues<Value>(_ lhs: Value, _ rhs: Value, options: ComparisonOptions) -> Swift.Bool
-extension ComparisonOptions {
-  public init(mode: ComparisonMode)
+  #endif
 }
 public func forEachField(of type: any Any.Type, do body: (Swift.UnsafePointer<Swift.Int8>, Swift.Int, any Any.Type) -> Swift.Void)
-extension Metadata : Swift.Hashable, Swift.CustomStringConvertible {
+extension AttributeGraph.Metadata : Swift.Hashable, Swift.CustomStringConvertible {
   public init(_ type: any Any.Type)
   public var type: any Any.Type {
     get
@@ -560,16 +631,12 @@ extension Metadata : Swift.Hashable, Swift.CustomStringConvertible {
   public var description: Swift.String {
     get
   }
-  public func forEachField(options: Metadata.ApplyOptions, do body: (Swift.UnsafePointer<Swift.Int8>, Swift.Int, any Any.Type) -> Swift.Bool) -> Swift.Bool
+  public func forEachField(options: AttributeGraph.Metadata.ApplyOptions, do body: (Swift.UnsafePointer<Swift.Int8>, Swift.Int, any Any.Type) -> Swift.Bool) -> Swift.Bool
 }
-extension Signature : Swift.Equatable {
-  public static func == (lhs: Signature, rhs: Signature) -> Swift.Bool
+extension AttributeGraph.Signature : Swift.Equatable {
+  public static func == (lhs: AttributeGraph.Signature, rhs: AttributeGraph.Signature) -> Swift.Bool
 }
-@discardableResult
-public func withUnsafePointerToEnumCase<T>(of value: Swift.UnsafeMutablePointer<T>, do body: (Swift.Int, any Any.Type, Swift.UnsafeRawPointer) -> ()) -> Swift.Bool
-@discardableResult
-public func withUnsafeMutablePointerToEnumCase<T>(of value: Swift.UnsafeMutablePointer<T>, do body: (Swift.Int, any Any.Type, Swift.UnsafeMutableRawPointer) -> ()) -> Swift.Bool
-extension TupleType {
+extension AttributeGraph.TupleType {
   @_transparent public init(_ types: [any Any.Type]) {
         self.init(count: types.count, elements: types.map(Metadata.init))
     }
@@ -593,16 +660,16 @@ extension TupleType {
   @_transparent public func offset<T>(at index: Swift.Int, as type: T.Type) -> Swift.Int {
         elementOffset(at: index, type: Metadata(type))
     }
-  @_transparent public func setElement<T>(in tupleValue: Swift.UnsafeMutableRawPointer, at index: Swift.Int, from srcValue: Swift.UnsafePointer<T>, options: TupleType.CopyOptions) {
+  @_transparent public func setElement<T>(in tupleValue: Swift.UnsafeMutableRawPointer, at index: Swift.Int, from srcValue: Swift.UnsafePointer<T>, options: AttributeGraph.TupleType.CopyOptions) {
         __AGTupleSetElement(self, tupleValue, index, srcValue, Metadata(T.self), options)
     }
-  @_transparent public func getElement<T>(in tupleValue: Swift.UnsafeMutableRawPointer, at index: Swift.Int, to dstValue: Swift.UnsafeMutablePointer<T>, options: TupleType.CopyOptions) {
+  @_transparent public func getElement<T>(in tupleValue: Swift.UnsafeMutableRawPointer, at index: Swift.Int, to dstValue: Swift.UnsafeMutablePointer<T>, options: AttributeGraph.TupleType.CopyOptions) {
         __AGTupleGetElement(self, tupleValue, index, dstValue, Metadata(T.self), options)
     }
 }
 @_silgen_name("AGTupleWithBuffer")
-public func withUnsafeTuple(of type: TupleType, count: Swift.Int, _ body: (UnsafeMutableTuple) -> Swift.Void)
-extension UnsafeTuple {
+public func withUnsafeTuple(of type: AttributeGraph.TupleType, count: Swift.Int, _ body: (AttributeGraph.UnsafeMutableTuple) -> Swift.Void)
+extension AttributeGraph.UnsafeTuple {
   @_transparent public var count: Swift.Int {
     @_transparent get { type.count }
   }
@@ -629,8 +696,8 @@ extension UnsafeTuple {
     @_transparent unsafeAddress { address(of: index, as: T.self) }
   }
 }
-extension UnsafeMutableTuple {
-  @_transparent public init(with tupleType: TupleType) {
+extension AttributeGraph.UnsafeMutableTuple {
+  @_transparent public init(with tupleType: AttributeGraph.TupleType) {
         self.init(
             type: tupleType,
             value: UnsafeMutableRawPointer.allocate(
@@ -684,21 +751,30 @@ extension UnsafeMutableTuple {
     @_transparent nonmutating unsafeMutableAddress { address(of: index, as: T.self) }
   }
 }
-extension AttributeGraph.Attribute : Swift.Sendable {}
-extension AttributeGraph.Attribute : Swift.BitwiseCopyable {}
-extension AttributeGraph.External : Swift.Sendable {}
-extension AttributeGraph.External : Swift.BitwiseCopyable {}
+@discardableResult
+public func withUnsafePointerToEnumCase<T>(of value: Swift.UnsafeMutablePointer<T>, do body: (Swift.Int, any Any.Type, Swift.UnsafeRawPointer) -> ()) -> Swift.Bool
+@discardableResult
+public func withUnsafeMutablePointerToEnumCase<T>(of value: Swift.UnsafeMutablePointer<T>, do body: (Swift.Int, any Any.Type, Swift.UnsafeMutableRawPointer) -> ()) -> Swift.Bool
+public func compareValues<Value>(_ lhs: Value, _ rhs: Value, mode: AttributeGraph.ComparisonMode = .equatableAlways) -> Swift.Bool
+public func compareValues<Value>(_ lhs: Value, _ rhs: Value, options: AttributeGraph.ComparisonOptions) -> Swift.Bool
+extension AttributeGraph.ComparisonOptions {
+  public init(mode: AttributeGraph.ComparisonMode)
+}
 extension AttributeGraph.PointerOffset : Swift.Sendable {}
 extension AttributeGraph.PointerOffset : Swift.BitwiseCopyable {}
-extension AttributeGraph.IndirectAttribute : Swift.Sendable {}
-extension AttributeGraph.IndirectAttribute : Swift.BitwiseCopyable {}
-extension AttributeGraph.AnyOptionalAttribute : Swift.Sendable {}
-extension AttributeGraph.AnyOptionalAttribute : Swift.BitwiseCopyable {}
+extension AttributeGraph.External : Swift.Sendable {}
+extension AttributeGraph.External : Swift.BitwiseCopyable {}
+extension AttributeGraph.Attribute : Swift.Sendable {}
+extension AttributeGraph.Attribute : Swift.BitwiseCopyable {}
+extension AttributeGraph.WeakAttribute : Swift.Sendable {}
+extension AttributeGraph.WeakAttribute : Swift.BitwiseCopyable {}
 extension AttributeGraph.OptionalAttribute : Swift.Sendable {}
 extension AttributeGraph.OptionalAttribute : Swift.BitwiseCopyable {}
+extension AttributeGraph.AnyOptionalAttribute : Swift.Sendable {}
+extension AttributeGraph.AnyOptionalAttribute : Swift.BitwiseCopyable {}
+extension AttributeGraph.IndirectAttribute : Swift.Sendable {}
+extension AttributeGraph.IndirectAttribute : Swift.BitwiseCopyable {}
 extension AttributeGraph.AnyRuleContext : Swift.Sendable {}
 extension AttributeGraph.AnyRuleContext : Swift.BitwiseCopyable {}
 extension AttributeGraph.RuleContext : Swift.Sendable {}
 extension AttributeGraph.RuleContext : Swift.BitwiseCopyable {}
-extension AttributeGraph.WeakAttribute : Swift.Sendable {}
-extension AttributeGraph.WeakAttribute : Swift.BitwiseCopyable {}

--- a/AG/generate_swiftinterface.sh
+++ b/AG/generate_swiftinterface.sh
@@ -17,6 +17,15 @@ FRAMEWORK_ROOT="${SCRIPT_DIR}/${VERSION}"
 SHIMS_DIR="${SCRIPT_DIR}/DeviceSwiftShims"
 TEMPLATE_PATH="${FRAMEWORK_ROOT}/Sources/Modules/AttributeGraph.swiftmodule/template.swiftinterface"
 
+# Verify Swift compiler version matches the expected version for this framework
+EXPECTED_SWIFT_VERSION="6.1" # 2024 -> 6.1, 2025 -> 6.2
+SWIFT_VERSION=$(xcrun swiftc --version 2>&1 | grep -o 'Swift version [0-9]*\.[0-9]*' | head -1 | awk '{print $3}')
+if [ "${SWIFT_VERSION}" != "${EXPECTED_SWIFT_VERSION}" ]; then
+    echo "Error: expected Swift ${EXPECTED_SWIFT_VERSION} but found Swift ${SWIFT_VERSION}"
+    echo "Set DEVELOPER_DIR to the correct Xcode version"
+    exit 1
+fi
+
 TMPDIR_WORK=$(mktemp -d)
 trap "rm -rf ${TMPDIR_WORK}" EXIT
 

--- a/AG/generate_swiftinterface.sh
+++ b/AG/generate_swiftinterface.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+## Generate template.swiftinterface from DeviceSwiftShims sources.
+##
+## This compiles the DeviceSwiftShims Swift files against the AttributeGraph xcframework
+## to produce a .swiftinterface, then transforms it into the template used by update.sh:
+##   1. Strip the compiler header comments (update.sh generates per-platform headers)
+
+# A `realpath` alternative using the default C implementation.
+filepath() {
+  [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
+}
+
+SCRIPT_DIR="$(dirname "$(filepath "$0")")"
+VERSION=${DARWINPRIVATEFRAMEWORKS_TARGET_RELEASE:-2024}
+FRAMEWORK_ROOT="${SCRIPT_DIR}/${VERSION}"
+SHIMS_DIR="${SCRIPT_DIR}/DeviceSwiftShims"
+TEMPLATE_PATH="${FRAMEWORK_ROOT}/Sources/Modules/AttributeGraph.swiftmodule/template.swiftinterface"
+
+TMPDIR_WORK=$(mktemp -d)
+trap "rm -rf ${TMPDIR_WORK}" EXIT
+
+GENERATED="${TMPDIR_WORK}/generated.swiftinterface"
+
+# Resolve the iOS Simulator SDK version for the -target flag
+IOS_SDK_VERSION=$(xcrun --sdk iphonesimulator --show-sdk-version)
+
+# Compile DeviceSwiftShims against the simulator xcframework to emit a swiftinterface
+xcrun --sdk iphonesimulator swiftc \
+    -emit-module-interface-path "${GENERATED}" \
+    -emit-module-path "${TMPDIR_WORK}/module.swiftmodule" \
+    -module-name AttributeGraph \
+    -enable-library-evolution \
+    -swift-version 5 \
+    -Osize \
+    -enable-upcoming-feature InternalImportsByDefault \
+    -enable-experimental-feature Extern \
+    -target "arm64-apple-ios${IOS_SDK_VERSION}-simulator" \
+    -F "${FRAMEWORK_ROOT}/AttributeGraph.xcframework/ios-arm64-x86_64-simulator/" \
+    $(find "${SHIMS_DIR}" -name '*.swift') \
+    2>/dev/null
+
+if [ ! -f "${GENERATED}" ]; then
+    echo "Error: failed to generate swiftinterface"
+    exit 1
+fi
+
+# Strip the compiler header comments (update.sh generates per-platform headers)
+sed -e '/^\/\/ swift-/d' \
+    "${GENERATED}" > "${TEMPLATE_PATH}"
+
+echo "Generated: ${TEMPLATE_PATH}"

--- a/AG/update.sh
+++ b/AG/update.sh
@@ -53,6 +53,9 @@ update_version_in_header() {
     sed -i '' "s/#define ATTRIBUTEGRAPH_RELEASE [0-9]\{4\}/#define ATTRIBUTEGRAPH_RELEASE ${version}/g" "$file"
 }
 
+# Regenerate template.swiftinterface from DeviceSwiftShims sources
+DARWINPRIVATEFRAMEWORKS_TARGET_RELEASE=${VERSION} "$(dirname "$(filepath "$0")")/generate_swiftinterface.sh"
+
 generate_framework() {
     local framework_name=$1
     local arch_name=$2

--- a/GF/2025/Gestures.xcframework/ios-arm64-x86_64-simulator/Gestures.framework/Modules/Gestures.swiftmodule/arm64-apple-ios-simulator.swiftinterface
+++ b/GF/2025/Gestures.xcframework/ios-arm64-x86_64-simulator/Gestures.framework/Modules/Gestures.swiftmodule/arm64-apple-ios-simulator.swiftinterface
@@ -2,7 +2,6 @@
 // swift-compiler-version: Apple Swift version 6.2 effective-5.10 (swiftlang-6.2.0.16.112 clang-1800.1.29)
 // swift-module-flags: -target arm64-apple-ios26.0-simulator -enable-objc-interop -enable-library-evolution -swift-version 5 -Osize -enable-upcoming-feature InternalImportsByDefault -enable-experimental-feature Extern -module-name Gestures
 // swift-module-flags-ignorable: -interface-compiler-version 6.2
-
 @_exported public import Gestures
 public import Swift
 public import _Concurrency

--- a/GF/2025/Gestures.xcframework/ios-arm64-x86_64-simulator/Gestures.framework/Modules/Gestures.swiftmodule/x86_64-apple-ios-simulator.swiftinterface
+++ b/GF/2025/Gestures.xcframework/ios-arm64-x86_64-simulator/Gestures.framework/Modules/Gestures.swiftmodule/x86_64-apple-ios-simulator.swiftinterface
@@ -2,7 +2,6 @@
 // swift-compiler-version: Apple Swift version 6.2 effective-5.10 (swiftlang-6.2.0.16.112 clang-1800.1.29)
 // swift-module-flags: -target x86_64-apple-ios26.0-simulator -enable-objc-interop -enable-library-evolution -swift-version 5 -Osize -enable-upcoming-feature InternalImportsByDefault -enable-experimental-feature Extern -module-name Gestures
 // swift-module-flags-ignorable: -interface-compiler-version 6.2
-
 @_exported public import Gestures
 public import Swift
 public import _Concurrency

--- a/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/arm64-apple-macos.swiftinterface
+++ b/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/arm64-apple-macos.swiftinterface
@@ -2,7 +2,6 @@
 // swift-compiler-version: Apple Swift version 6.2 effective-5.10 (swiftlang-6.2.0.16.112 clang-1800.1.29)
 // swift-module-flags: -target arm64-apple-macos26.0 -enable-objc-interop -enable-library-evolution -swift-version 5 -Osize -enable-upcoming-feature InternalImportsByDefault -enable-experimental-feature Extern -module-name Gestures
 // swift-module-flags-ignorable: -interface-compiler-version 6.2
-
 @_exported public import Gestures
 public import Swift
 public import _Concurrency

--- a/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/arm64e-apple-macos.swiftinterface
+++ b/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/arm64e-apple-macos.swiftinterface
@@ -2,7 +2,6 @@
 // swift-compiler-version: Apple Swift version 6.2 effective-5.10 (swiftlang-6.2.0.16.112 clang-1800.1.29)
 // swift-module-flags: -target arm64e-apple-macos26.0 -enable-objc-interop -enable-library-evolution -swift-version 5 -Osize -enable-upcoming-feature InternalImportsByDefault -enable-experimental-feature Extern -module-name Gestures
 // swift-module-flags-ignorable: -interface-compiler-version 6.2
-
 @_exported public import Gestures
 public import Swift
 public import _Concurrency

--- a/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/x86_64-apple-macos.swiftinterface
+++ b/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/x86_64-apple-macos.swiftinterface
@@ -2,7 +2,6 @@
 // swift-compiler-version: Apple Swift version 6.2 effective-5.10 (swiftlang-6.2.0.16.112 clang-1800.1.29)
 // swift-module-flags: -target x86_64-apple-macos26.0 -enable-objc-interop -enable-library-evolution -swift-version 5 -Osize -enable-upcoming-feature InternalImportsByDefault -enable-experimental-feature Extern -module-name Gestures
 // swift-module-flags-ignorable: -interface-compiler-version 6.2
-
 @_exported public import Gestures
 public import Swift
 public import _Concurrency

--- a/GF/2025/Sources/Modules/Gestures.swiftmodule/template.swiftinterface
+++ b/GF/2025/Sources/Modules/Gestures.swiftmodule/template.swiftinterface
@@ -1,4 +1,3 @@
-
 @_exported public import Gestures
 public import Swift
 public import _Concurrency

--- a/GF/generate_swiftinterface.sh
+++ b/GF/generate_swiftinterface.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+## Generate template.swiftinterface from DeviceSwiftShims sources.
+##
+## This compiles the DeviceSwiftShims Swift files against the Gestures xcframework
+## to produce a .swiftinterface, then transforms it into the template used by update.sh:
+##   1. Strip the compiler header comments (update.sh generates per-platform headers)
+##   2. Remove `Gestures.` module prefix from extension type names
+
+# A `realpath` alternative using the default C implementation.
+filepath() {
+  [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
+}
+
+SCRIPT_DIR="$(dirname "$(filepath "$0")")"
+VERSION=${DARWINPRIVATEFRAMEWORKS_TARGET_RELEASE:-2025}
+FRAMEWORK_ROOT="${SCRIPT_DIR}/${VERSION}"
+SHIMS_DIR="${SCRIPT_DIR}/DeviceSwiftShims"
+TEMPLATE_PATH="${FRAMEWORK_ROOT}/Sources/Modules/Gestures.swiftmodule/template.swiftinterface"
+
+TMPDIR_WORK=$(mktemp -d)
+trap "rm -rf ${TMPDIR_WORK}" EXIT
+
+GENERATED="${TMPDIR_WORK}/generated.swiftinterface"
+
+# Resolve the iOS Simulator SDK version for the -target flag
+IOS_SDK_VERSION=$(xcrun --sdk iphonesimulator --show-sdk-version)
+
+# Compile DeviceSwiftShims against the simulator xcframework to emit a swiftinterface
+xcrun --sdk iphonesimulator swiftc \
+    -emit-module-interface-path "${GENERATED}" \
+    -emit-module-path "${TMPDIR_WORK}/module.swiftmodule" \
+    -module-name Gestures \
+    -enable-library-evolution \
+    -swift-version 5 \
+    -Osize \
+    -enable-upcoming-feature InternalImportsByDefault \
+    -enable-experimental-feature Extern \
+    -target "arm64-apple-ios${IOS_SDK_VERSION}-simulator" \
+    -F "${FRAMEWORK_ROOT}/Gestures.xcframework/ios-arm64-x86_64-simulator/" \
+    "${SHIMS_DIR}/Export.swift" \
+    $(find "${SHIMS_DIR}/Extension" -name '*.swift' 2>/dev/null) \
+    2>/dev/null
+
+if [ ! -f "${GENERATED}" ]; then
+    echo "Error: failed to generate swiftinterface"
+    exit 1
+fi
+
+# Transform:
+#   1. Strip the compiler header comments (update.sh generates per-platform headers)
+#   2. Remove `Gestures.` module prefix from extension declarations
+sed -e '/^\/\/ swift-/d' \
+    -e 's/extension Gestures\./extension /g' \
+    "${GENERATED}" > "${TEMPLATE_PATH}"
+
+echo "Generated: ${TEMPLATE_PATH}"

--- a/GF/generate_swiftinterface.sh
+++ b/GF/generate_swiftinterface.sh
@@ -18,6 +18,15 @@ FRAMEWORK_ROOT="${SCRIPT_DIR}/${VERSION}"
 SHIMS_DIR="${SCRIPT_DIR}/DeviceSwiftShims"
 TEMPLATE_PATH="${FRAMEWORK_ROOT}/Sources/Modules/Gestures.swiftmodule/template.swiftinterface"
 
+# Verify Swift compiler version matches the expected version for this framework
+EXPECTED_SWIFT_VERSION="6.2" # 2024 -> 6.1, 2025 -> 6.2
+SWIFT_VERSION=$(xcrun swiftc --version 2>&1 | grep -o 'Swift version [0-9]*\.[0-9]*' | head -1 | awk '{print $3}')
+if [ "${SWIFT_VERSION}" != "${EXPECTED_SWIFT_VERSION}" ]; then
+    echo "Error: expected Swift ${EXPECTED_SWIFT_VERSION} but found Swift ${SWIFT_VERSION}"
+    echo "Set DEVELOPER_DIR to the correct Xcode version"
+    exit 1
+fi
+
 TMPDIR_WORK=$(mktemp -d)
 trap "rm -rf ${TMPDIR_WORK}" EXIT
 

--- a/GF/update.sh
+++ b/GF/update.sh
@@ -59,6 +59,9 @@ generate_xcframework() {
     cp ${FRAMEWORK_ROOT}/Info.plist ${path}/
 }
 
+# Regenerate template.swiftinterface from DeviceSwiftShims sources
+DARWINPRIVATEFRAMEWORKS_TARGET_RELEASE=${VERSION} "$(dirname "$(filepath "$0")")/generate_swiftinterface.sh"
+
 generate_xcframework $framework_name
 
 generate_framework $framework_name ios-arm64-arm64e


### PR DESCRIPTION
## Summary
- Add `GF/generate_swiftinterface.sh` and `AG/generate_swiftinterface.sh` to auto-generate `template.swiftinterface` from DeviceSwiftShims sources
- Both use matching module compiler flags (`-module-name`, `-enable-upcoming-feature InternalImportsByDefault`, `-enable-experimental-feature Extern`)
- Integrate into respective `update.sh` so template is regenerated before xcframework assembly
- AG template now uses fully-qualified type names and `#if compiler` guards, matching native compiler output

## Test plan
- [ ] Run `bash GF/update.sh` — verify no errors and xcframework is correct
- [ ] Run `bash AG/update.sh` — verify no errors and xcframework is correct
- [ ] `swift build` succeeds