### PR TITLE
Add GestureNodeOptions and GestureTrait APIs to Gestures framework

### DIFF
--- a/GF/2025/Gestures.xcframework/ios-arm64-x86_64-simulator/Gestures.framework/Modules/Gestures.swiftmodule/arm64-apple-ios-simulator.swiftinterface
+++ b/GF/2025/Gestures.xcframework/ios-arm64-x86_64-simulator/Gestures.framework/Modules/Gestures.swiftmodule/arm64-apple-ios-simulator.swiftinterface
@@ -51,9 +51,6 @@ public struct GestureTrait : Swift.Hashable, Swift.Identifiable, Swift.Sendable 
   public struct AttributeKey : Swift.Hashable, Swift.Sendable, Swift.CustomStringConvertible {
     public let rawValue: Swift.Int
     public init(_ label: Swift.String)
-    public var label: Swift.String {
-      get
-    }
     public var description: Swift.String {
       get
     }

--- a/GF/2025/Gestures.xcframework/ios-arm64-x86_64-simulator/Gestures.framework/Modules/Gestures.swiftmodule/arm64-apple-ios-simulator.swiftinterface
+++ b/GF/2025/Gestures.xcframework/ios-arm64-x86_64-simulator/Gestures.framework/Modules/Gestures.swiftmodule/arm64-apple-ios-simulator.swiftinterface
@@ -41,15 +41,6 @@ public struct GestureTrait : Swift.Hashable, Swift.Identifiable, Swift.Sendable 
   public var id: Gestures.GestureTraitID
   public var attributes: [Gestures.GestureTrait.AttributeKey : Gestures.GestureTrait.AttributeValue]
   public init(id: Gestures.GestureTraitID, attributes: [Gestures.GestureTrait.AttributeKey : Gestures.GestureTrait.AttributeValue] = [:])
-  public var label: Swift.String {
-    get
-  }
-  public var description: Swift.String {
-    get
-  }
-  public var debugDescription: Swift.String {
-    get
-  }
   #if compiler(>=5.3) && $NonescapableTypes
   public static func tap(tapCount: Swift.Int? = nil, pointCount: Swift.Int? = nil) -> Gestures.GestureTrait
   #endif
@@ -121,24 +112,3 @@ public struct GestureTraitCollection : Swift.Hashable, Swift.Sendable {
     get
   }
 }
-extension GestureTraitCollection : Swift.Sequence {
-  public func makeIterator() -> some Swift.IteratorProtocol
-  
-  public typealias Element = (@_opaqueReturnTypeOf("$s8Gestures22GestureTraitCollectionV12makeIteratorQryF", 0) __).Element
-  public typealias Iterator = @_opaqueReturnTypeOf("$s8Gestures22GestureTraitCollectionV12makeIteratorQryF", 0) __
-}
-extension GestureTraitCollection {
-  public var label: Swift.String {
-    get
-  }
-  public var description: Swift.String {
-    get
-  }
-  public var debugDescription: Swift.String {
-    get
-  }
-}
-extension GestureTrait : Swift.CustomStringConvertible {}
-extension GestureTrait : Swift.CustomDebugStringConvertible {}
-extension GestureTraitCollection : Swift.CustomStringConvertible {}
-extension GestureTraitCollection : Swift.CustomDebugStringConvertible {}

--- a/GF/2025/Gestures.xcframework/ios-arm64-x86_64-simulator/Gestures.framework/Modules/Gestures.swiftmodule/arm64-apple-ios-simulator.swiftinterface
+++ b/GF/2025/Gestures.xcframework/ios-arm64-x86_64-simulator/Gestures.framework/Modules/Gestures.swiftmodule/arm64-apple-ios-simulator.swiftinterface
@@ -22,3 +22,123 @@ extension GFGestureRelationRole : Swift.CustomStringConvertible {
     get
   }
 }
