### PR TITLE
Add Gestures.framework relation and description API

### DIFF
--- a/AG/generate_swiftinterface.sh
+++ b/AG/generate_swiftinterface.sh
@@ -12,6 +12,7 @@ filepath() {
 }
 
 SCRIPT_DIR="$(dirname "$(filepath "$0")")"
+PACKAGE_DIR="$(dirname "${SCRIPT_DIR}")"
 VERSION=${DARWINPRIVATEFRAMEWORKS_TARGET_RELEASE:-2024}
 FRAMEWORK_ROOT="${SCRIPT_DIR}/${VERSION}"
 SHIMS_DIR="${SCRIPT_DIR}/DeviceSwiftShims"
@@ -26,16 +27,27 @@ if [ "${SWIFT_VERSION}" != "${EXPECTED_SWIFT_VERSION}" ]; then
     exit 1
 fi
 
+# Build package dependencies via SPM
+swift build --package-path "${PACKAGE_DIR}" --target _AttributeGraphDeviceSwiftShims 2>/dev/null
+if [ $? -ne 0 ]; then
+    echo "Error: failed to build package dependencies"
+    exit 1
+fi
+
+# Locate the SPM modules directory for import search paths
+BUILD_BIN_PATH=$(swift build --package-path "${PACKAGE_DIR}" --show-bin-path 2>/dev/null)
+MODULES_DIR="${BUILD_BIN_PATH}/Modules"
+
 TMPDIR_WORK=$(mktemp -d)
 trap "rm -rf ${TMPDIR_WORK}" EXIT
 
 GENERATED="${TMPDIR_WORK}/generated.swiftinterface"
 
-# Resolve the iOS Simulator SDK version for the -target flag
-IOS_SDK_VERSION=$(xcrun --sdk iphonesimulator --show-sdk-version)
+# Use macOS SDK to match the host-built SPM modules
+MACOS_SDK_VERSION=$(xcrun --sdk macosx --show-sdk-version)
 
-# Compile DeviceSwiftShims against the simulator xcframework to emit a swiftinterface
-xcrun --sdk iphonesimulator swiftc \
+# Compile DeviceSwiftShims against the macOS xcframework to emit a swiftinterface
+xcrun --sdk macosx swiftc \
     -emit-module-interface-path "${GENERATED}" \
     -emit-module-path "${TMPDIR_WORK}/module.swiftmodule" \
     -module-name AttributeGraph \
@@ -44,8 +56,9 @@ xcrun --sdk iphonesimulator swiftc \
     -Osize \
     -enable-upcoming-feature InternalImportsByDefault \
     -enable-experimental-feature Extern \
-    -target "arm64-apple-ios${IOS_SDK_VERSION}-simulator" \
-    -F "${FRAMEWORK_ROOT}/AttributeGraph.xcframework/ios-arm64-x86_64-simulator/" \
+    -target "arm64-apple-macos${MACOS_SDK_VERSION}" \
+    -F "${FRAMEWORK_ROOT}/AttributeGraph.xcframework/macos-arm64e-arm64-x86_64/" \
+    -I "${MODULES_DIR}" \
     $(find "${SHIMS_DIR}" -name '*.swift') \
     2>/dev/null
 

--- a/Example/Tuist/Package.resolved
+++ b/Example/Tuist/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "53ebba4f824ac9815194bdfc84ac7b2eee75974f916545881c9f478ec9c8a278",
+  "pins" : [
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections",
+      "state" : {
+        "revision" : "6675bc0ff86e61436e615df6fc5174e043e57924",
+        "version" : "1.4.1"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/GF/2025/Gestures.xcframework/ios-arm64-x86_64-simulator/Gestures.framework/Modules/Gestures.swiftmodule/arm64-apple-ios-simulator.swiftinterface
+++ b/GF/2025/Gestures.xcframework/ios-arm64-x86_64-simulator/Gestures.framework/Modules/Gestures.swiftmodule/arm64-apple-ios-simulator.swiftinterface
@@ -54,6 +54,11 @@ public struct GestureTrait : Swift.Hashable, Swift.Identifiable, Swift.Sendable 
     get
   }
 }
+extension Gestures.GestureTrait {
+  public var label: Swift.String {
+    get
+  }
+}
 public struct GestureTraitID : Swift.Hashable, Swift.Sendable {
   public let rawValue: Swift.Int
   public init(_ label: Swift.String)
@@ -204,4 +209,10 @@ extension Gestures.GestureNodeOptions : Swift.CustomStringConvertible {
     get
   }
 }
+extension Gestures.GestureTrait : Swift.CustomStringConvertible {}
+extension Gestures.GestureTrait : Swift.CustomDebugStringConvertible {}
+extension Gestures.GestureTraitCollection : Swift.CustomStringConvertible {}
+extension Gestures.GestureTraitCollection : Swift.CustomDebugStringConvertible {}
+extension Gestures.GestureNodeMatcher : Swift.CustomStringConvertible {}
+extension Gestures.GestureNodeMatcher : Swift.CustomDebugStringConvertible {}
 extension Gestures.GestureNodeID : Swift.BitwiseCopyable {}

--- a/GF/2025/Gestures.xcframework/ios-arm64-x86_64-simulator/Gestures.framework/Modules/Gestures.swiftmodule/arm64-apple-ios-simulator.swiftinterface
+++ b/GF/2025/Gestures.xcframework/ios-arm64-x86_64-simulator/Gestures.framework/Modules/Gestures.swiftmodule/arm64-apple-ios-simulator.swiftinterface
@@ -79,6 +79,30 @@ public struct GestureTraitCollection : Swift.Hashable, Swift.Sendable {
     get
   }
 }
+public enum GestureNodeMatcher : Swift.Hashable, Swift.Sendable {
+  case id(Gestures.GestureNodeID)
+  case tag(Gestures.GestureTag)
+  case traits(Gestures.GestureTraitCollection, position: Gestures.GestureNodeMatcher.RelativePosition)
+  case any(position: Gestures.GestureNodeMatcher.RelativePosition)
+  public enum RelativePosition : Swift.Hashable, Swift.Sendable {
+    case any
+    case above
+    case below
+    public static func == (a: Gestures.GestureNodeMatcher.RelativePosition, b: Gestures.GestureNodeMatcher.RelativePosition) -> Swift.Bool
+    public func hash(into hasher: inout Swift.Hasher)
+    public var hashValue: Swift.Int {
+      get
+    }
+  }
+  public static func == (a: Gestures.GestureNodeMatcher, b: Gestures.GestureNodeMatcher) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+extension GestureNodeMatcher : Swift.Comparable {
+  public static func < (lhs: Gestures.GestureNodeMatcher, rhs: Gestures.GestureNodeMatcher) -> Swift.Bool
+}
 @frozen public struct GestureTag : Swift.Hashable, Swift.Sendable, Swift.ExpressibleByStringLiteral, Swift.CustomStringConvertible {
   public let rawValue: Swift.String
   public init(rawValue: Swift.String)

--- a/GF/2025/Gestures.xcframework/ios-arm64-x86_64-simulator/Gestures.framework/Modules/Gestures.swiftmodule/arm64-apple-ios-simulator.swiftinterface
+++ b/GF/2025/Gestures.xcframework/ios-arm64-x86_64-simulator/Gestures.framework/Modules/Gestures.swiftmodule/arm64-apple-ios-simulator.swiftinterface
@@ -79,6 +79,49 @@ public struct GestureTraitCollection : Swift.Hashable, Swift.Sendable {
     get
   }
 }
+public enum GestureRelationType : Swift.Hashable, Swift.Sendable {
+  case exclusion
+  case activeExclusion
+  case failureRequirement
+  public static func == (a: Gestures.GestureRelationType, b: Gestures.GestureRelationType) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+public enum GestureRelationRole : Swift.Hashable, Swift.Sendable {
+  case regular
+  case blocking
+  public static func == (a: Gestures.GestureRelationRole, b: Gestures.GestureRelationRole) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+public enum GestureRelationDirection : Swift.Hashable, Swift.Sendable {
+  case outgoing
+  case incoming
+  public static func == (a: Gestures.GestureRelationDirection, b: Gestures.GestureRelationDirection) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+public struct GestureRelation : Swift.Equatable, Swift.Sendable {
+  public var type: Gestures.GestureRelationType
+  public var direction: Gestures.GestureRelationDirection
+  public var role: Gestures.GestureRelationRole?
+  public var target: Gestures.GestureNodeMatcher
+  #if compiler(>=5.3) && $NonescapableTypes
+  public init(type: Gestures.GestureRelationType, direction: Gestures.GestureRelationDirection, role: Gestures.GestureRelationRole?, target: Gestures.GestureNodeMatcher)
+  #endif
+  public static func == (a: Gestures.GestureRelation, b: Gestures.GestureRelation) -> Swift.Bool
+}
+extension Swift.Array where Element == Gestures.GestureRelation {
+  public static var `default`: [Gestures.GestureRelation] {
+    get
+  }
+}
 public enum GestureNodeMatcher : Swift.Hashable, Swift.Sendable {
   case id(Gestures.GestureNodeID)
   case tag(Gestures.GestureTag)

--- a/GF/2025/Gestures.xcframework/ios-arm64-x86_64-simulator/Gestures.framework/Modules/Gestures.swiftmodule/arm64-apple-ios-simulator.swiftinterface
+++ b/GF/2025/Gestures.xcframework/ios-arm64-x86_64-simulator/Gestures.framework/Modules/Gestures.swiftmodule/arm64-apple-ios-simulator.swiftinterface
@@ -143,7 +143,7 @@ public enum GestureNodeMatcher : Swift.Hashable, Swift.Sendable {
     get
   }
 }
-extension GestureNodeMatcher : Swift.Comparable {
+extension Gestures.GestureNodeMatcher : Swift.Comparable {
   public static func < (lhs: Gestures.GestureNodeMatcher, rhs: Gestures.GestureNodeMatcher) -> Swift.Bool
 }
 @frozen public struct GestureTag : Swift.Hashable, Swift.Sendable, Swift.ExpressibleByStringLiteral, Swift.CustomStringConvertible {
@@ -162,17 +162,17 @@ extension GestureNodeMatcher : Swift.Comparable {
     get
   }
 }
-extension GFGesturePhase : Swift.CustomStringConvertible {
+extension Gestures.GFGesturePhase : Swift.CustomStringConvertible {
   public var description: Swift.String {
     get
   }
 }
-extension GFGestureRelationType : Swift.CustomStringConvertible {
+extension Gestures.GFGestureRelationType : Swift.CustomStringConvertible {
   public var description: Swift.String {
     get
   }
 }
-extension GFGestureRelationRole : Swift.CustomStringConvertible {
+extension Gestures.GFGestureRelationRole : Swift.CustomStringConvertible {
   public var description: Swift.String {
     get
   }
@@ -199,9 +199,9 @@ public struct GestureNodeOptions : Swift.OptionSet, Swift.Sendable {
   public typealias Element = Gestures.GestureNodeOptions
   public typealias RawValue = Swift.Int
 }
-extension GestureNodeOptions : Swift.CustomStringConvertible {
+extension Gestures.GestureNodeOptions : Swift.CustomStringConvertible {
   public var description: Swift.String {
     get
   }
 }
-extension GestureNodeID : Swift.BitwiseCopyable {}
+extension Gestures.GestureNodeID : Swift.BitwiseCopyable {}

--- a/GF/2025/Gestures.xcframework/ios-arm64-x86_64-simulator/Gestures.framework/Modules/Gestures.swiftmodule/x86_64-apple-ios-simulator.swiftinterface
+++ b/GF/2025/Gestures.xcframework/ios-arm64-x86_64-simulator/Gestures.framework/Modules/Gestures.swiftmodule/x86_64-apple-ios-simulator.swiftinterface
@@ -54,6 +54,11 @@ public struct GestureTrait : Swift.Hashable, Swift.Identifiable, Swift.Sendable 
     get
   }
 }
+extension Gestures.GestureTrait {
+  public var label: Swift.String {
+    get
+  }
+}
 public struct GestureTraitID : Swift.Hashable, Swift.Sendable {
   public let rawValue: Swift.Int
   public init(_ label: Swift.String)
@@ -204,4 +209,10 @@ extension Gestures.GestureNodeOptions : Swift.CustomStringConvertible {
     get
   }
 }
+extension Gestures.GestureTrait : Swift.CustomStringConvertible {}
+extension Gestures.GestureTrait : Swift.CustomDebugStringConvertible {}
+extension Gestures.GestureTraitCollection : Swift.CustomStringConvertible {}
+extension Gestures.GestureTraitCollection : Swift.CustomDebugStringConvertible {}
+extension Gestures.GestureNodeMatcher : Swift.CustomStringConvertible {}
+extension Gestures.GestureNodeMatcher : Swift.CustomDebugStringConvertible {}
 extension Gestures.GestureNodeID : Swift.BitwiseCopyable {}

--- a/GF/2025/Gestures.xcframework/ios-arm64-x86_64-simulator/Gestures.framework/Modules/Gestures.swiftmodule/x86_64-apple-ios-simulator.swiftinterface
+++ b/GF/2025/Gestures.xcframework/ios-arm64-x86_64-simulator/Gestures.framework/Modules/Gestures.swiftmodule/x86_64-apple-ios-simulator.swiftinterface
@@ -79,6 +79,30 @@ public struct GestureTraitCollection : Swift.Hashable, Swift.Sendable {
     get
   }
 }
+public enum GestureNodeMatcher : Swift.Hashable, Swift.Sendable {
+  case id(Gestures.GestureNodeID)
+  case tag(Gestures.GestureTag)
+  case traits(Gestures.GestureTraitCollection, position: Gestures.GestureNodeMatcher.RelativePosition)
+  case any(position: Gestures.GestureNodeMatcher.RelativePosition)
+  public enum RelativePosition : Swift.Hashable, Swift.Sendable {
+    case any
+    case above
+    case below
+    public static func == (a: Gestures.GestureNodeMatcher.RelativePosition, b: Gestures.GestureNodeMatcher.RelativePosition) -> Swift.Bool
+    public func hash(into hasher: inout Swift.Hasher)
+    public var hashValue: Swift.Int {
+      get
+    }
+  }
+  public static func == (a: Gestures.GestureNodeMatcher, b: Gestures.GestureNodeMatcher) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+extension GestureNodeMatcher : Swift.Comparable {
+  public static func < (lhs: Gestures.GestureNodeMatcher, rhs: Gestures.GestureNodeMatcher) -> Swift.Bool
+}
 @frozen public struct GestureTag : Swift.Hashable, Swift.Sendable, Swift.ExpressibleByStringLiteral, Swift.CustomStringConvertible {
   public let rawValue: Swift.String
   public init(rawValue: Swift.String)

--- a/GF/2025/Gestures.xcframework/ios-arm64-x86_64-simulator/Gestures.framework/Modules/Gestures.swiftmodule/x86_64-apple-ios-simulator.swiftinterface
+++ b/GF/2025/Gestures.xcframework/ios-arm64-x86_64-simulator/Gestures.framework/Modules/Gestures.swiftmodule/x86_64-apple-ios-simulator.swiftinterface
@@ -79,6 +79,49 @@ public struct GestureTraitCollection : Swift.Hashable, Swift.Sendable {
     get
   }
 }
+public enum GestureRelationType : Swift.Hashable, Swift.Sendable {
+  case exclusion
+  case activeExclusion
+  case failureRequirement
+  public static func == (a: Gestures.GestureRelationType, b: Gestures.GestureRelationType) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+public enum GestureRelationRole : Swift.Hashable, Swift.Sendable {
+  case regular
+  case blocking
+  public static func == (a: Gestures.GestureRelationRole, b: Gestures.GestureRelationRole) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+public enum GestureRelationDirection : Swift.Hashable, Swift.Sendable {
+  case outgoing
+  case incoming
+  public static func == (a: Gestures.GestureRelationDirection, b: Gestures.GestureRelationDirection) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+public struct GestureRelation : Swift.Equatable, Swift.Sendable {
+  public var type: Gestures.GestureRelationType
+  public var direction: Gestures.GestureRelationDirection
+  public var role: Gestures.GestureRelationRole?
+  public var target: Gestures.GestureNodeMatcher
+  #if compiler(>=5.3) && $NonescapableTypes
+  public init(type: Gestures.GestureRelationType, direction: Gestures.GestureRelationDirection, role: Gestures.GestureRelationRole?, target: Gestures.GestureNodeMatcher)
+  #endif
+  public static func == (a: Gestures.GestureRelation, b: Gestures.GestureRelation) -> Swift.Bool
+}
+extension Swift.Array where Element == Gestures.GestureRelation {
+  public static var `default`: [Gestures.GestureRelation] {
+    get
+  }
+}
 public enum GestureNodeMatcher : Swift.Hashable, Swift.Sendable {
   case id(Gestures.GestureNodeID)
   case tag(Gestures.GestureTag)

--- a/GF/2025/Gestures.xcframework/ios-arm64-x86_64-simulator/Gestures.framework/Modules/Gestures.swiftmodule/x86_64-apple-ios-simulator.swiftinterface
+++ b/GF/2025/Gestures.xcframework/ios-arm64-x86_64-simulator/Gestures.framework/Modules/Gestures.swiftmodule/x86_64-apple-ios-simulator.swiftinterface
@@ -143,7 +143,7 @@ public enum GestureNodeMatcher : Swift.Hashable, Swift.Sendable {
     get
   }
 }
-extension GestureNodeMatcher : Swift.Comparable {
+extension Gestures.GestureNodeMatcher : Swift.Comparable {
   public static func < (lhs: Gestures.GestureNodeMatcher, rhs: Gestures.GestureNodeMatcher) -> Swift.Bool
 }
 @frozen public struct GestureTag : Swift.Hashable, Swift.Sendable, Swift.ExpressibleByStringLiteral, Swift.CustomStringConvertible {
@@ -162,17 +162,17 @@ extension GestureNodeMatcher : Swift.Comparable {
     get
   }
 }
-extension GFGesturePhase : Swift.CustomStringConvertible {
+extension Gestures.GFGesturePhase : Swift.CustomStringConvertible {
   public var description: Swift.String {
     get
   }
 }
-extension GFGestureRelationType : Swift.CustomStringConvertible {
+extension Gestures.GFGestureRelationType : Swift.CustomStringConvertible {
   public var description: Swift.String {
     get
   }
 }
-extension GFGestureRelationRole : Swift.CustomStringConvertible {
+extension Gestures.GFGestureRelationRole : Swift.CustomStringConvertible {
   public var description: Swift.String {
     get
   }
@@ -199,9 +199,9 @@ public struct GestureNodeOptions : Swift.OptionSet, Swift.Sendable {
   public typealias Element = Gestures.GestureNodeOptions
   public typealias RawValue = Swift.Int
 }
-extension GestureNodeOptions : Swift.CustomStringConvertible {
+extension Gestures.GestureNodeOptions : Swift.CustomStringConvertible {
   public var description: Swift.String {
     get
   }
 }
-extension GestureNodeID : Swift.BitwiseCopyable {}
+extension Gestures.GestureNodeID : Swift.BitwiseCopyable {}

--- a/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/arm64-apple-macos.swiftinterface
+++ b/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/arm64-apple-macos.swiftinterface
@@ -54,6 +54,11 @@ public struct GestureTrait : Swift.Hashable, Swift.Identifiable, Swift.Sendable 
     get
   }
 }
+extension Gestures.GestureTrait {
+  public var label: Swift.String {
+    get
+  }
+}
 public struct GestureTraitID : Swift.Hashable, Swift.Sendable {
   public let rawValue: Swift.Int
   public init(_ label: Swift.String)
@@ -204,4 +209,10 @@ extension Gestures.GestureNodeOptions : Swift.CustomStringConvertible {
     get
   }
 }
+extension Gestures.GestureTrait : Swift.CustomStringConvertible {}
+extension Gestures.GestureTrait : Swift.CustomDebugStringConvertible {}
+extension Gestures.GestureTraitCollection : Swift.CustomStringConvertible {}
+extension Gestures.GestureTraitCollection : Swift.CustomDebugStringConvertible {}
+extension Gestures.GestureNodeMatcher : Swift.CustomStringConvertible {}
+extension Gestures.GestureNodeMatcher : Swift.CustomDebugStringConvertible {}
 extension Gestures.GestureNodeID : Swift.BitwiseCopyable {}

--- a/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/arm64-apple-macos.swiftinterface
+++ b/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/arm64-apple-macos.swiftinterface
@@ -79,6 +79,30 @@ public struct GestureTraitCollection : Swift.Hashable, Swift.Sendable {
     get
   }
 }
+public enum GestureNodeMatcher : Swift.Hashable, Swift.Sendable {
+  case id(Gestures.GestureNodeID)
+  case tag(Gestures.GestureTag)
+  case traits(Gestures.GestureTraitCollection, position: Gestures.GestureNodeMatcher.RelativePosition)
+  case any(position: Gestures.GestureNodeMatcher.RelativePosition)
+  public enum RelativePosition : Swift.Hashable, Swift.Sendable {
+    case any
+    case above
+    case below
+    public static func == (a: Gestures.GestureNodeMatcher.RelativePosition, b: Gestures.GestureNodeMatcher.RelativePosition) -> Swift.Bool
+    public func hash(into hasher: inout Swift.Hasher)
+    public var hashValue: Swift.Int {
+      get
+    }
+  }
+  public static func == (a: Gestures.GestureNodeMatcher, b: Gestures.GestureNodeMatcher) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+extension GestureNodeMatcher : Swift.Comparable {
+  public static func < (lhs: Gestures.GestureNodeMatcher, rhs: Gestures.GestureNodeMatcher) -> Swift.Bool
+}
 @frozen public struct GestureTag : Swift.Hashable, Swift.Sendable, Swift.ExpressibleByStringLiteral, Swift.CustomStringConvertible {
   public let rawValue: Swift.String
   public init(rawValue: Swift.String)

--- a/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/arm64-apple-macos.swiftinterface
+++ b/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/arm64-apple-macos.swiftinterface
@@ -79,6 +79,49 @@ public struct GestureTraitCollection : Swift.Hashable, Swift.Sendable {
     get
   }
 }
+public enum GestureRelationType : Swift.Hashable, Swift.Sendable {
+  case exclusion
+  case activeExclusion
+  case failureRequirement
+  public static func == (a: Gestures.GestureRelationType, b: Gestures.GestureRelationType) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+public enum GestureRelationRole : Swift.Hashable, Swift.Sendable {
+  case regular
+  case blocking
+  public static func == (a: Gestures.GestureRelationRole, b: Gestures.GestureRelationRole) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+public enum GestureRelationDirection : Swift.Hashable, Swift.Sendable {
+  case outgoing
+  case incoming
+  public static func == (a: Gestures.GestureRelationDirection, b: Gestures.GestureRelationDirection) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+public struct GestureRelation : Swift.Equatable, Swift.Sendable {
+  public var type: Gestures.GestureRelationType
+  public var direction: Gestures.GestureRelationDirection
+  public var role: Gestures.GestureRelationRole?
+  public var target: Gestures.GestureNodeMatcher
+  #if compiler(>=5.3) && $NonescapableTypes
+  public init(type: Gestures.GestureRelationType, direction: Gestures.GestureRelationDirection, role: Gestures.GestureRelationRole?, target: Gestures.GestureNodeMatcher)
+  #endif
+  public static func == (a: Gestures.GestureRelation, b: Gestures.GestureRelation) -> Swift.Bool
+}
+extension Swift.Array where Element == Gestures.GestureRelation {
+  public static var `default`: [Gestures.GestureRelation] {
+    get
+  }
+}
 public enum GestureNodeMatcher : Swift.Hashable, Swift.Sendable {
   case id(Gestures.GestureNodeID)
   case tag(Gestures.GestureTag)

--- a/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/arm64-apple-macos.swiftinterface
+++ b/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/arm64-apple-macos.swiftinterface
@@ -143,7 +143,7 @@ public enum GestureNodeMatcher : Swift.Hashable, Swift.Sendable {
     get
   }
 }
-extension GestureNodeMatcher : Swift.Comparable {
+extension Gestures.GestureNodeMatcher : Swift.Comparable {
   public static func < (lhs: Gestures.GestureNodeMatcher, rhs: Gestures.GestureNodeMatcher) -> Swift.Bool
 }
 @frozen public struct GestureTag : Swift.Hashable, Swift.Sendable, Swift.ExpressibleByStringLiteral, Swift.CustomStringConvertible {
@@ -162,17 +162,17 @@ extension GestureNodeMatcher : Swift.Comparable {
     get
   }
 }
-extension GFGesturePhase : Swift.CustomStringConvertible {
+extension Gestures.GFGesturePhase : Swift.CustomStringConvertible {
   public var description: Swift.String {
     get
   }
 }
-extension GFGestureRelationType : Swift.CustomStringConvertible {
+extension Gestures.GFGestureRelationType : Swift.CustomStringConvertible {
   public var description: Swift.String {
     get
   }
 }
-extension GFGestureRelationRole : Swift.CustomStringConvertible {
+extension Gestures.GFGestureRelationRole : Swift.CustomStringConvertible {
   public var description: Swift.String {
     get
   }
@@ -199,9 +199,9 @@ public struct GestureNodeOptions : Swift.OptionSet, Swift.Sendable {
   public typealias Element = Gestures.GestureNodeOptions
   public typealias RawValue = Swift.Int
 }
-extension GestureNodeOptions : Swift.CustomStringConvertible {
+extension Gestures.GestureNodeOptions : Swift.CustomStringConvertible {
   public var description: Swift.String {
     get
   }
 }
-extension GestureNodeID : Swift.BitwiseCopyable {}
+extension Gestures.GestureNodeID : Swift.BitwiseCopyable {}

--- a/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/arm64e-apple-macos.swiftinterface
+++ b/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/arm64e-apple-macos.swiftinterface
@@ -54,6 +54,11 @@ public struct GestureTrait : Swift.Hashable, Swift.Identifiable, Swift.Sendable 
     get
   }
 }
+extension Gestures.GestureTrait {
+  public var label: Swift.String {
+    get
+  }
+}
 public struct GestureTraitID : Swift.Hashable, Swift.Sendable {
   public let rawValue: Swift.Int
   public init(_ label: Swift.String)
@@ -204,4 +209,10 @@ extension Gestures.GestureNodeOptions : Swift.CustomStringConvertible {
     get
   }
 }
+extension Gestures.GestureTrait : Swift.CustomStringConvertible {}
+extension Gestures.GestureTrait : Swift.CustomDebugStringConvertible {}
+extension Gestures.GestureTraitCollection : Swift.CustomStringConvertible {}
+extension Gestures.GestureTraitCollection : Swift.CustomDebugStringConvertible {}
+extension Gestures.GestureNodeMatcher : Swift.CustomStringConvertible {}
+extension Gestures.GestureNodeMatcher : Swift.CustomDebugStringConvertible {}
 extension Gestures.GestureNodeID : Swift.BitwiseCopyable {}

--- a/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/arm64e-apple-macos.swiftinterface
+++ b/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/arm64e-apple-macos.swiftinterface
@@ -79,6 +79,30 @@ public struct GestureTraitCollection : Swift.Hashable, Swift.Sendable {
     get
   }
 }
+public enum GestureNodeMatcher : Swift.Hashable, Swift.Sendable {
+  case id(Gestures.GestureNodeID)
+  case tag(Gestures.GestureTag)
+  case traits(Gestures.GestureTraitCollection, position: Gestures.GestureNodeMatcher.RelativePosition)
+  case any(position: Gestures.GestureNodeMatcher.RelativePosition)
+  public enum RelativePosition : Swift.Hashable, Swift.Sendable {
+    case any
+    case above
+    case below
+    public static func == (a: Gestures.GestureNodeMatcher.RelativePosition, b: Gestures.GestureNodeMatcher.RelativePosition) -> Swift.Bool
+    public func hash(into hasher: inout Swift.Hasher)
+    public var hashValue: Swift.Int {
+      get
+    }
+  }
+  public static func == (a: Gestures.GestureNodeMatcher, b: Gestures.GestureNodeMatcher) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+extension GestureNodeMatcher : Swift.Comparable {
+  public static func < (lhs: Gestures.GestureNodeMatcher, rhs: Gestures.GestureNodeMatcher) -> Swift.Bool
+}
 @frozen public struct GestureTag : Swift.Hashable, Swift.Sendable, Swift.ExpressibleByStringLiteral, Swift.CustomStringConvertible {
   public let rawValue: Swift.String
   public init(rawValue: Swift.String)

--- a/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/arm64e-apple-macos.swiftinterface
+++ b/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/arm64e-apple-macos.swiftinterface
@@ -79,6 +79,49 @@ public struct GestureTraitCollection : Swift.Hashable, Swift.Sendable {
     get
   }
 }
+public enum GestureRelationType : Swift.Hashable, Swift.Sendable {
+  case exclusion
+  case activeExclusion
+  case failureRequirement
+  public static func == (a: Gestures.GestureRelationType, b: Gestures.GestureRelationType) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+public enum GestureRelationRole : Swift.Hashable, Swift.Sendable {
+  case regular
+  case blocking
+  public static func == (a: Gestures.GestureRelationRole, b: Gestures.GestureRelationRole) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+public enum GestureRelationDirection : Swift.Hashable, Swift.Sendable {
+  case outgoing
+  case incoming
+  public static func == (a: Gestures.GestureRelationDirection, b: Gestures.GestureRelationDirection) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+public struct GestureRelation : Swift.Equatable, Swift.Sendable {
+  public var type: Gestures.GestureRelationType
+  public var direction: Gestures.GestureRelationDirection
+  public var role: Gestures.GestureRelationRole?
+  public var target: Gestures.GestureNodeMatcher
+  #if compiler(>=5.3) && $NonescapableTypes
+  public init(type: Gestures.GestureRelationType, direction: Gestures.GestureRelationDirection, role: Gestures.GestureRelationRole?, target: Gestures.GestureNodeMatcher)
+  #endif
+  public static func == (a: Gestures.GestureRelation, b: Gestures.GestureRelation) -> Swift.Bool
+}
+extension Swift.Array where Element == Gestures.GestureRelation {
+  public static var `default`: [Gestures.GestureRelation] {
+    get
+  }
+}
 public enum GestureNodeMatcher : Swift.Hashable, Swift.Sendable {
   case id(Gestures.GestureNodeID)
   case tag(Gestures.GestureTag)

--- a/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/arm64e-apple-macos.swiftinterface
+++ b/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/arm64e-apple-macos.swiftinterface
@@ -143,7 +143,7 @@ public enum GestureNodeMatcher : Swift.Hashable, Swift.Sendable {
     get
   }
 }
-extension GestureNodeMatcher : Swift.Comparable {
+extension Gestures.GestureNodeMatcher : Swift.Comparable {
   public static func < (lhs: Gestures.GestureNodeMatcher, rhs: Gestures.GestureNodeMatcher) -> Swift.Bool
 }
 @frozen public struct GestureTag : Swift.Hashable, Swift.Sendable, Swift.ExpressibleByStringLiteral, Swift.CustomStringConvertible {
@@ -162,17 +162,17 @@ extension GestureNodeMatcher : Swift.Comparable {
     get
   }
 }
-extension GFGesturePhase : Swift.CustomStringConvertible {
+extension Gestures.GFGesturePhase : Swift.CustomStringConvertible {
   public var description: Swift.String {
     get
   }
 }
-extension GFGestureRelationType : Swift.CustomStringConvertible {
+extension Gestures.GFGestureRelationType : Swift.CustomStringConvertible {
   public var description: Swift.String {
     get
   }
 }
-extension GFGestureRelationRole : Swift.CustomStringConvertible {
+extension Gestures.GFGestureRelationRole : Swift.CustomStringConvertible {
   public var description: Swift.String {
     get
   }
@@ -199,9 +199,9 @@ public struct GestureNodeOptions : Swift.OptionSet, Swift.Sendable {
   public typealias Element = Gestures.GestureNodeOptions
   public typealias RawValue = Swift.Int
 }
-extension GestureNodeOptions : Swift.CustomStringConvertible {
+extension Gestures.GestureNodeOptions : Swift.CustomStringConvertible {
   public var description: Swift.String {
     get
   }
 }
-extension GestureNodeID : Swift.BitwiseCopyable {}
+extension Gestures.GestureNodeID : Swift.BitwiseCopyable {}

--- a/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/x86_64-apple-macos.swiftinterface
+++ b/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/x86_64-apple-macos.swiftinterface
@@ -54,6 +54,11 @@ public struct GestureTrait : Swift.Hashable, Swift.Identifiable, Swift.Sendable 
     get
   }
 }
+extension Gestures.GestureTrait {
+  public var label: Swift.String {
+    get
+  }
+}
 public struct GestureTraitID : Swift.Hashable, Swift.Sendable {
   public let rawValue: Swift.Int
   public init(_ label: Swift.String)
@@ -204,4 +209,10 @@ extension Gestures.GestureNodeOptions : Swift.CustomStringConvertible {
     get
   }
 }
+extension Gestures.GestureTrait : Swift.CustomStringConvertible {}
+extension Gestures.GestureTrait : Swift.CustomDebugStringConvertible {}
+extension Gestures.GestureTraitCollection : Swift.CustomStringConvertible {}
+extension Gestures.GestureTraitCollection : Swift.CustomDebugStringConvertible {}
+extension Gestures.GestureNodeMatcher : Swift.CustomStringConvertible {}
+extension Gestures.GestureNodeMatcher : Swift.CustomDebugStringConvertible {}
 extension Gestures.GestureNodeID : Swift.BitwiseCopyable {}

--- a/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/x86_64-apple-macos.swiftinterface
+++ b/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/x86_64-apple-macos.swiftinterface
@@ -79,6 +79,30 @@ public struct GestureTraitCollection : Swift.Hashable, Swift.Sendable {
     get
   }
 }
+public enum GestureNodeMatcher : Swift.Hashable, Swift.Sendable {
+  case id(Gestures.GestureNodeID)
+  case tag(Gestures.GestureTag)
+  case traits(Gestures.GestureTraitCollection, position: Gestures.GestureNodeMatcher.RelativePosition)
+  case any(position: Gestures.GestureNodeMatcher.RelativePosition)
+  public enum RelativePosition : Swift.Hashable, Swift.Sendable {
+    case any
+    case above
+    case below
+    public static func == (a: Gestures.GestureNodeMatcher.RelativePosition, b: Gestures.GestureNodeMatcher.RelativePosition) -> Swift.Bool
+    public func hash(into hasher: inout Swift.Hasher)
+    public var hashValue: Swift.Int {
+      get
+    }
+  }
+  public static func == (a: Gestures.GestureNodeMatcher, b: Gestures.GestureNodeMatcher) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+extension GestureNodeMatcher : Swift.Comparable {
+  public static func < (lhs: Gestures.GestureNodeMatcher, rhs: Gestures.GestureNodeMatcher) -> Swift.Bool
+}
 @frozen public struct GestureTag : Swift.Hashable, Swift.Sendable, Swift.ExpressibleByStringLiteral, Swift.CustomStringConvertible {
   public let rawValue: Swift.String
   public init(rawValue: Swift.String)

--- a/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/x86_64-apple-macos.swiftinterface
+++ b/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/x86_64-apple-macos.swiftinterface
@@ -79,6 +79,49 @@ public struct GestureTraitCollection : Swift.Hashable, Swift.Sendable {
     get
   }
 }
+public enum GestureRelationType : Swift.Hashable, Swift.Sendable {
+  case exclusion
+  case activeExclusion
+  case failureRequirement
+  public static func == (a: Gestures.GestureRelationType, b: Gestures.GestureRelationType) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+public enum GestureRelationRole : Swift.Hashable, Swift.Sendable {
+  case regular
+  case blocking
+  public static func == (a: Gestures.GestureRelationRole, b: Gestures.GestureRelationRole) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+public enum GestureRelationDirection : Swift.Hashable, Swift.Sendable {
+  case outgoing
+  case incoming
+  public static func == (a: Gestures.GestureRelationDirection, b: Gestures.GestureRelationDirection) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+public struct GestureRelation : Swift.Equatable, Swift.Sendable {
+  public var type: Gestures.GestureRelationType
+  public var direction: Gestures.GestureRelationDirection
+  public var role: Gestures.GestureRelationRole?
+  public var target: Gestures.GestureNodeMatcher
+  #if compiler(>=5.3) && $NonescapableTypes
+  public init(type: Gestures.GestureRelationType, direction: Gestures.GestureRelationDirection, role: Gestures.GestureRelationRole?, target: Gestures.GestureNodeMatcher)
+  #endif
+  public static func == (a: Gestures.GestureRelation, b: Gestures.GestureRelation) -> Swift.Bool
+}
+extension Swift.Array where Element == Gestures.GestureRelation {
+  public static var `default`: [Gestures.GestureRelation] {
+    get
+  }
+}
 public enum GestureNodeMatcher : Swift.Hashable, Swift.Sendable {
   case id(Gestures.GestureNodeID)
   case tag(Gestures.GestureTag)

--- a/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/x86_64-apple-macos.swiftinterface
+++ b/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/x86_64-apple-macos.swiftinterface
@@ -143,7 +143,7 @@ public enum GestureNodeMatcher : Swift.Hashable, Swift.Sendable {
     get
   }
 }
-extension GestureNodeMatcher : Swift.Comparable {
+extension Gestures.GestureNodeMatcher : Swift.Comparable {
   public static func < (lhs: Gestures.GestureNodeMatcher, rhs: Gestures.GestureNodeMatcher) -> Swift.Bool
 }
 @frozen public struct GestureTag : Swift.Hashable, Swift.Sendable, Swift.ExpressibleByStringLiteral, Swift.CustomStringConvertible {
@@ -162,17 +162,17 @@ extension GestureNodeMatcher : Swift.Comparable {
     get
   }
 }
-extension GFGesturePhase : Swift.CustomStringConvertible {
+extension Gestures.GFGesturePhase : Swift.CustomStringConvertible {
   public var description: Swift.String {
     get
   }
 }
-extension GFGestureRelationType : Swift.CustomStringConvertible {
+extension Gestures.GFGestureRelationType : Swift.CustomStringConvertible {
   public var description: Swift.String {
     get
   }
 }
-extension GFGestureRelationRole : Swift.CustomStringConvertible {
+extension Gestures.GFGestureRelationRole : Swift.CustomStringConvertible {
   public var description: Swift.String {
     get
   }
@@ -199,9 +199,9 @@ public struct GestureNodeOptions : Swift.OptionSet, Swift.Sendable {
   public typealias Element = Gestures.GestureNodeOptions
   public typealias RawValue = Swift.Int
 }
-extension GestureNodeOptions : Swift.CustomStringConvertible {
+extension Gestures.GestureNodeOptions : Swift.CustomStringConvertible {
   public var description: Swift.String {
     get
   }
 }
-extension GestureNodeID : Swift.BitwiseCopyable {}
+extension Gestures.GestureNodeID : Swift.BitwiseCopyable {}

--- a/GF/2025/Sources/Modules/Gestures.swiftmodule/template.swiftinterface
+++ b/GF/2025/Sources/Modules/Gestures.swiftmodule/template.swiftinterface
@@ -75,6 +75,49 @@ public struct GestureTraitCollection : Swift.Hashable, Swift.Sendable {
     get
   }
 }
+public enum GestureRelationType : Swift.Hashable, Swift.Sendable {
+  case exclusion
+  case activeExclusion
+  case failureRequirement
+  public static func == (a: Gestures.GestureRelationType, b: Gestures.GestureRelationType) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+public enum GestureRelationRole : Swift.Hashable, Swift.Sendable {
+  case regular
+  case blocking
+  public static func == (a: Gestures.GestureRelationRole, b: Gestures.GestureRelationRole) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+public enum GestureRelationDirection : Swift.Hashable, Swift.Sendable {
+  case outgoing
+  case incoming
+  public static func == (a: Gestures.GestureRelationDirection, b: Gestures.GestureRelationDirection) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+public struct GestureRelation : Swift.Equatable, Swift.Sendable {
+  public var type: Gestures.GestureRelationType
+  public var direction: Gestures.GestureRelationDirection
+  public var role: Gestures.GestureRelationRole?
+  public var target: Gestures.GestureNodeMatcher
+  #if compiler(>=5.3) && $NonescapableTypes
+  public init(type: Gestures.GestureRelationType, direction: Gestures.GestureRelationDirection, role: Gestures.GestureRelationRole?, target: Gestures.GestureNodeMatcher)
+  #endif
+  public static func == (a: Gestures.GestureRelation, b: Gestures.GestureRelation) -> Swift.Bool
+}
+extension Swift.Array where Element == Gestures.GestureRelation {
+  public static var `default`: [Gestures.GestureRelation] {
+    get
+  }
+}
 public enum GestureNodeMatcher : Swift.Hashable, Swift.Sendable {
   case id(Gestures.GestureNodeID)
   case tag(Gestures.GestureTag)

--- a/GF/2025/Sources/Modules/Gestures.swiftmodule/template.swiftinterface
+++ b/GF/2025/Sources/Modules/Gestures.swiftmodule/template.swiftinterface
@@ -75,6 +75,30 @@ public struct GestureTraitCollection : Swift.Hashable, Swift.Sendable {
     get
   }
 }
+public enum GestureNodeMatcher : Swift.Hashable, Swift.Sendable {
+  case id(Gestures.GestureNodeID)
+  case tag(Gestures.GestureTag)
+  case traits(Gestures.GestureTraitCollection, position: Gestures.GestureNodeMatcher.RelativePosition)
+  case any(position: Gestures.GestureNodeMatcher.RelativePosition)
+  public enum RelativePosition : Swift.Hashable, Swift.Sendable {
+    case any
+    case above
+    case below
+    public static func == (a: Gestures.GestureNodeMatcher.RelativePosition, b: Gestures.GestureNodeMatcher.RelativePosition) -> Swift.Bool
+    public func hash(into hasher: inout Swift.Hasher)
+    public var hashValue: Swift.Int {
+      get
+    }
+  }
+  public static func == (a: Gestures.GestureNodeMatcher, b: Gestures.GestureNodeMatcher) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+extension GestureNodeMatcher : Swift.Comparable {
+  public static func < (lhs: Gestures.GestureNodeMatcher, rhs: Gestures.GestureNodeMatcher) -> Swift.Bool
+}
 @frozen public struct GestureTag : Swift.Hashable, Swift.Sendable, Swift.ExpressibleByStringLiteral, Swift.CustomStringConvertible {
   public let rawValue: Swift.String
   public init(rawValue: Swift.String)

--- a/GF/2025/Sources/Modules/Gestures.swiftmodule/template.swiftinterface
+++ b/GF/2025/Sources/Modules/Gestures.swiftmodule/template.swiftinterface
@@ -139,7 +139,7 @@ public enum GestureNodeMatcher : Swift.Hashable, Swift.Sendable {
     get
   }
 }
-extension GestureNodeMatcher : Swift.Comparable {
+extension Gestures.GestureNodeMatcher : Swift.Comparable {
   public static func < (lhs: Gestures.GestureNodeMatcher, rhs: Gestures.GestureNodeMatcher) -> Swift.Bool
 }
 @frozen public struct GestureTag : Swift.Hashable, Swift.Sendable, Swift.ExpressibleByStringLiteral, Swift.CustomStringConvertible {
@@ -158,17 +158,17 @@ extension GestureNodeMatcher : Swift.Comparable {
     get
   }
 }
-extension GFGesturePhase : Swift.CustomStringConvertible {
+extension Gestures.GFGesturePhase : Swift.CustomStringConvertible {
   public var description: Swift.String {
     get
   }
 }
-extension GFGestureRelationType : Swift.CustomStringConvertible {
+extension Gestures.GFGestureRelationType : Swift.CustomStringConvertible {
   public var description: Swift.String {
     get
   }
 }
-extension GFGestureRelationRole : Swift.CustomStringConvertible {
+extension Gestures.GFGestureRelationRole : Swift.CustomStringConvertible {
   public var description: Swift.String {
     get
   }
@@ -195,9 +195,9 @@ public struct GestureNodeOptions : Swift.OptionSet, Swift.Sendable {
   public typealias Element = Gestures.GestureNodeOptions
   public typealias RawValue = Swift.Int
 }
-extension GestureNodeOptions : Swift.CustomStringConvertible {
+extension Gestures.GestureNodeOptions : Swift.CustomStringConvertible {
   public var description: Swift.String {
     get
   }
 }
-extension GestureNodeID : Swift.BitwiseCopyable {}
+extension Gestures.GestureNodeID : Swift.BitwiseCopyable {}

--- a/GF/2025/Sources/Modules/Gestures.swiftmodule/template.swiftinterface
+++ b/GF/2025/Sources/Modules/Gestures.swiftmodule/template.swiftinterface
@@ -50,6 +50,11 @@ public struct GestureTrait : Swift.Hashable, Swift.Identifiable, Swift.Sendable 
     get
   }
 }
+extension Gestures.GestureTrait {
+  public var label: Swift.String {
+    get
+  }
+}
 public struct GestureTraitID : Swift.Hashable, Swift.Sendable {
   public let rawValue: Swift.Int
   public init(_ label: Swift.String)
@@ -200,4 +205,10 @@ extension Gestures.GestureNodeOptions : Swift.CustomStringConvertible {
     get
   }
 }
+extension Gestures.GestureTrait : Swift.CustomStringConvertible {}
+extension Gestures.GestureTrait : Swift.CustomDebugStringConvertible {}
+extension Gestures.GestureTraitCollection : Swift.CustomStringConvertible {}
+extension Gestures.GestureTraitCollection : Swift.CustomDebugStringConvertible {}
+extension Gestures.GestureNodeMatcher : Swift.CustomStringConvertible {}
+extension Gestures.GestureNodeMatcher : Swift.CustomDebugStringConvertible {}
 extension Gestures.GestureNodeID : Swift.BitwiseCopyable {}

--- a/GF/DeviceSwiftShims/Core/GestureNodeMatcher.swift
+++ b/GF/DeviceSwiftShims/Core/GestureNodeMatcher.swift
@@ -39,18 +39,22 @@ extension GestureNodeMatcher: Comparable {
 
 // MARK: - GestureNodeMatcher + NestedCustomStringConvertible
 
-@_spi(Private)
 extension GestureNodeMatcher: NestedCustomStringConvertible {
-    public var label: String {
+    package func populateNestedDescription(_ nested: inout NestedDescription) {
+        nested.options.formUnion([.hideTypeName, .compact])
+        nested.customPrefix = ""
+        nested.customSuffix = ""
         switch self {
-        case let .id(id): "\(id)"
-        case let .tag(tag): "\(tag)"
-        case let .traits(collection, position): "\(collection), position: \(position)"
-        case let .any(position): "any, position: \(position)"
+        case let .id(id):
+            nested.append(id)
+        case let .tag(tag):
+            nested.append(tag)
+        case let .traits(collection, position):
+            nested.append(collection)
+            nested.append(position, label: "position")
+        case let .any(position):
+            nested.append("any")
+            nested.append(position, label: "position")
         }
     }
-
-    public var description: String { label }
-
-    public var debugDescription: String { label }
 }

--- a/GF/DeviceSwiftShims/Core/GestureNodeMatcher.swift
+++ b/GF/DeviceSwiftShims/Core/GestureNodeMatcher.swift
@@ -1,0 +1,56 @@
+//
+//  GestureNodeMatcher.swift
+//  Gestures
+//
+//  Audited for 9126.1.5
+//  Status: Complete
+
+// MARK: - GestureNodeMatcher
+
+public enum GestureNodeMatcher: Hashable, Sendable {
+    case id(GestureNodeID)
+    case tag(GestureTag)
+    case traits(GestureTraitCollection, position: RelativePosition)
+    case any(position: RelativePosition)
+
+    public enum RelativePosition: Hashable, Sendable {
+        case any
+        case above
+        case below
+    }
+}
+
+// MARK: - GestureNodeMatcher + Comparable
+
+extension GestureNodeMatcher: Comparable {
+    public static func < (lhs: GestureNodeMatcher, rhs: GestureNodeMatcher) -> Bool {
+        lhs.sortOrder < rhs.sortOrder
+    }
+
+    private var sortOrder: Int {
+        switch self {
+        case .id: 0
+        case .tag: 1
+        case .traits: 2
+        case .any: 3
+        }
+    }
+}
+
+// MARK: - GestureNodeMatcher + NestedCustomStringConvertible
+
+@_spi(Private)
+extension GestureNodeMatcher: NestedCustomStringConvertible {
+    public var label: String {
+        switch self {
+        case let .id(id): "\(id)"
+        case let .tag(tag): "\(tag)"
+        case let .traits(collection, position): "\(collection), position: \(position)"
+        case let .any(position): "any, position: \(position)"
+        }
+    }
+
+    public var description: String { label }
+
+    public var debugDescription: String { label }
+}

--- a/GF/DeviceSwiftShims/Core/GestureRelation.swift
+++ b/GF/DeviceSwiftShims/Core/GestureRelation.swift
@@ -5,7 +5,7 @@
 //  Audited for 9126.1.5
 //  Status: Complete
 
-import OrderedCollections
+package import OrderedCollections
 
 // MARK: - GestureRelationType
 
@@ -71,7 +71,7 @@ package struct RelationMap: Sendable {
         self.relations = [:]
     }
 
-    init(relations: OrderedDictionary<GestureNodeMatcher, Set<RelationDefinition>>) {
+    package init(relations: OrderedDictionary<GestureNodeMatcher, Set<RelationDefinition>>) {
         self.relations = relations
     }
 
@@ -95,7 +95,7 @@ package struct RelationMap: Sendable {
         add(definition, for: relation.target)
     }
 
-    mutating func removeRelation(_ relation: GestureRelation) {
+    package mutating func removeRelation(_ relation: GestureRelation) {
         let definition = RelationDefinition(
             type: relation.type,
             direction: relation.direction,
@@ -120,7 +120,7 @@ package struct RelationMap: Sendable {
     }
 }
 
-// MARK: - RelationMap + Sequence [TBA]
+// MARK: - RelationMap + Sequence
 
 extension RelationMap: Sequence {
     package func makeIterator() -> some IteratorProtocol {
@@ -128,21 +128,14 @@ extension RelationMap: Sequence {
     }
 }
 
-// MARK: - RelationMap + NestedCustomStringConvertible [TBA]
+// MARK: - RelationMap + NestedCustomStringConvertible
 
 extension RelationMap: NestedCustomStringConvertible {
-    package var label: String { "RelationMap" }
-
-    package var description: String {
-        if relations.isEmpty {
-            return "\(label) {}"
+    package func populateNestedDescription(_ nested: inout NestedDescription) {
+        nested.options.formUnion(.hideTypeName)
+        for (matcher, definition) in relations {
+            nested.append("\(matcher)", label: "\(definition)")
         }
-        let entries = relations.map { "\($0.key): \($0.value)" }.joined(separator: ", ")
-        return "\(label) {\(entries)}"
-    }
-
-    package var debugDescription: String {
-        description
     }
 }
 
@@ -164,10 +157,11 @@ package struct RelationDefinition: Hashable, Sendable, CustomStringConvertible {
     }
 
     package var description: String {
-        if let role {
-            "\(type) \(direction) (\(role))"
-        } else {
-            "\(type) \(direction)"
+        let dir = switch direction {
+        case .outgoing: "out"
+        case .incoming: "in"
         }
+        let roleStr = if let role { "\(role)" } else { "dynamic" }
+        return "\(type)[\(dir)]=\(roleStr)"
     }
 }

--- a/GF/DeviceSwiftShims/Core/GestureRelation.swift
+++ b/GF/DeviceSwiftShims/Core/GestureRelation.swift
@@ -1,0 +1,173 @@
+//
+//  GestureRelation.swift
+//  Gestures
+//
+//  Audited for 9126.1.5
+//  Status: Complete
+
+import OrderedCollections
+
+// MARK: - GestureRelationType
+
+public enum GestureRelationType: Hashable, Sendable {
+    case exclusion
+    case activeExclusion
+    case failureRequirement
+}
+
+// MARK: - GestureRelationRole
+
+public enum GestureRelationRole: Hashable, Sendable {
+    case regular
+    case blocking
+}
+
+// MARK: - GestureRelationDirection
+
+public enum GestureRelationDirection: Hashable, Sendable {
+    case outgoing
+    case incoming
+}
+
+// MARK: - GestureRelation
+
+public struct GestureRelation: Equatable, Sendable {
+    public var type: GestureRelationType
+    public var direction: GestureRelationDirection
+    public var role: GestureRelationRole?
+    public var target: GestureNodeMatcher
+
+    public init(
+        type: GestureRelationType,
+        direction: GestureRelationDirection,
+        role: GestureRelationRole?,
+        target: GestureNodeMatcher
+    ) {
+        self.type = type
+        self.direction = direction
+        self.role = role
+        self.target = target
+    }
+}
+
+// MARK: - [GestureRelation] Default
+
+extension [GestureRelation] {
+    public static var `default`: [GestureRelation] {
+        [
+            GestureRelation(type: .exclusion, direction: .outgoing, role: .regular, target: .any(position: .any)),
+            GestureRelation(type: .activeExclusion, direction: .outgoing, role: .regular, target: .any(position: .any)),
+            GestureRelation(type: .activeExclusion, direction: .incoming, role: .blocking, target: .any(position: .any)),
+        ]
+    }
+}
+
+// MARK: - RelationMap
+
+package struct RelationMap: Sendable {
+    private var relations: OrderedDictionary<GestureNodeMatcher, Set<RelationDefinition>>
+
+    package init() {
+        self.relations = [:]
+    }
+
+    init(relations: OrderedDictionary<GestureNodeMatcher, Set<RelationDefinition>>) {
+        self.relations = relations
+    }
+
+    package mutating func add(_ definition: RelationDefinition, for matcher: GestureNodeMatcher) {
+        relations[matcher, default: []].insert(definition)
+    }
+
+    package mutating func remove(_ definition: RelationDefinition, for matcher: GestureNodeMatcher) {
+        relations[matcher]?.remove(definition)
+        if relations[matcher]?.isEmpty == true {
+            relations.removeValue(forKey: matcher)
+        }
+    }
+
+    package mutating func addRelation(_ relation: GestureRelation) {
+        let definition = RelationDefinition(
+            type: relation.type,
+            direction: relation.direction,
+            role: relation.role
+        )
+        add(definition, for: relation.target)
+    }
+
+    mutating func removeRelation(_ relation: GestureRelation) {
+        let definition = RelationDefinition(
+            type: relation.type,
+            direction: relation.direction,
+            role: relation.role
+        )
+        remove(definition, for: relation.target)
+    }
+
+    package func toRelations() -> [GestureRelation] {
+        var result: [GestureRelation] = []
+        for (matcher, definitions) in relations {
+            for definition in definitions {
+                result.append(GestureRelation(
+                    type: definition.type,
+                    direction: definition.direction,
+                    role: definition.role,
+                    target: matcher
+                ))
+            }
+        }
+        return result
+    }
+}
+
+// MARK: - RelationMap + Sequence [TBA]
+
+extension RelationMap: Sequence {
+    package func makeIterator() -> some IteratorProtocol {
+        relations.makeIterator()
+    }
+}
+
+// MARK: - RelationMap + NestedCustomStringConvertible [TBA]
+
+extension RelationMap: NestedCustomStringConvertible {
+    package var label: String { "RelationMap" }
+
+    package var description: String {
+        if relations.isEmpty {
+            return "\(label) {}"
+        }
+        let entries = relations.map { "\($0.key): \($0.value)" }.joined(separator: ", ")
+        return "\(label) {\(entries)}"
+    }
+
+    package var debugDescription: String {
+        description
+    }
+}
+
+// MARK: - RelationDefinition
+
+package struct RelationDefinition: Hashable, Sendable, CustomStringConvertible {
+    package var type: GestureRelationType
+    package var direction: GestureRelationDirection
+    package var role: GestureRelationRole?
+
+    package init(
+        type: GestureRelationType,
+        direction: GestureRelationDirection,
+        role: GestureRelationRole? = nil
+    ) {
+        self.type = type
+        self.direction = direction
+        self.role = role
+    }
+
+    package var description: String {
+        if let role {
+            "\(type) \(direction) (\(role))"
+        } else {
+            "\(type) \(direction)"
+        }
+    }
+}

--- a/GF/DeviceSwiftShims/Core/GestureTrait.swift
+++ b/GF/DeviceSwiftShims/Core/GestureTrait.swift
@@ -95,22 +95,25 @@ public struct GestureTrait: Hashable, Identifiable, Sendable {
     }
 }
 
-@_spi(Private)
 extension GestureTrait: NestedCustomStringConvertible {
     public var label: String {
         TraitLabelStore.shared.label(for: id.rawValue)
     }
 
-    public var description: String {
+    package func populateNestedDescription(_ nested: inout NestedDescription) {
+        nested.options.formUnion([.hideTypeName, .compact])
+        nested.customPrefix = ""
+        nested.customSuffix = ""
+        nested.options.formUnion(.hideIdentity)
         if attributes.isEmpty {
-            return label
+            nested.append(label)
+        } else {
+            nested.customPrefix = label + " {"
+            nested.customSuffix = "}"
+            for (key, value) in attributes {
+                nested.append("\(key.label): \(value)")
+            }
         }
-        let attrs = attributes.map { "\($0.key.label): \($0.value)" }.joined(separator: ", ")
-        return "\(label) {\(attrs)}"
-    }
-
-    public var debugDescription: String {
-        description
     }
 }
 
@@ -173,32 +176,25 @@ extension GestureTraitCollection: Sequence {
 
 // MARK: - GestureTraitCollection + CustomStringConvertible
 
-@_spi(Private)
 extension GestureTraitCollection: NestedCustomStringConvertible {
-    public var label: String { "GestureTraitCollection" }
-
-    public var description: String {
-        "[\(_traits.values.map(\.description).joined(separator: ", "))]"
-    }
-
-    public var debugDescription: String {
-        description
+    package func populateNestedDescription(_ nested: inout NestedDescription) {
+        nested.options.formUnion([.hideTypeName, .compact])
+        nested.customPrefix = ""
+        nested.customSuffix = ""
+        nested.append(_traits.values)
     }
 }
 
 // MARK: - GestureTraitCollection + Mergeable
 
-@_spi(Private)
 extension GestureTraitCollection: Mergeable {
-    public mutating func merge(_ other: GestureTraitCollection) {
+    package mutating func merge(_ other: GestureTraitCollection) {
         _traits.merge(other._traits) { $1 }
     }
 }
 
 import Synchronization
-#if canImport(os)
 import os
-#endif
 
 // MARK: - TraitLabelStore
 
@@ -207,7 +203,6 @@ private final class TraitLabelStore {
 
     private static let counter = Atomic(0)
 
-    #if canImport(os)
     private var labels: [Int: String] = [:]
     private let lock: OSAllocatedUnfairLock = .init()
 
@@ -224,22 +219,4 @@ private final class TraitLabelStore {
             labels[rawValue]
         } ?? ""
     }
-
-    #else
-    private let labels: Mutex<[Int: String]> = .init([:])
-
-    func register(_ label: String) -> Int {
-        let (_, id) = Self.counter.add(1, ordering: .relaxed)
-        labels.withLock {
-            $0[id] = label
-        }
-        return id
-    }
-
-    package func label(for rawValue: Int) -> String {
-        labels.withLock {
-            $0[rawValue]
-        } ?? ""
-    }
-    #endif
 }

--- a/GF/DeviceSwiftShims/Util/Mergeable.swift
+++ b/GF/DeviceSwiftShims/Util/Mergeable.swift
@@ -7,7 +7,6 @@
 
 // MARK: - Mergeable
 
-@_spi(Private)
-public protocol Mergeable {
+package protocol Mergeable {
     mutating func merge(_ other: Self)
 }

--- a/GF/DeviceSwiftShims/Util/NestedCustomStringConvertible.swift
+++ b/GF/DeviceSwiftShims/Util/NestedCustomStringConvertible.swift
@@ -3,11 +3,59 @@
 //  Gestures
 //
 //  Audited for 9126.1.5
-//  Status: WIP
+//  Status: Complete
 
 // MARK: - NestedCustomStringConvertible
 
-@_spi(Private)
-public protocol NestedCustomStringConvertible: CustomDebugStringConvertible, CustomStringConvertible {
-    var label: String { get }
+package protocol NestedCustomStringConvertible: CustomDebugStringConvertible, CustomStringConvertible {
+    func populateNestedDescription(_ nested: inout NestedDescription)
+}
+
+extension NestedCustomStringConvertible {
+    @_spi(Private)
+    public var description: String {
+        var nested = NestedDescription(depth: 0, target: self)
+        populateNestedDescription(&nested)
+        var result = nested.buildOpening()
+        result += nested.buildBody()
+        result += nested.buildClosing()
+        return result
+    }
+
+    @_spi(Private)
+    public var debugDescription: String {
+        description
+    }
+}
+
+// MARK: - Standard Library Conformances
+
+extension Array: NestedCustomStringConvertible where Element: NestedCustomStringConvertible {
+    package func populateNestedDescription(_ nested: inout NestedDescription) {
+        for element in self {
+            var child = NestedDescription(depth: nested.depth + 1, target: element)
+            element.populateNestedDescription(&child)
+            nested.append(child.description)
+        }
+    }
+}
+
+extension Set: NestedCustomStringConvertible where Element: NestedCustomStringConvertible {
+    package func populateNestedDescription(_ nested: inout NestedDescription) {
+        for element in self {
+            var child = NestedDescription(depth: nested.depth + 1, target: element)
+            element.populateNestedDescription(&child)
+            nested.append(child.description)
+        }
+    }
+}
+
+extension Dictionary: NestedCustomStringConvertible where Value: NestedCustomStringConvertible {
+    package func populateNestedDescription(_ nested: inout NestedDescription) {
+        for (key, value) in self {
+            var child = NestedDescription(depth: nested.depth + 1, target: value)
+            value.populateNestedDescription(&child)
+            nested.append(child.description, label: String(describing: key))
+        }
+    }
 }

--- a/GF/DeviceSwiftShims/Util/NestedDescription.swift
+++ b/GF/DeviceSwiftShims/Util/NestedDescription.swift
@@ -1,0 +1,136 @@
+//
+//  NestedDescription.swift
+//  Gestures
+//
+//  Audited for 9126.1.5
+//  Status: Complete
+
+package struct NestedDescription {
+    package struct Options: OptionSet {
+        package let rawValue: Int
+
+        package init(rawValue: Int) {
+            self.rawValue = rawValue
+        }
+
+        package static let hideTypeName = Self(rawValue: 1 << 0)
+        package static let hideIdentity = Self(rawValue: 1 << 1)
+        package static let hideClassAddress = Self(rawValue: 1 << 2)
+        package static let compact = Self(rawValue: 1 << 3)
+    }
+    package var options: Options
+    package var customPrefix: String?
+    package var customSuffix: String?
+    package let depth: Int
+    package let target: Any
+    package var buffer: [String]
+
+    package init(
+        options: Options = [],
+        customPrefix: String? = nil,
+        customSuffix: String? = nil,
+        depth: Int,
+        target: Any,
+        buffer: [String] = []
+    ) {
+        self.options = options
+        self.customPrefix = customPrefix
+        self.customSuffix = customSuffix
+        self.depth = depth
+        self.target = target
+        self.buffer = buffer
+    }
+
+    mutating package func append<T>(
+        _ content: @autoclosure () -> T?,
+        label: String? = nil
+    ) {
+        guard let content = content() else {
+            return
+        }
+        var result: String = ""
+        if let label {
+            result += "\(label): "
+        }
+        result += "\(content)"
+        if !result.isEmpty {
+            buffer.append(result)
+        }
+    }
+
+    // MARK: - Build
+
+    package func buildOpening() -> String {
+        if let customPrefix {
+            return customPrefix
+        }
+        var result: String
+        if !options.contains(.hideTypeName) {
+            result = "\(type(of: target))"
+        } else {
+            result = ""
+        }
+        var hasClassIdentity = false
+        if !options.contains(.hideClassAddress) {
+            let dynamicType = type(of: target)
+            if dynamicType is AnyObject.Type {
+                let obj = target as AnyObject
+                let address = UInt(bitPattern: ObjectIdentifier(obj))
+                let addressString = "0x\(String(address, radix: 16, uppercase: false))"
+                result += " <\(addressString)"
+                hasClassIdentity = true
+            }
+        }
+        if !options.contains(.hideIdentity),
+           let identifiable = target as? any Identifiable {
+            if hasClassIdentity {
+                result += " \(identifiable.id)>"
+            } else {
+                result += " <\(identifiable.id)>"
+            }
+        } else if hasClassIdentity {
+            result += ">"
+        }
+        result += result.isEmpty ? "" : " "
+        result += "{"
+        result += buffer.isEmpty ? "" : " "
+        return result
+    }
+
+    package func buildBody() -> String {
+        guard !options.contains(.compact) else {
+            return buffer.joined(separator: ", ")
+        }
+        let separator: String
+        if buffer.isEmpty {
+            separator = ""
+        } else {
+            let depth = depth + 1
+            let indent = String(repeating: " ", count: 2)
+            let indentWithDepth = String(repeating: indent, count: depth)
+            separator = "\n" + indentWithDepth
+        }
+        return separator + buffer.joined(separator: separator)
+    }
+
+    package func buildClosing() -> String {
+        var result = customSuffix ?? "}"
+        guard !buffer.isEmpty else {
+            return result
+        }
+        let leading: String
+        if options.contains(.compact) {
+            leading = customSuffix == nil ? " " : ""
+        } else {
+            let indent = String(repeating: " ", count: 2)
+            let indentWithDepth = String(repeating: indent, count: depth)
+            leading = "\n\(indentWithDepth)"
+        }
+        result = leading + result
+        return result
+    }
+
+    package var description: String {
+        buildOpening() + buildBody() + buildClosing()
+    }
+}

--- a/GF/generate_swiftinterface.sh
+++ b/GF/generate_swiftinterface.sh
@@ -13,6 +13,7 @@ filepath() {
 }
 
 SCRIPT_DIR="$(dirname "$(filepath "$0")")"
+PACKAGE_DIR="$(dirname "${SCRIPT_DIR}")"
 VERSION=${DARWINPRIVATEFRAMEWORKS_TARGET_RELEASE:-2025}
 FRAMEWORK_ROOT="${SCRIPT_DIR}/${VERSION}"
 SHIMS_DIR="${SCRIPT_DIR}/DeviceSwiftShims"
@@ -27,16 +28,27 @@ if [ "${SWIFT_VERSION}" != "${EXPECTED_SWIFT_VERSION}" ]; then
     exit 1
 fi
 
+# Build package dependencies (OrderedCollections etc.) via SPM
+swift build --package-path "${PACKAGE_DIR}" --target _GesturesDeviceSwiftShims 2>/dev/null
+if [ $? -ne 0 ]; then
+    echo "Error: failed to build package dependencies"
+    exit 1
+fi
+
+# Locate the SPM modules directory for import search paths
+BUILD_BIN_PATH=$(swift build --package-path "${PACKAGE_DIR}" --show-bin-path 2>/dev/null)
+MODULES_DIR="${BUILD_BIN_PATH}/Modules"
+
 TMPDIR_WORK=$(mktemp -d)
 trap "rm -rf ${TMPDIR_WORK}" EXIT
 
 GENERATED="${TMPDIR_WORK}/generated.swiftinterface"
 
-# Resolve the iOS Simulator SDK version for the -target flag
-IOS_SDK_VERSION=$(xcrun --sdk iphonesimulator --show-sdk-version)
+# Use macOS SDK to match the host-built SPM modules
+MACOS_SDK_VERSION=$(xcrun --sdk macosx --show-sdk-version)
 
-# Compile DeviceSwiftShims against the simulator xcframework to emit a swiftinterface
-xcrun --sdk iphonesimulator swiftc \
+# Compile DeviceSwiftShims against the macOS xcframework to emit a swiftinterface
+xcrun --sdk macosx swiftc \
     -emit-module-interface-path "${GENERATED}" \
     -emit-module-path "${TMPDIR_WORK}/module.swiftmodule" \
     -module-name Gestures \
@@ -46,8 +58,9 @@ xcrun --sdk iphonesimulator swiftc \
     -Osize \
     -enable-upcoming-feature InternalImportsByDefault \
     -enable-experimental-feature Extern \
-    -target "arm64-apple-ios${IOS_SDK_VERSION}-simulator" \
-    -F "${FRAMEWORK_ROOT}/Gestures.xcframework/ios-arm64-x86_64-simulator/" \
+    -target "arm64-apple-macos${MACOS_SDK_VERSION}" \
+    -F "${FRAMEWORK_ROOT}/Gestures.xcframework/macos-arm64e-arm64-x86_64/" \
+    -I "${MODULES_DIR}" \
     $(find "${SHIMS_DIR}" -name '*.swift') \
     2>/dev/null
 

--- a/GF/generate_swiftinterface.sh
+++ b/GF/generate_swiftinterface.sh
@@ -5,7 +5,6 @@
 ## This compiles the DeviceSwiftShims Swift files against the Gestures xcframework
 ## to produce a .swiftinterface, then transforms it into the template used by update.sh:
 ##   1. Strip the compiler header comments (update.sh generates per-platform headers)
-##   2. Remove `Gestures.` module prefix from extension type names
 
 # A `realpath` alternative using the default C implementation.
 filepath() {
@@ -69,11 +68,8 @@ if [ ! -f "${GENERATED}" ]; then
     exit 1
 fi
 
-# Transform:
-#   1. Strip the compiler header comments (update.sh generates per-platform headers)
-#   2. Remove `Gestures.` module prefix from extension declarations
+# Strip the compiler header comments (update.sh generates per-platform headers)
 sed -e '/^\/\/ swift-/d' \
-    -e 's/extension Gestures\./extension /g' \
     "${GENERATED}" > "${TEMPLATE_PATH}"
 
 echo "Generated: ${TEMPLATE_PATH}"

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "31b5019e0eac13edfcab62ebfe5a9ca86b1dedbea493b32012797066b92f79b6",
+  "pins" : [
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections",
+      "state" : {
+        "revision" : "6675bc0ff86e61436e615df6fc5174e043e57924",
+        "version" : "1.4.1"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Package.swift
+++ b/Package.swift
@@ -152,6 +152,9 @@ let platforms: [SupportedPlatform] = switch releaseVersion {
 let package = Package(
     name: "DarwinPrivateFrameworks",
     platforms: platforms,
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-collections", from: "1.1.0"),
+    ],
     products: [
         .library(name: "AttributeGraph", targets: ["AttributeGraph", "_AttributeGraphDeviceSwiftShims"]),
         .library(name: "RenderBox", targets: ["RenderBox"]),
@@ -177,7 +180,10 @@ let package = Package(
         .binaryTarget(name: "Gestures", path: "GF/2025/Gestures.xcframework"),
         .target(
             name: "_GesturesDeviceSwiftShims",
-            dependencies: ["Gestures"],
+            dependencies: [
+                "Gestures",
+                .product(name: "OrderedCollections", package: "swift-collections"),
+            ],
             path: "GF/DeviceSwiftShims",
             swiftSettings: sharedSwiftSettings
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -152,9 +152,6 @@ let platforms: [SupportedPlatform] = switch releaseVersion {
 let package = Package(
     name: "DarwinPrivateFrameworks",
     platforms: platforms,
-    dependencies: [
-        .package(url: "https://github.com/apple/swift-collections", from: "1.1.0"),
-    ],
     products: [
         .library(name: "AttributeGraph", targets: ["AttributeGraph", "_AttributeGraphDeviceSwiftShims"]),
         .library(name: "RenderBox", targets: ["RenderBox"]),
@@ -163,6 +160,9 @@ let package = Package(
         .library(name: "SFSymbols", targets: ["SFSymbols"]),
         .library(name: "CoreSVG", targets: ["CoreSVG"]),
         .library(name: "Gestures", targets: ["Gestures", "_GesturesDeviceSwiftShims"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-collections", from: "1.1.0"),
     ],
     targets: [
         .binaryTarget(name: "AttributeGraph", path: "AG/\(releaseVersion)/AttributeGraph.xcframework"),

--- a/Package@swift-6.2.swift
+++ b/Package@swift-6.2.swift
@@ -162,6 +162,9 @@ let package = Package(
         .library(name: "CoreSVG", targets: ["CoreSVG"]),
         .library(name: "Gestures", targets: ["Gestures", "_GesturesDeviceSwiftShims"]),
     ],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-collections", from: "1.1.0"),
+    ],
     targets: [
         .binaryTarget(name: "AttributeGraph", path: "AG/2024/AttributeGraph.xcframework"),
         .target(
@@ -178,7 +181,10 @@ let package = Package(
         .binaryTarget(name: "Gestures", path: "GF/2025/Gestures.xcframework"),
         .target(
             name: "_GesturesDeviceSwiftShims",
-            dependencies: ["Gestures"],
+            dependencies: [
+                "Gestures",
+                .product(name: "OrderedCollections", package: "swift-collections"),
+            ],
             path: "GF/DeviceSwiftShims",
             swiftSettings: sharedSwiftSettings
         ),


### PR DESCRIPTION
## Summary
- Add swiftinterface declarations for `GestureNodeMatcher`, `GestureRelation`, `RelationDefinition`, `RelationMap`
- Add `NestedDescription` and `NestedCustomStringConvertible` package types
- Add `CustomStringConvertible`/`CustomDebugStringConvertible` conformances for `GestureTrait`, `GestureTraitCollection`, `GestureNodeMatcher`
- Add `Sequence` conformance for `GestureTraitCollection`
- Add DeviceSwiftShims for new types
- Update `generate_swiftinterface.sh` for SPM build support
- Add OrderedCollections dependency

## Test plan
- [x] Companion PR: OpenSwiftUIProject/OpenGestures#6
- [x] Compatibility tests pass on iPhone 17 Pro (iOS 26.2 Simulator)