+public struct GestureNodeOptions : Swift.OptionSet, Swift.Sendable {
+  public let rawValue: Swift.Int
+  public init(rawValue: Swift.Int)
+  public static let isDisabled: Gestures.GestureNodeOptions
+  public static let disallowExclusionWithUnresolvedFailureRequirements: Gestures.GestureNodeOptions
+  public static let isGloballyScoped: Gestures.GestureNodeOptions
+  public typealias ArrayLiteralElement = Gestures.GestureNodeOptions
+  public typealias Element = Gestures.GestureNodeOptions
+  public typealias RawValue = Swift.Int
+}
+extension GestureNodeOptions : Swift.CustomStringConvertible {
+  public var description: Swift.String {
+    get
+  }
+}
+public struct GestureTrait : Swift.Hashable, Swift.Identifiable, Swift.Sendable {
+  public var id: Gestures.GestureTraitID
+  public var attributes: [Gestures.GestureTrait.AttributeKey : Gestures.GestureTrait.AttributeValue]
+  public init(id: Gestures.GestureTraitID, attributes: [Gestures.GestureTrait.AttributeKey : Gestures.GestureTrait.AttributeValue] = [:])
+  public var label: Swift.String {
+    get
+  }
+  public var description: Swift.String {
+    get
+  }
+  public var debugDescription: Swift.String {
+    get
+  }
+  #if compiler(>=5.3) && $NonescapableTypes
+  public static func tap(tapCount: Swift.Int? = nil, pointCount: Swift.Int? = nil) -> Gestures.GestureTrait
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public static func longPress(pointCount: Swift.Int? = nil, minimumDuration: Swift.Duration? = nil, maximumMovement: Swift.Double? = nil) -> Gestures.GestureTrait
+  #endif
+  public static func pan() -> Gestures.GestureTrait
+  public struct AttributeKey : Swift.Hashable, Swift.Sendable, Swift.CustomStringConvertible {
+    public let rawValue: Swift.Int
+    public init(_ label: Swift.String)
+    public var label: Swift.String {
+      get
+    }
+    public var description: Swift.String {
+      get
+    }
+    public static let pointCount: Gestures.GestureTrait.AttributeKey
+    public static let tapCount: Gestures.GestureTrait.AttributeKey
+    public static let minimumDuration: Gestures.GestureTrait.AttributeKey
+    public static let maximumMovement: Gestures.GestureTrait.AttributeKey
+    public static func == (a: Gestures.GestureTrait.AttributeKey, b: Gestures.GestureTrait.AttributeKey) -> Swift.Bool
+    public func hash(into hasher: inout Swift.Hasher)
+    public var hashValue: Swift.Int {
+      get
+    }
+  }
+  public enum AttributeValue : Swift.Hashable, Swift.Sendable, Swift.CustomStringConvertible {
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case double(Swift.Double)
+    public var description: Swift.String {
+      get
+    }
+    public static func == (a: Gestures.GestureTrait.AttributeValue, b: Gestures.GestureTrait.AttributeValue) -> Swift.Bool
+    public func hash(into hasher: inout Swift.Hasher)
+    public var hashValue: Swift.Int {
+      get
+    }
+  }
+  public static func == (a: Gestures.GestureTrait, b: Gestures.GestureTrait) -> Swift.Bool
+  public typealias ID = Gestures.GestureTraitID
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+public struct GestureTraitID : Swift.Hashable, Swift.Sendable {
+  public let rawValue: Swift.Int
+  public init(_ label: Swift.String)
+  public static let tap: Gestures.GestureTraitID
+  public static let longPress: Gestures.GestureTraitID
+  public static let pan: Gestures.GestureTraitID
+  public static func == (a: Gestures.GestureTraitID, b: Gestures.GestureTraitID) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+public struct GestureTraitCollection : Swift.Hashable, Swift.Sendable {
+  public init(traits: [Gestures.GestureTrait] = [])
+  public static func withTrait(_ trait: Gestures.GestureTrait) -> Gestures.GestureTraitCollection
+  public var allTraits: [Gestures.GestureTrait] {
+    get
+  }
+  public func containsSubtraits(from other: Gestures.GestureTraitCollection) -> Swift.Bool
+  public static func == (a: Gestures.GestureTraitCollection, b: Gestures.GestureTraitCollection) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+extension GestureTraitCollection : Swift.Sequence {
+  public func makeIterator() -> some Swift.IteratorProtocol
+  
+  public typealias Element = (@_opaqueReturnTypeOf("$s8Gestures22GestureTraitCollectionV12makeIteratorQryF", 0) __).Element
+  public typealias Iterator = @_opaqueReturnTypeOf("$s8Gestures22GestureTraitCollectionV12makeIteratorQryF", 0) __
+}
+extension GestureTraitCollection {
+  public var label: Swift.String {
+    get
+  }
+  public var description: Swift.String {
+    get
+  }
+  public var debugDescription: Swift.String {
+    get
+  }
+}
+extension GestureTrait : Swift.CustomStringConvertible {}
+extension GestureTrait : Swift.CustomDebugStringConvertible {}
+extension GestureTraitCollection : Swift.CustomStringConvertible {}
+extension GestureTraitCollection : Swift.CustomDebugStringConvertible {}

--- a/GF/2025/Gestures.xcframework/ios-arm64-x86_64-simulator/Gestures.framework/Modules/Gestures.swiftmodule/x86_64-apple-ios-simulator.swiftinterface
+++ b/GF/2025/Gestures.xcframework/ios-arm64-x86_64-simulator/Gestures.framework/Modules/Gestures.swiftmodule/x86_64-apple-ios-simulator.swiftinterface
@@ -51,9 +51,6 @@ public struct GestureTrait : Swift.Hashable, Swift.Identifiable, Swift.Sendable 
   public struct AttributeKey : Swift.Hashable, Swift.Sendable, Swift.CustomStringConvertible {
     public let rawValue: Swift.Int
     public init(_ label: Swift.String)
-    public var label: Swift.String {
-      get
-    }
     public var description: Swift.String {
       get
     }

--- a/GF/2025/Gestures.xcframework/ios-arm64-x86_64-simulator/Gestures.framework/Modules/Gestures.swiftmodule/x86_64-apple-ios-simulator.swiftinterface
+++ b/GF/2025/Gestures.xcframework/ios-arm64-x86_64-simulator/Gestures.framework/Modules/Gestures.swiftmodule/x86_64-apple-ios-simulator.swiftinterface
@@ -41,15 +41,6 @@ public struct GestureTrait : Swift.Hashable, Swift.Identifiable, Swift.Sendable 
   public var id: Gestures.GestureTraitID
   public var attributes: [Gestures.GestureTrait.AttributeKey : Gestures.GestureTrait.AttributeValue]
   public init(id: Gestures.GestureTraitID, attributes: [Gestures.GestureTrait.AttributeKey : Gestures.GestureTrait.AttributeValue] = [:])
-  public var label: Swift.String {
-    get
-  }
-  public var description: Swift.String {
-    get
-  }
-  public var debugDescription: Swift.String {
-    get
-  }
   #if compiler(>=5.3) && $NonescapableTypes
   public static func tap(tapCount: Swift.Int? = nil, pointCount: Swift.Int? = nil) -> Gestures.GestureTrait
   #endif
@@ -121,24 +112,3 @@ public struct GestureTraitCollection : Swift.Hashable, Swift.Sendable {
     get
   }
 }
-extension GestureTraitCollection : Swift.Sequence {
-  public func makeIterator() -> some Swift.IteratorProtocol
-  
-  public typealias Element = (@_opaqueReturnTypeOf("$s8Gestures22GestureTraitCollectionV12makeIteratorQryF", 0) __).Element
-  public typealias Iterator = @_opaqueReturnTypeOf("$s8Gestures22GestureTraitCollectionV12makeIteratorQryF", 0) __
-}
-extension GestureTraitCollection {
-  public var label: Swift.String {
-    get
-  }
-  public var description: Swift.String {
-    get
-  }
-  public var debugDescription: Swift.String {
-    get
-  }
-}
-extension GestureTrait : Swift.CustomStringConvertible {}
-extension GestureTrait : Swift.CustomDebugStringConvertible {}
-extension GestureTraitCollection : Swift.CustomStringConvertible {}
-extension GestureTraitCollection : Swift.CustomDebugStringConvertible {}

--- a/GF/2025/Gestures.xcframework/ios-arm64-x86_64-simulator/Gestures.framework/Modules/Gestures.swiftmodule/x86_64-apple-ios-simulator.swiftinterface
+++ b/GF/2025/Gestures.xcframework/ios-arm64-x86_64-simulator/Gestures.framework/Modules/Gestures.swiftmodule/x86_64-apple-ios-simulator.swiftinterface
@@ -22,3 +22,123 @@ extension GFGestureRelationRole : Swift.CustomStringConvertible {
     get
   }
 }
+public struct GestureNodeOptions : Swift.OptionSet, Swift.Sendable {
+  public let rawValue: Swift.Int
+  public init(rawValue: Swift.Int)
+  public static let isDisabled: Gestures.GestureNodeOptions
+  public static let disallowExclusionWithUnresolvedFailureRequirements: Gestures.GestureNodeOptions
+  public static let isGloballyScoped: Gestures.GestureNodeOptions
+  public typealias ArrayLiteralElement = Gestures.GestureNodeOptions
+  public typealias Element = Gestures.GestureNodeOptions
+  public typealias RawValue = Swift.Int
+}
+extension GestureNodeOptions : Swift.CustomStringConvertible {
+  public var description: Swift.String {
+    get
+  }
+}
+public struct GestureTrait : Swift.Hashable, Swift.Identifiable, Swift.Sendable {
+  public var id: Gestures.GestureTraitID
+  public var attributes: [Gestures.GestureTrait.AttributeKey : Gestures.GestureTrait.AttributeValue]
+  public init(id: Gestures.GestureTraitID, attributes: [Gestures.GestureTrait.AttributeKey : Gestures.GestureTrait.AttributeValue] = [:])
+  public var label: Swift.String {
+    get
+  }
+  public var description: Swift.String {
+    get
+  }
+  public var debugDescription: Swift.String {
+    get
+  }
+  #if compiler(>=5.3) && $NonescapableTypes
+  public static func tap(tapCount: Swift.Int? = nil, pointCount: Swift.Int? = nil) -> Gestures.GestureTrait
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public static func longPress(pointCount: Swift.Int? = nil, minimumDuration: Swift.Duration? = nil, maximumMovement: Swift.Double? = nil) -> Gestures.GestureTrait
+  #endif
+  public static func pan() -> Gestures.GestureTrait
+  public struct AttributeKey : Swift.Hashable, Swift.Sendable, Swift.CustomStringConvertible {
+    public let rawValue: Swift.Int
+    public init(_ label: Swift.String)
+    public var label: Swift.String {
+      get
+    }
+    public var description: Swift.String {
+      get
+    }
+    public static let pointCount: Gestures.GestureTrait.AttributeKey
+    public static let tapCount: Gestures.GestureTrait.AttributeKey
+    public static let minimumDuration: Gestures.GestureTrait.AttributeKey
+    public static let maximumMovement: Gestures.GestureTrait.AttributeKey
+    public static func == (a: Gestures.GestureTrait.AttributeKey, b: Gestures.GestureTrait.AttributeKey) -> Swift.Bool
+    public func hash(into hasher: inout Swift.Hasher)
+    public var hashValue: Swift.Int {
+      get
+    }
+  }
+  public enum AttributeValue : Swift.Hashable, Swift.Sendable, Swift.CustomStringConvertible {
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case double(Swift.Double)
+    public var description: Swift.String {
+      get
+    }
+    public static func == (a: Gestures.GestureTrait.AttributeValue, b: Gestures.GestureTrait.AttributeValue) -> Swift.Bool
+    public func hash(into hasher: inout Swift.Hasher)
+    public var hashValue: Swift.Int {
+      get
+    }
+  }
+  public static func == (a: Gestures.GestureTrait, b: Gestures.GestureTrait) -> Swift.Bool
+  public typealias ID = Gestures.GestureTraitID
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+public struct GestureTraitID : Swift.Hashable, Swift.Sendable {
+  public let rawValue: Swift.Int
+  public init(_ label: Swift.String)
+  public static let tap: Gestures.GestureTraitID
+  public static let longPress: Gestures.GestureTraitID
+  public static let pan: Gestures.GestureTraitID
+  public static func == (a: Gestures.GestureTraitID, b: Gestures.GestureTraitID) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+public struct GestureTraitCollection : Swift.Hashable, Swift.Sendable {
+  public init(traits: [Gestures.GestureTrait] = [])
+  public static func withTrait(_ trait: Gestures.GestureTrait) -> Gestures.GestureTraitCollection
+  public var allTraits: [Gestures.GestureTrait] {
+    get
+  }
+  public func containsSubtraits(from other: Gestures.GestureTraitCollection) -> Swift.Bool
+  public static func == (a: Gestures.GestureTraitCollection, b: Gestures.GestureTraitCollection) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+extension GestureTraitCollection : Swift.Sequence {
+  public func makeIterator() -> some Swift.IteratorProtocol
+  
+  public typealias Element = (@_opaqueReturnTypeOf("$s8Gestures22GestureTraitCollectionV12makeIteratorQryF", 0) __).Element
+  public typealias Iterator = @_opaqueReturnTypeOf("$s8Gestures22GestureTraitCollectionV12makeIteratorQryF", 0) __
+}
+extension GestureTraitCollection {
+  public var label: Swift.String {
+    get
+  }
+  public var description: Swift.String {
+    get
+  }
+  public var debugDescription: Swift.String {
+    get
+  }
+}
+extension GestureTrait : Swift.CustomStringConvertible {}
+extension GestureTrait : Swift.CustomDebugStringConvertible {}
+extension GestureTraitCollection : Swift.CustomStringConvertible {}
+extension GestureTraitCollection : Swift.CustomDebugStringConvertible {}

--- a/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/arm64-apple-macos.swiftinterface
+++ b/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/arm64-apple-macos.swiftinterface
@@ -51,9 +51,6 @@ public struct GestureTrait : Swift.Hashable, Swift.Identifiable, Swift.Sendable 
   public struct AttributeKey : Swift.Hashable, Swift.Sendable, Swift.CustomStringConvertible {
     public let rawValue: Swift.Int
     public init(_ label: Swift.String)
-    public var label: Swift.String {
-      get
-    }
     public var description: Swift.String {
       get
     }

--- a/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/arm64-apple-macos.swiftinterface
+++ b/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/arm64-apple-macos.swiftinterface
@@ -41,15 +41,6 @@ public struct GestureTrait : Swift.Hashable, Swift.Identifiable, Swift.Sendable 
   public var id: Gestures.GestureTraitID
   public var attributes: [Gestures.GestureTrait.AttributeKey : Gestures.GestureTrait.AttributeValue]
   public init(id: Gestures.GestureTraitID, attributes: [Gestures.GestureTrait.AttributeKey : Gestures.GestureTrait.AttributeValue] = [:])
-  public var label: Swift.String {
-    get
-  }
-  public var description: Swift.String {
-    get
-  }
-  public var debugDescription: Swift.String {
-    get
-  }
   #if compiler(>=5.3) && $NonescapableTypes
   public static func tap(tapCount: Swift.Int? = nil, pointCount: Swift.Int? = nil) -> Gestures.GestureTrait
   #endif
@@ -121,24 +112,3 @@ public struct GestureTraitCollection : Swift.Hashable, Swift.Sendable {
     get
   }
 }
-extension GestureTraitCollection : Swift.Sequence {
-  public func makeIterator() -> some Swift.IteratorProtocol
-  
-  public typealias Element = (@_opaqueReturnTypeOf("$s8Gestures22GestureTraitCollectionV12makeIteratorQryF", 0) __).Element
-  public typealias Iterator = @_opaqueReturnTypeOf("$s8Gestures22GestureTraitCollectionV12makeIteratorQryF", 0) __
-}
-extension GestureTraitCollection {
-  public var label: Swift.String {
-    get
-  }
-  public var description: Swift.String {
-    get
-  }
-  public var debugDescription: Swift.String {
-    get
-  }
-}
-extension GestureTrait : Swift.CustomStringConvertible {}
-extension GestureTrait : Swift.CustomDebugStringConvertible {}
-extension GestureTraitCollection : Swift.CustomStringConvertible {}
-extension GestureTraitCollection : Swift.CustomDebugStringConvertible {}

--- a/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/arm64-apple-macos.swiftinterface
+++ b/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/arm64-apple-macos.swiftinterface
@@ -22,3 +22,123 @@ extension GFGestureRelationRole : Swift.CustomStringConvertible {
     get
   }
 }
+public struct GestureNodeOptions : Swift.OptionSet, Swift.Sendable {
+  public let rawValue: Swift.Int
+  public init(rawValue: Swift.Int)
+  public static let isDisabled: Gestures.GestureNodeOptions
+  public static let disallowExclusionWithUnresolvedFailureRequirements: Gestures.GestureNodeOptions
+  public static let isGloballyScoped: Gestures.GestureNodeOptions
+  public typealias ArrayLiteralElement = Gestures.GestureNodeOptions
+  public typealias Element = Gestures.GestureNodeOptions
+  public typealias RawValue = Swift.Int
+}
+extension GestureNodeOptions : Swift.CustomStringConvertible {
+  public var description: Swift.String {
+    get
+  }
+}
+public struct GestureTrait : Swift.Hashable, Swift.Identifiable, Swift.Sendable {
+  public var id: Gestures.GestureTraitID
+  public var attributes: [Gestures.GestureTrait.AttributeKey : Gestures.GestureTrait.AttributeValue]
+  public init(id: Gestures.GestureTraitID, attributes: [Gestures.GestureTrait.AttributeKey : Gestures.GestureTrait.AttributeValue] = [:])
+  public var label: Swift.String {
+    get
+  }
+  public var description: Swift.String {
+    get
+  }
+  public var debugDescription: Swift.String {
+    get
+  }
+  #if compiler(>=5.3) && $NonescapableTypes
+  public static func tap(tapCount: Swift.Int? = nil, pointCount: Swift.Int? = nil) -> Gestures.GestureTrait
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public static func longPress(pointCount: Swift.Int? = nil, minimumDuration: Swift.Duration? = nil, maximumMovement: Swift.Double? = nil) -> Gestures.GestureTrait
+  #endif
+  public static func pan() -> Gestures.GestureTrait
+  public struct AttributeKey : Swift.Hashable, Swift.Sendable, Swift.CustomStringConvertible {
+    public let rawValue: Swift.Int
+    public init(_ label: Swift.String)
+    public var label: Swift.String {
+      get
+    }
+    public var description: Swift.String {
+      get
+    }
+    public static let pointCount: Gestures.GestureTrait.AttributeKey
+    public static let tapCount: Gestures.GestureTrait.AttributeKey
+    public static let minimumDuration: Gestures.GestureTrait.AttributeKey
+    public static let maximumMovement: Gestures.GestureTrait.AttributeKey
+    public static func == (a: Gestures.GestureTrait.AttributeKey, b: Gestures.GestureTrait.AttributeKey) -> Swift.Bool
+    public func hash(into hasher: inout Swift.Hasher)
+    public var hashValue: Swift.Int {
+      get
+    }
+  }
+  public enum AttributeValue : Swift.Hashable, Swift.Sendable, Swift.CustomStringConvertible {
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case double(Swift.Double)
+    public var description: Swift.String {
+      get
+    }
+    public static func == (a: Gestures.GestureTrait.AttributeValue, b: Gestures.GestureTrait.AttributeValue) -> Swift.Bool
+    public func hash(into hasher: inout Swift.Hasher)
+    public var hashValue: Swift.Int {
+      get
+    }
+  }
+  public static func == (a: Gestures.GestureTrait, b: Gestures.GestureTrait) -> Swift.Bool
+  public typealias ID = Gestures.GestureTraitID
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+public struct GestureTraitID : Swift.Hashable, Swift.Sendable {
+  public let rawValue: Swift.Int
+  public init(_ label: Swift.String)
+  public static let tap: Gestures.GestureTraitID
+  public static let longPress: Gestures.GestureTraitID
+  public static let pan: Gestures.GestureTraitID
+  public static func == (a: Gestures.GestureTraitID, b: Gestures.GestureTraitID) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+public struct GestureTraitCollection : Swift.Hashable, Swift.Sendable {
+  public init(traits: [Gestures.GestureTrait] = [])
+  public static func withTrait(_ trait: Gestures.GestureTrait) -> Gestures.GestureTraitCollection
+  public var allTraits: [Gestures.GestureTrait] {
+    get
+  }
+  public func containsSubtraits(from other: Gestures.GestureTraitCollection) -> Swift.Bool
+  public static func == (a: Gestures.GestureTraitCollection, b: Gestures.GestureTraitCollection) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+extension GestureTraitCollection : Swift.Sequence {
+  public func makeIterator() -> some Swift.IteratorProtocol
+  
+  public typealias Element = (@_opaqueReturnTypeOf("$s8Gestures22GestureTraitCollectionV12makeIteratorQryF", 0) __).Element
+  public typealias Iterator = @_opaqueReturnTypeOf("$s8Gestures22GestureTraitCollectionV12makeIteratorQryF", 0) __
+}
+extension GestureTraitCollection {
+  public var label: Swift.String {
+    get
+  }
+  public var description: Swift.String {
+    get
+  }
+  public var debugDescription: Swift.String {
+    get
+  }
+}
+extension GestureTrait : Swift.CustomStringConvertible {}
+extension GestureTrait : Swift.CustomDebugStringConvertible {}
+extension GestureTraitCollection : Swift.CustomStringConvertible {}
+extension GestureTraitCollection : Swift.CustomDebugStringConvertible {}

--- a/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/arm64e-apple-macos.swiftinterface
+++ b/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/arm64e-apple-macos.swiftinterface
@@ -51,9 +51,6 @@ public struct GestureTrait : Swift.Hashable, Swift.Identifiable, Swift.Sendable 
   public struct AttributeKey : Swift.Hashable, Swift.Sendable, Swift.CustomStringConvertible {
     public let rawValue: Swift.Int
     public init(_ label: Swift.String)
-    public var label: Swift.String {
-      get
-    }
     public var description: Swift.String {
       get
     }

--- a/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/arm64e-apple-macos.swiftinterface
+++ b/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/arm64e-apple-macos.swiftinterface
@@ -41,15 +41,6 @@ public struct GestureTrait : Swift.Hashable, Swift.Identifiable, Swift.Sendable 
   public var id: Gestures.GestureTraitID
   public var attributes: [Gestures.GestureTrait.AttributeKey : Gestures.GestureTrait.AttributeValue]
   public init(id: Gestures.GestureTraitID, attributes: [Gestures.GestureTrait.AttributeKey : Gestures.GestureTrait.AttributeValue] = [:])
-  public var label: Swift.String {
-    get
-  }
-  public var description: Swift.String {
-    get
-  }
-  public var debugDescription: Swift.String {
-    get
-  }
   #if compiler(>=5.3) && $NonescapableTypes
   public static func tap(tapCount: Swift.Int? = nil, pointCount: Swift.Int? = nil) -> Gestures.GestureTrait
   #endif
@@ -121,24 +112,3 @@ public struct GestureTraitCollection : Swift.Hashable, Swift.Sendable {
     get
   }
 }
-extension GestureTraitCollection : Swift.Sequence {
-  public func makeIterator() -> some Swift.IteratorProtocol
-  
-  public typealias Element = (@_opaqueReturnTypeOf("$s8Gestures22GestureTraitCollectionV12makeIteratorQryF", 0) __).Element
-  public typealias Iterator = @_opaqueReturnTypeOf("$s8Gestures22GestureTraitCollectionV12makeIteratorQryF", 0) __
-}
-extension GestureTraitCollection {
-  public var label: Swift.String {
-    get
-  }
-  public var description: Swift.String {
-    get
-  }
-  public var debugDescription: Swift.String {
-    get
-  }
-}
-extension GestureTrait : Swift.CustomStringConvertible {}
-extension GestureTrait : Swift.CustomDebugStringConvertible {}
-extension GestureTraitCollection : Swift.CustomStringConvertible {}
-extension GestureTraitCollection : Swift.CustomDebugStringConvertible {}

--- a/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/arm64e-apple-macos.swiftinterface
+++ b/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/arm64e-apple-macos.swiftinterface
@@ -22,3 +22,123 @@ extension GFGestureRelationRole : Swift.CustomStringConvertible {
     get
   }
 }
+public struct GestureNodeOptions : Swift.OptionSet, Swift.Sendable {
+  public let rawValue: Swift.Int
+  public init(rawValue: Swift.Int)
+  public static let isDisabled: Gestures.GestureNodeOptions
+  public static let disallowExclusionWithUnresolvedFailureRequirements: Gestures.GestureNodeOptions
+  public static let isGloballyScoped: Gestures.GestureNodeOptions
+  public typealias ArrayLiteralElement = Gestures.GestureNodeOptions
+  public typealias Element = Gestures.GestureNodeOptions
+  public typealias RawValue = Swift.Int
+}
+extension GestureNodeOptions : Swift.CustomStringConvertible {
+  public var description: Swift.String {
+    get
+  }
+}
+public struct GestureTrait : Swift.Hashable, Swift.Identifiable, Swift.Sendable {
+  public var id: Gestures.GestureTraitID
+  public var attributes: [Gestures.GestureTrait.AttributeKey : Gestures.GestureTrait.AttributeValue]
+  public init(id: Gestures.GestureTraitID, attributes: [Gestures.GestureTrait.AttributeKey : Gestures.GestureTrait.AttributeValue] = [:])
+  public var label: Swift.String {
+    get
+  }
+  public var description: Swift.String {
+    get
+  }
+  public var debugDescription: Swift.String {
+    get
+  }
+  #if compiler(>=5.3) && $NonescapableTypes
+  public static func tap(tapCount: Swift.Int? = nil, pointCount: Swift.Int? = nil) -> Gestures.GestureTrait
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public static func longPress(pointCount: Swift.Int? = nil, minimumDuration: Swift.Duration? = nil, maximumMovement: Swift.Double? = nil) -> Gestures.GestureTrait
+  #endif
+  public static func pan() -> Gestures.GestureTrait
+  public struct AttributeKey : Swift.Hashable, Swift.Sendable, Swift.CustomStringConvertible {
+    public let rawValue: Swift.Int
+    public init(_ label: Swift.String)
+    public var label: Swift.String {
+      get
+    }
+    public var description: Swift.String {
+      get
+    }
+    public static let pointCount: Gestures.GestureTrait.AttributeKey
+    public static let tapCount: Gestures.GestureTrait.AttributeKey
+    public static let minimumDuration: Gestures.GestureTrait.AttributeKey
+    public static let maximumMovement: Gestures.GestureTrait.AttributeKey
+    public static func == (a: Gestures.GestureTrait.AttributeKey, b: Gestures.GestureTrait.AttributeKey) -> Swift.Bool
+    public func hash(into hasher: inout Swift.Hasher)
+    public var hashValue: Swift.Int {
+      get
+    }
+  }
+  public enum AttributeValue : Swift.Hashable, Swift.Sendable, Swift.CustomStringConvertible {
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case double(Swift.Double)
+    public var description: Swift.String {
+      get
+    }
+    public static func == (a: Gestures.GestureTrait.AttributeValue, b: Gestures.GestureTrait.AttributeValue) -> Swift.Bool
+    public func hash(into hasher: inout Swift.Hasher)
+    public var hashValue: Swift.Int {
+      get
+    }
+  }
+  public static func == (a: Gestures.GestureTrait, b: Gestures.GestureTrait) -> Swift.Bool
+  public typealias ID = Gestures.GestureTraitID
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+public struct GestureTraitID : Swift.Hashable, Swift.Sendable {
+  public let rawValue: Swift.Int
+  public init(_ label: Swift.String)
+  public static let tap: Gestures.GestureTraitID
+  public static let longPress: Gestures.GestureTraitID
+  public static let pan: Gestures.GestureTraitID
+  public static func == (a: Gestures.GestureTraitID, b: Gestures.GestureTraitID) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+public struct GestureTraitCollection : Swift.Hashable, Swift.Sendable {
+  public init(traits: [Gestures.GestureTrait] = [])
+  public static func withTrait(_ trait: Gestures.GestureTrait) -> Gestures.GestureTraitCollection
+  public var allTraits: [Gestures.GestureTrait] {
+    get
+  }
+  public func containsSubtraits(from other: Gestures.GestureTraitCollection) -> Swift.Bool
+  public static func == (a: Gestures.GestureTraitCollection, b: Gestures.GestureTraitCollection) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+extension GestureTraitCollection : Swift.Sequence {
+  public func makeIterator() -> some Swift.IteratorProtocol
+  
+  public typealias Element = (@_opaqueReturnTypeOf("$s8Gestures22GestureTraitCollectionV12makeIteratorQryF", 0) __).Element
+  public typealias Iterator = @_opaqueReturnTypeOf("$s8Gestures22GestureTraitCollectionV12makeIteratorQryF", 0) __
+}
+extension GestureTraitCollection {
+  public var label: Swift.String {
+    get
+  }
+  public var description: Swift.String {
+    get
+  }
+  public var debugDescription: Swift.String {
+    get
+  }
+}
+extension GestureTrait : Swift.CustomStringConvertible {}
+extension GestureTrait : Swift.CustomDebugStringConvertible {}
+extension GestureTraitCollection : Swift.CustomStringConvertible {}
+extension GestureTraitCollection : Swift.CustomDebugStringConvertible {}

--- a/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/x86_64-apple-macos.swiftinterface
+++ b/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/x86_64-apple-macos.swiftinterface
@@ -51,9 +51,6 @@ public struct GestureTrait : Swift.Hashable, Swift.Identifiable, Swift.Sendable 
   public struct AttributeKey : Swift.Hashable, Swift.Sendable, Swift.CustomStringConvertible {
     public let rawValue: Swift.Int
     public init(_ label: Swift.String)
-    public var label: Swift.String {
-      get
-    }
     public var description: Swift.String {
       get
     }

--- a/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/x86_64-apple-macos.swiftinterface
+++ b/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/x86_64-apple-macos.swiftinterface
@@ -41,15 +41,6 @@ public struct GestureTrait : Swift.Hashable, Swift.Identifiable, Swift.Sendable 
   public var id: Gestures.GestureTraitID
   public var attributes: [Gestures.GestureTrait.AttributeKey : Gestures.GestureTrait.AttributeValue]
   public init(id: Gestures.GestureTraitID, attributes: [Gestures.GestureTrait.AttributeKey : Gestures.GestureTrait.AttributeValue] = [:])
-  public var label: Swift.String {
-    get
-  }
-  public var description: Swift.String {
-    get
-  }
-  public var debugDescription: Swift.String {
-    get
-  }
   #if compiler(>=5.3) && $NonescapableTypes
   public static func tap(tapCount: Swift.Int? = nil, pointCount: Swift.Int? = nil) -> Gestures.GestureTrait
   #endif
@@ -121,24 +112,3 @@ public struct GestureTraitCollection : Swift.Hashable, Swift.Sendable {
     get
   }
 }
-extension GestureTraitCollection : Swift.Sequence {
-  public func makeIterator() -> some Swift.IteratorProtocol
-  
-  public typealias Element = (@_opaqueReturnTypeOf("$s8Gestures22GestureTraitCollectionV12makeIteratorQryF", 0) __).Element
-  public typealias Iterator = @_opaqueReturnTypeOf("$s8Gestures22GestureTraitCollectionV12makeIteratorQryF", 0) __
-}
-extension GestureTraitCollection {
-  public var label: Swift.String {
-    get
-  }
-  public var description: Swift.String {
-    get
-  }
-  public var debugDescription: Swift.String {
-    get
-  }
-}
-extension GestureTrait : Swift.CustomStringConvertible {}
-extension GestureTrait : Swift.CustomDebugStringConvertible {}
-extension GestureTraitCollection : Swift.CustomStringConvertible {}
-extension GestureTraitCollection : Swift.CustomDebugStringConvertible {}

--- a/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/x86_64-apple-macos.swiftinterface
+++ b/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/x86_64-apple-macos.swiftinterface
@@ -22,3 +22,123 @@ extension GFGestureRelationRole : Swift.CustomStringConvertible {
     get
   }
 }
+public struct GestureNodeOptions : Swift.OptionSet, Swift.Sendable {
+  public let rawValue: Swift.Int
+  public init(rawValue: Swift.Int)
+  public static let isDisabled: Gestures.GestureNodeOptions
+  public static let disallowExclusionWithUnresolvedFailureRequirements: Gestures.GestureNodeOptions
+  public static let isGloballyScoped: Gestures.GestureNodeOptions
+  public typealias ArrayLiteralElement = Gestures.GestureNodeOptions
+  public typealias Element = Gestures.GestureNodeOptions
+  public typealias RawValue = Swift.Int
+}
+extension GestureNodeOptions : Swift.CustomStringConvertible {
+  public var description: Swift.String {
+    get
+  }
+}
+public struct GestureTrait : Swift.Hashable, Swift.Identifiable, Swift.Sendable {
+  public var id: Gestures.GestureTraitID
+  public var attributes: [Gestures.GestureTrait.AttributeKey : Gestures.GestureTrait.AttributeValue]
+  public init(id: Gestures.GestureTraitID, attributes: [Gestures.GestureTrait.AttributeKey : Gestures.GestureTrait.AttributeValue] = [:])
+  public var label: Swift.String {
+    get
+  }
+  public var description: Swift.String {
+    get
+  }
+  public var debugDescription: Swift.String {
+    get
+  }
+  #if compiler(>=5.3) && $NonescapableTypes
+  public static func tap(tapCount: Swift.Int? = nil, pointCount: Swift.Int? = nil) -> Gestures.GestureTrait
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public static func longPress(pointCount: Swift.Int? = nil, minimumDuration: Swift.Duration? = nil, maximumMovement: Swift.Double? = nil) -> Gestures.GestureTrait
+  #endif
+  public static func pan() -> Gestures.GestureTrait
+  public struct AttributeKey : Swift.Hashable, Swift.Sendable, Swift.CustomStringConvertible {
+    public let rawValue: Swift.Int
+    public init(_ label: Swift.String)
+    public var label: Swift.String {
+      get
+    }
+    public var description: Swift.String {
+      get
+    }
+    public static let pointCount: Gestures.GestureTrait.AttributeKey
+    public static let tapCount: Gestures.GestureTrait.AttributeKey
+    public static let minimumDuration: Gestures.GestureTrait.AttributeKey
+    public static let maximumMovement: Gestures.GestureTrait.AttributeKey
+    public static func == (a: Gestures.GestureTrait.AttributeKey, b: Gestures.GestureTrait.AttributeKey) -> Swift.Bool
+    public func hash(into hasher: inout Swift.Hasher)
+    public var hashValue: Swift.Int {
+      get
+    }
+  }
+  public enum AttributeValue : Swift.Hashable, Swift.Sendable, Swift.CustomStringConvertible {
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case double(Swift.Double)
+    public var description: Swift.String {
+      get
+    }
+    public static func == (a: Gestures.GestureTrait.AttributeValue, b: Gestures.GestureTrait.AttributeValue) -> Swift.Bool
+    public func hash(into hasher: inout Swift.Hasher)
+    public var hashValue: Swift.Int {
+      get
+    }
+  }
+  public static func == (a: Gestures.GestureTrait, b: Gestures.GestureTrait) -> Swift.Bool
+  public typealias ID = Gestures.GestureTraitID
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+public struct GestureTraitID : Swift.Hashable, Swift.Sendable {
+  public let rawValue: Swift.Int
+  public init(_ label: Swift.String)
+  public static let tap: Gestures.GestureTraitID
+  public static let longPress: Gestures.GestureTraitID
+  public static let pan: Gestures.GestureTraitID
+  public static func == (a: Gestures.GestureTraitID, b: Gestures.GestureTraitID) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+public struct GestureTraitCollection : Swift.Hashable, Swift.Sendable {
+  public init(traits: [Gestures.GestureTrait] = [])
+  public static func withTrait(_ trait: Gestures.GestureTrait) -> Gestures.GestureTraitCollection
+  public var allTraits: [Gestures.GestureTrait] {
+    get
+  }
+  public func containsSubtraits(from other: Gestures.GestureTraitCollection) -> Swift.Bool
+  public static func == (a: Gestures.GestureTraitCollection, b: Gestures.GestureTraitCollection) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+extension GestureTraitCollection : Swift.Sequence {
+  public func makeIterator() -> some Swift.IteratorProtocol
+  
+  public typealias Element = (@_opaqueReturnTypeOf("$s8Gestures22GestureTraitCollectionV12makeIteratorQryF", 0) __).Element
+  public typealias Iterator = @_opaqueReturnTypeOf("$s8Gestures22GestureTraitCollectionV12makeIteratorQryF", 0) __
+}
+extension GestureTraitCollection {
+  public var label: Swift.String {
+    get
+  }
+  public var description: Swift.String {
+    get
+  }
+  public var debugDescription: Swift.String {
+    get
+  }
+}
+extension GestureTrait : Swift.CustomStringConvertible {}
+extension GestureTrait : Swift.CustomDebugStringConvertible {}
+extension GestureTraitCollection : Swift.CustomStringConvertible {}
+extension GestureTraitCollection : Swift.CustomDebugStringConvertible {}

--- a/GF/2025/Sources/Modules/Gestures.swiftmodule/template.swiftinterface
+++ b/GF/2025/Sources/Modules/Gestures.swiftmodule/template.swiftinterface
@@ -37,15 +37,6 @@ public struct GestureTrait : Swift.Hashable, Swift.Identifiable, Swift.Sendable 
   public var id: Gestures.GestureTraitID
   public var attributes: [Gestures.GestureTrait.AttributeKey : Gestures.GestureTrait.AttributeValue]
   public init(id: Gestures.GestureTraitID, attributes: [Gestures.GestureTrait.AttributeKey : Gestures.GestureTrait.AttributeValue] = [:])
-  public var label: Swift.String {
-    get
-  }
-  public var description: Swift.String {
-    get
-  }
-  public var debugDescription: Swift.String {
-    get
-  }
   #if compiler(>=5.3) && $NonescapableTypes
   public static func tap(tapCount: Swift.Int? = nil, pointCount: Swift.Int? = nil) -> Gestures.GestureTrait
   #endif
@@ -117,24 +108,3 @@ public struct GestureTraitCollection : Swift.Hashable, Swift.Sendable {
     get
   }
 }
-extension GestureTraitCollection : Swift.Sequence {
-  public func makeIterator() -> some Swift.IteratorProtocol
-  
-  public typealias Element = (@_opaqueReturnTypeOf("$s8Gestures22GestureTraitCollectionV12makeIteratorQryF", 0) __).Element
-  public typealias Iterator = @_opaqueReturnTypeOf("$s8Gestures22GestureTraitCollectionV12makeIteratorQryF", 0) __
-}
-extension GestureTraitCollection {
-  public var label: Swift.String {
-    get
-  }
-  public var description: Swift.String {
-    get
-  }
-  public var debugDescription: Swift.String {
-    get
-  }
-}
-extension GestureTrait : Swift.CustomStringConvertible {}
-extension GestureTrait : Swift.CustomDebugStringConvertible {}
-extension GestureTraitCollection : Swift.CustomStringConvertible {}
-extension GestureTraitCollection : Swift.CustomDebugStringConvertible {}

--- a/GF/2025/Sources/Modules/Gestures.swiftmodule/template.swiftinterface
+++ b/GF/2025/Sources/Modules/Gestures.swiftmodule/template.swiftinterface
@@ -47,9 +47,6 @@ public struct GestureTrait : Swift.Hashable, Swift.Identifiable, Swift.Sendable 
   public struct AttributeKey : Swift.Hashable, Swift.Sendable, Swift.CustomStringConvertible {
     public let rawValue: Swift.Int
     public init(_ label: Swift.String)
-    public var label: Swift.String {
-      get
-    }
     public var description: Swift.String {
       get
     }

--- a/GF/2025/Sources/Modules/Gestures.swiftmodule/template.swiftinterface
+++ b/GF/2025/Sources/Modules/Gestures.swiftmodule/template.swiftinterface
@@ -33,3 +33,108 @@ extension GestureNodeOptions : Swift.CustomStringConvertible {
     get
   }
 }
+public struct GestureTrait : Swift.Hashable, Swift.Identifiable, Swift.Sendable {
+  public var id: Gestures.GestureTraitID
+  public var attributes: [Gestures.GestureTrait.AttributeKey : Gestures.GestureTrait.AttributeValue]
+  public init(id: Gestures.GestureTraitID, attributes: [Gestures.GestureTrait.AttributeKey : Gestures.GestureTrait.AttributeValue] = [:])
+  public var label: Swift.String {
+    get
+  }
+  public var description: Swift.String {
+    get
+  }
+  public var debugDescription: Swift.String {
+    get
+  }
+  #if compiler(>=5.3) && $NonescapableTypes
+  public static func tap(tapCount: Swift.Int? = nil, pointCount: Swift.Int? = nil) -> Gestures.GestureTrait
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public static func longPress(pointCount: Swift.Int? = nil, minimumDuration: Swift.Duration? = nil, maximumMovement: Swift.Double? = nil) -> Gestures.GestureTrait
+  #endif
+  public static func pan() -> Gestures.GestureTrait
+  public struct AttributeKey : Swift.Hashable, Swift.Sendable, Swift.CustomStringConvertible {
+    public let rawValue: Swift.Int
+    public init(_ label: Swift.String)
+    public var label: Swift.String {
+      get
+    }
+    public var description: Swift.String {
+      get
+    }
+    public static let pointCount: Gestures.GestureTrait.AttributeKey
+    public static let tapCount: Gestures.GestureTrait.AttributeKey
+    public static let minimumDuration: Gestures.GestureTrait.AttributeKey
+    public static let maximumMovement: Gestures.GestureTrait.AttributeKey
+    public static func == (a: Gestures.GestureTrait.AttributeKey, b: Gestures.GestureTrait.AttributeKey) -> Swift.Bool
+    public func hash(into hasher: inout Swift.Hasher)
+    public var hashValue: Swift.Int {
+      get
+    }
+  }
+  public enum AttributeValue : Swift.Hashable, Swift.Sendable, Swift.CustomStringConvertible {
+    case bool(Swift.Bool)
+    case int(Swift.Int)
+    case double(Swift.Double)
+    public var description: Swift.String {
+      get
+    }
+    public static func == (a: Gestures.GestureTrait.AttributeValue, b: Gestures.GestureTrait.AttributeValue) -> Swift.Bool
+    public func hash(into hasher: inout Swift.Hasher)
+    public var hashValue: Swift.Int {
+      get
+    }
+  }
+  public static func == (a: Gestures.GestureTrait, b: Gestures.GestureTrait) -> Swift.Bool
+  public typealias ID = Gestures.GestureTraitID
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+public struct GestureTraitID : Swift.Hashable, Swift.Sendable {
+  public let rawValue: Swift.Int
+  public init(_ label: Swift.String)
+  public static let tap: Gestures.GestureTraitID
+  public static let longPress: Gestures.GestureTraitID
+  public static let pan: Gestures.GestureTraitID
+  public static func == (a: Gestures.GestureTraitID, b: Gestures.GestureTraitID) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+public struct GestureTraitCollection : Swift.Hashable, Swift.Sendable {
+  public init(traits: [Gestures.GestureTrait] = [])
+  public static func withTrait(_ trait: Gestures.GestureTrait) -> Gestures.GestureTraitCollection
+  public var allTraits: [Gestures.GestureTrait] {
+    get
+  }
+  public func containsSubtraits(from other: Gestures.GestureTraitCollection) -> Swift.Bool
+  public static func == (a: Gestures.GestureTraitCollection, b: Gestures.GestureTraitCollection) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+extension GestureTraitCollection : Swift.Sequence {
+  public func makeIterator() -> some Swift.IteratorProtocol
+  
+  public typealias Element = (@_opaqueReturnTypeOf("$s8Gestures22GestureTraitCollectionV12makeIteratorQryF", 0) __).Element
+  public typealias Iterator = @_opaqueReturnTypeOf("$s8Gestures22GestureTraitCollectionV12makeIteratorQryF", 0) __
+}
+extension GestureTraitCollection {
+  public var label: Swift.String {
+    get
+  }
+  public var description: Swift.String {
+    get
+  }
+  public var debugDescription: Swift.String {
+    get
+  }
+}
+extension GestureTrait : Swift.CustomStringConvertible {}
+extension GestureTrait : Swift.CustomDebugStringConvertible {}
+extension GestureTraitCollection : Swift.CustomStringConvertible {}
+extension GestureTraitCollection : Swift.CustomDebugStringConvertible {}

--- a/GF/2025/Sources/Modules/Gestures.swiftmodule/template.swiftinterface
+++ b/GF/2025/Sources/Modules/Gestures.swiftmodule/template.swiftinterface
@@ -18,3 +18,18 @@ extension GFGestureRelationRole : Swift.CustomStringConvertible {
     get
   }
 }
+public struct GestureNodeOptions : Swift.OptionSet, Swift.Sendable {
+  public let rawValue: Swift.Int
+  public init(rawValue: Swift.Int)
+  public static let isDisabled: Gestures.GestureNodeOptions
+  public static let disallowExclusionWithUnresolvedFailureRequirements: Gestures.GestureNodeOptions
+  public static let isGloballyScoped: Gestures.GestureNodeOptions
+  public typealias ArrayLiteralElement = Gestures.GestureNodeOptions
+  public typealias Element = Gestures.GestureNodeOptions
+  public typealias RawValue = Swift.Int
+}
+extension GestureNodeOptions : Swift.CustomStringConvertible {
+  public var description: Swift.String {
+    get
+  }
+}

--- a/GF/DeviceSwiftShims/Extension/StandardLibraryAdditions.swift
+++ b/GF/DeviceSwiftShims/Extension/StandardLibraryAdditions.swift
@@ -1,0 +1,10 @@
+//
+//  StandardLibraryAdditions.swift
+//  Gestures
+
+extension Double {
+    package init(_ duration: Duration) {
+        let (seconds, attoseconds) = duration.components
+        self = Double(seconds) + Double(attoseconds) / 1e18
+    }
+}

--- a/GF/DeviceSwiftShims/GestureCore/GestureTrait.swift
+++ b/GF/DeviceSwiftShims/GestureCore/GestureTrait.swift
@@ -8,31 +8,13 @@
 
 // MARK: - GestureTrait
 
-public struct GestureTrait: Hashable, Identifiable, Sendable, NestedCustomStringConvertible {
+public struct GestureTrait: Hashable, Identifiable, Sendable {
     public var id: GestureTraitID
     public var attributes: [AttributeKey: AttributeValue]
 
     public init(id: GestureTraitID, attributes: [AttributeKey: AttributeValue] = [:]) {
         self.id = id
         self.attributes = attributes
-    }
-
-    public var label: String {
-        TraitLabelStore.shared.label(for: id.rawValue)
-    }
-
-    // TBA
-    public var description: String {
-        if attributes.isEmpty {
-            return label
-        }
-        let attrs = attributes.map { "\($0.key.label): \($0.value)" }.joined(separator: ", ")
-        return "\(label)(\(attrs))"
-    }
-
-    // TBA
-    public var debugDescription: String {
-        description
     }
 
     // MARK: - Factory Methods
@@ -113,6 +95,25 @@ public struct GestureTrait: Hashable, Identifiable, Sendable, NestedCustomString
     }
 }
 
+@_spi(Private)
+extension GestureTrait: NestedCustomStringConvertible {
+    public var label: String {
+        TraitLabelStore.shared.label(for: id.rawValue)
+    }
+
+    public var description: String {
+        if attributes.isEmpty {
+            return label
+        }
+        let attrs = attributes.map { "\($0.key.label): \($0.value)" }.joined(separator: ", ")
+        return "\(label) {\(attrs)}"
+    }
+
+    public var debugDescription: String {
+        description
+    }
+}
+
 // MARK: - GestureTraitID
 
 public struct GestureTraitID: Hashable, Sendable {
@@ -163,6 +164,7 @@ public struct GestureTraitCollection: Hashable, Sendable {
 
 // MARK: - GestureTraitCollection + Sequence
 
+@_spi(Private)
 extension GestureTraitCollection: Sequence {
     public func makeIterator() -> some IteratorProtocol {
         _traits.values.makeIterator()
@@ -171,13 +173,12 @@ extension GestureTraitCollection: Sequence {
 
 // MARK: - GestureTraitCollection + CustomStringConvertible
 
-// TBA
+@_spi(Private)
 extension GestureTraitCollection: NestedCustomStringConvertible {
     public var label: String { "GestureTraitCollection" }
 
     public var description: String {
-        let traitDescs = _traits.values.map(\.description).joined(separator: ", ")
-        return "[\(traitDescs)]"
+        "[\(_traits.values.map(\.description).joined(separator: ", "))]"
     }
 
     public var debugDescription: String {
@@ -187,8 +188,9 @@ extension GestureTraitCollection: NestedCustomStringConvertible {
 
 // MARK: - GestureTraitCollection + Mergeable
 
+@_spi(Private)
 extension GestureTraitCollection: Mergeable {
-    package mutating func merge(_ other: GestureTraitCollection) {
+    public mutating func merge(_ other: GestureTraitCollection) {
         _traits.merge(other._traits) { $1 }
     }
 }

--- a/GF/DeviceSwiftShims/GestureCore/GestureTrait.swift
+++ b/GF/DeviceSwiftShims/GestureCore/GestureTrait.swift
@@ -61,7 +61,7 @@ public struct GestureTrait: Hashable, Identifiable, Sendable {
             self.rawValue = TraitLabelStore.shared.register(label)
         }
 
-        public var label: String {
+        package var label: String {
             TraitLabelStore.shared.label(for: rawValue)
         }
 

--- a/GF/DeviceSwiftShims/GestureCore/GestureTrait.swift
+++ b/GF/DeviceSwiftShims/GestureCore/GestureTrait.swift
@@ -1,0 +1,243 @@
+//
+//  GestureTrait.swift
+//  Gestures
+//
+//  Audited for 9126.1.5
+//  Status: Complete
+//  ID: 6B817C31FCBD37CBF6F881EA231AB252 (Gestures)
+
+// MARK: - GestureTrait
+
+public struct GestureTrait: Hashable, Identifiable, Sendable, NestedCustomStringConvertible {
+    public var id: GestureTraitID
+    public var attributes: [AttributeKey: AttributeValue]
+
+    public init(id: GestureTraitID, attributes: [AttributeKey: AttributeValue] = [:]) {
+        self.id = id
+        self.attributes = attributes
+    }
+
+    public var label: String {
+        TraitLabelStore.shared.label(for: id.rawValue)
+    }
+
+    // TBA
+    public var description: String {
+        if attributes.isEmpty {
+            return label
+        }
+        let attrs = attributes.map { "\($0.key.label): \($0.value)" }.joined(separator: ", ")
+        return "\(label)(\(attrs))"
+    }
+
+    // TBA
+    public var debugDescription: String {
+        description
+    }
+
+    // MARK: - Factory Methods
+
+    public static func tap(tapCount: Int? = nil, pointCount: Int? = nil) -> GestureTrait {
+        var attrs: [AttributeKey: AttributeValue] = [:]
+        if let tapCount {
+            attrs[.tapCount] = .int(tapCount)
+        }
+        if let pointCount {
+            attrs[.pointCount] = .int(pointCount)
+        }
+        return GestureTrait(id: .tap, attributes: attrs)
+    }
+
+    public static func longPress(
+        pointCount: Int? = nil,
+        minimumDuration: Duration? = nil,
+        maximumMovement: Double? = nil
+    ) -> GestureTrait {
+        var attrs: [AttributeKey: AttributeValue] = [:]
+        if let pointCount {
+            attrs[.pointCount] = .int(pointCount)
+        }
+        if let minimumDuration {
+            attrs[.minimumDuration] = .double(Double(minimumDuration))
+        }
+        if let maximumMovement {
+            attrs[.maximumMovement] = .double(maximumMovement)
+        }
+        return GestureTrait(id: .longPress, attributes: attrs)
+    }
+
+    public static func pan() -> GestureTrait {
+        GestureTrait(id: .pan, attributes: [:])
+    }
+
+    // MARK: - AttributeKey
+
+    public struct AttributeKey: Hashable, Sendable, CustomStringConvertible {
+        public let rawValue: Int
+
+        public init(_ label: String) {
+            self.rawValue = TraitLabelStore.shared.register(label)
+        }
+
+        public var label: String {
+            TraitLabelStore.shared.label(for: rawValue)
+        }
+
+        public var description: String {
+            label
+        }
+
+        public static let pointCount = AttributeKey("pointCount")
+        public static let tapCount = AttributeKey("tapCount")
+        public static let minimumDuration = AttributeKey("minimumDuration")
+        public static let maximumMovement = AttributeKey("maximumMovement")
+    }
+
+    // MARK: - AttributeValue
+
+    public enum AttributeValue: Hashable, Sendable, CustomStringConvertible {
+        case bool(Bool)
+        case int(Int)
+        case double(Double)
+
+        public var description: String {
+            switch self {
+            case let .bool(value):
+                value ? "true" : "false"
+            case let .int(value):
+                "\(value)"
+            case let .double(value):
+                "\(value)"
+            }
+        }
+    }
+}
+
+// MARK: - GestureTraitID
+
+public struct GestureTraitID: Hashable, Sendable {
+    public let rawValue: Int
+
+    public init(_ label: String) {
+        self.rawValue = TraitLabelStore.shared.register(label)
+    }
+
+    // MARK: - Static Properties
+
+    public static let tap = GestureTraitID("tap")
+    public static let longPress = GestureTraitID("longPress")
+    public static let pan = GestureTraitID("pan")
+}
+
+
+// MARK: - GestureTraitCollection
+
+public struct GestureTraitCollection: Hashable, Sendable {
+    private var _traits: [GestureTraitID: GestureTrait]
+
+    public init(traits: [GestureTrait] = []) {
+        var dict: [GestureTraitID: GestureTrait] = [:]
+        for trait in traits {
+            dict[trait.id] = trait
+        }
+        self._traits = dict
+    }
+
+    public static func withTrait(_ trait: GestureTrait) -> GestureTraitCollection {
+        GestureTraitCollection(traits: [trait])
+    }
+
+    public var allTraits: [GestureTrait] {
+        Array(_traits.values)
+    }
+
+    public func containsSubtraits(from other: GestureTraitCollection) -> Bool {
+        for (id, otherTrait) in other._traits {
+            guard let selfTrait = _traits[id], selfTrait == otherTrait else {
+                return false
+            }
+        }
+        return true
+    }
+}
+
+// MARK: - GestureTraitCollection + Sequence
+
+extension GestureTraitCollection: Sequence {
+    public func makeIterator() -> some IteratorProtocol {
+        _traits.values.makeIterator()
+    }
+}
+
+// MARK: - GestureTraitCollection + CustomStringConvertible
+
+// TBA
+extension GestureTraitCollection: NestedCustomStringConvertible {
+    public var label: String { "GestureTraitCollection" }
+
+    public var description: String {
+        let traitDescs = _traits.values.map(\.description).joined(separator: ", ")
+        return "[\(traitDescs)]"
+    }
+
+    public var debugDescription: String {
+        description
+    }
+}
+
+// MARK: - GestureTraitCollection + Mergeable
+
+extension GestureTraitCollection: Mergeable {
+    package mutating func merge(_ other: GestureTraitCollection) {
+        _traits.merge(other._traits) { $1 }
+    }
+}
+
+import Synchronization
+#if canImport(os)
+import os
+#endif
+
+// MARK: - TraitLabelStore
+
+private final class TraitLabelStore {
+    static let shared = TraitLabelStore()
+
+    private static let counter = Atomic(0)
+
+    #if canImport(os)
+    private var labels: [Int: String] = [:]
+    private let lock: OSAllocatedUnfairLock = .init()
+
+    func register(_ label: String) -> Int {
+        let (_, id) = Self.counter.add(1, ordering: .relaxed)
+        lock.withLock {
+            labels[id] = label
+        }
+        return id
+    }
+
+    func label(for rawValue: Int) -> String {
+        lock.withLock {
+            labels[rawValue]
+        } ?? ""
+    }
+
+    #else
+    private let labels: Mutex<[Int: String]> = .init([:])
+
+    func register(_ label: String) -> Int {
+        let (_, id) = Self.counter.add(1, ordering: .relaxed)
+        labels.withLock {
+            $0[id] = label
+        }
+        return id
+    }
+
+    package func label(for rawValue: Int) -> String {
+        labels.withLock {
+            $0[rawValue]
+        } ?? ""
+    }
+    #endif
+}

--- a/GF/DeviceSwiftShims/GestureCore/Mergeable.swift
+++ b/GF/DeviceSwiftShims/GestureCore/Mergeable.swift
@@ -1,0 +1,13 @@
+//
+//  Mergeable.swift
+//  Gestures
+//
+//  Audited for 9126.1.5
+//  Status: WIP
+
+// MARK: - Mergeable
+
+// TBA
+package protocol Mergeable {
+    mutating func merge(_ other: Self)
+}

--- a/GF/DeviceSwiftShims/GestureCore/Mergeable.swift
+++ b/GF/DeviceSwiftShims/GestureCore/Mergeable.swift
@@ -3,11 +3,11 @@
 //  Gestures
 //
 //  Audited for 9126.1.5
-//  Status: WIP
+//  Status: Complete
 
 // MARK: - Mergeable
 
-// TBA
-package protocol Mergeable {
+@_spi(Private)
+public protocol Mergeable {
     mutating func merge(_ other: Self)
 }

--- a/GF/DeviceSwiftShims/GestureCore/NestedCustomStringConvertible.swift
+++ b/GF/DeviceSwiftShims/GestureCore/NestedCustomStringConvertible.swift
@@ -7,7 +7,7 @@
 
 // MARK: - NestedCustomStringConvertible
 
-// TBA
-package protocol NestedCustomStringConvertible: CustomDebugStringConvertible, CustomStringConvertible {
+@_spi(Private)
+public protocol NestedCustomStringConvertible: CustomDebugStringConvertible, CustomStringConvertible {
     var label: String { get }
 }

--- a/GF/DeviceSwiftShims/GestureCore/NestedCustomStringConvertible.swift
+++ b/GF/DeviceSwiftShims/GestureCore/NestedCustomStringConvertible.swift
@@ -1,0 +1,13 @@
+//
+//  NestedCustomStringConvertible.swift
+//  Gestures
+//
+//  Audited for 9126.1.5
+//  Status: WIP
+
+// MARK: - NestedCustomStringConvertible
+
+// TBA
+package protocol NestedCustomStringConvertible: CustomDebugStringConvertible, CustomStringConvertible {
+    var label: String { get }
+}

--- a/GF/DeviceSwiftShims/GestureNode/GestureNodeOptions.swift
+++ b/GF/DeviceSwiftShims/GestureNode/GestureNodeOptions.swift
@@ -36,6 +36,6 @@ extension GestureNodeOptions: CustomStringConvertible {
         if contains(.isGloballyScoped) {
             names.append("isGloballyScoped")
         }
-        return "GestureNodeOptions { \(names.joined(separator: ", ")) }"
+        return "{ \(names.joined(separator: " | ")) }"
     }
 }

--- a/GF/DeviceSwiftShims/GestureNode/GestureNodeOptions.swift
+++ b/GF/DeviceSwiftShims/GestureNode/GestureNodeOptions.swift
@@ -1,0 +1,41 @@
+//
+//  GestureNodeOptions.swift
+//  Gestures
+//
+//  Audited for 9126.1.5
+//  Status: Complete
+
+// MARK: - GestureNodeOptions
+
+public struct GestureNodeOptions: OptionSet, Sendable {
+    public let rawValue: Int
+
+    public init(rawValue: Int) {
+        self.rawValue = rawValue
+    }
+
+    public static let isDisabled = GestureNodeOptions(rawValue: 0x1)
+    public static let disallowExclusionWithUnresolvedFailureRequirements = GestureNodeOptions(rawValue: 0x2)
+    public static let isGloballyScoped = GestureNodeOptions(rawValue: 0x4)
+}
+
+// MARK: - GestureNodeOptions + CustomStringConvertible
+
+extension GestureNodeOptions: CustomStringConvertible {
+    public var description: String {
+        guard self != [] else {
+            return "none"
+        }
+        var names: [String] = []
+        if contains(.isDisabled) {
+            names.append("isDisabled")
+        }
+        if contains(.disallowExclusionWithUnresolvedFailureRequirements) {
+            names.append("disallowExclusionWithUnresolvedFailureRequirements")
+        }
+        if contains(.isGloballyScoped) {
+            names.append("isGloballyScoped")
+        }
+        return "GestureNodeOptions { \(names.joined(separator: ", ")) }"
+    }
+}

--- a/GF/generate_swiftinterface.sh
+++ b/GF/generate_swiftinterface.sh
@@ -40,6 +40,7 @@ xcrun --sdk iphonesimulator swiftc \
     -emit-module-interface-path "${GENERATED}" \
     -emit-module-path "${TMPDIR_WORK}/module.swiftmodule" \
     -module-name Gestures \
+    -package-name Gestures \
     -enable-library-evolution \
     -swift-version 5 \
     -Osize \

--- a/GF/generate_swiftinterface.sh
+++ b/GF/generate_swiftinterface.sh
@@ -47,8 +47,7 @@ xcrun --sdk iphonesimulator swiftc \
     -enable-experimental-feature Extern \
     -target "arm64-apple-ios${IOS_SDK_VERSION}-simulator" \
     -F "${FRAMEWORK_ROOT}/Gestures.xcframework/ios-arm64-x86_64-simulator/" \
-    "${SHIMS_DIR}/Export.swift" \
-    $(find "${SHIMS_DIR}/Extension" -name '*.swift' 2>/dev/null) \
+    $(find "${SHIMS_DIR}" -name '*.swift') \
     2>/dev/null
 
 if [ ! -f "${GENERATED}" ]; then


### PR DESCRIPTION
## Summary
- Add `GestureNodeOptions` OptionSet with `isDisabled`, `disallowExclusionWithUnresolvedFailureRequirements`, and `isGloballyScoped` flags
- Add `GestureTrait` / `GestureTraitID` / `GestureTraitCollection` APIs with factory methods for tap, longPress, and pan gestures
- Add supporting protocols: `Mergeable`, `NestedCustomStringConvertible`, and `StandardLibraryAdditions` (Duration → Double conversion)
- Regenerate swiftinterface files across all platform slices to include the new public API
- Fix GF interface build and remove unlinkable symbol

All types audited against Gestures 9126.1.5.

## Test plan
- [ ] `swift build` succeeds
- [ ] `bash GF/update.sh` regenerates xcframework without errors
- [ ] Swiftinterface files reflect new `GestureNodeOptions` and `GestureTrait` types