### PR TITLE
Add Core types and UpdateScheduler for GF

### DIFF
--- a/GF/2025/Gestures.xcframework/ios-arm64-x86_64-simulator/Gestures.framework/Modules/Gestures.swiftmodule/arm64-apple-ios-simulator.swiftinterface
+++ b/GF/2025/Gestures.xcframework/ios-arm64-x86_64-simulator/Gestures.framework/Modules/Gestures.swiftmodule/arm64-apple-ios-simulator.swiftinterface
@@ -8,6 +8,74 @@ public import Swift
 public import _Concurrency
 public import _StringProcessing
 public import _SwiftConcurrencyShims
+public enum GestureOutput<Value> {
+  case empty(Gestures.GestureOutputEmptyReason, metadata: Gestures.GestureOutputMetadata?)
+  case value(Value, metadata: Gestures.GestureOutputMetadata?)
+  case finalValue(Value, metadata: Gestures.GestureOutputMetadata?)
+}
+extension Gestures.GestureOutput : Swift.Sendable where Value : Swift.Sendable {
+}
+extension Gestures.GestureOutput {
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var value: Value? {
+    get
+  }
+  #endif
+  public var isEmpty: Swift.Bool {
+    get
+  }
+  public var isFinal: Swift.Bool {
+    get
+  }
+}
+public enum GestureOutputEmptyReason : Swift.Hashable, Swift.Sendable {
+  case noData
+  case filtered
+  case timeUpdate
+  public static func == (a: Gestures.GestureOutputEmptyReason, b: Gestures.GestureOutputEmptyReason) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+public struct GestureOutputMetadata : Swift.Sendable {
+  public var updatesToSchedule: [Gestures.UpdateRequest]
+  public var updatesToCancel: [Gestures.UpdateRequest]
+  public var traceAnnotation: Gestures.UpdateTraceAnnotation?
+  #if compiler(>=5.3) && $NonescapableTypes
+  public init(updatesToSchedule: [Gestures.UpdateRequest] = [], updatesToCancel: [Gestures.UpdateRequest] = [], traceAnnotation: Gestures.UpdateTraceAnnotation? = nil)
+  #endif
+}
+public struct UpdateTraceAnnotation : Swift.Sendable {
+  public var value: Swift.String
+  public init(value: Swift.String)
+}
+public enum GestureOutputStatus : Swift.Hashable, Swift.Sendable {
+  case empty
+  case value
+  case finalValue
+  public static func == (a: Gestures.GestureOutputStatus, b: Gestures.GestureOutputStatus) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+public struct GestureOutputStatusCombiner : Swift.Sendable {
+  public var combine: @Sendable ([Gestures.GestureOutputStatus]) throws -> Gestures.GestureOutputStatus
+  public init(combine: @escaping @Sendable ([Gestures.GestureOutputStatus]) throws -> Gestures.GestureOutputStatus)
+}
+public struct GestureOutputArrayCombiner<A> : Swift.Sendable where A : Swift.Sendable {
+  public let statusCombiner: Gestures.GestureOutputStatusCombiner
+  public init(statusCombiner: Gestures.GestureOutputStatusCombiner)
+}
+public struct GestureOutputCombiner<each A, B> : Swift.Sendable where repeat each A : Swift.Sendable, B : Swift.Sendable {
+  public let combineValues: (@Sendable (repeat each A) throws -> B)?
+  public let combineOptionals: (@Sendable (repeat (each A)?) throws -> B)?
+  public let statusCombiner: Gestures.GestureOutputStatusCombiner
+  #if compiler(>=5.3) && $NonescapableTypes
+  public init(combineValues: (@Sendable (repeat each A) throws -> B)?, combineOptionals: (@Sendable (repeat (each A)?) throws -> B)?, statusCombiner: Gestures.GestureOutputStatusCombiner)
+  #endif
+}
 public struct GestureTrait : Swift.Hashable, Swift.Identifiable, Swift.Sendable {
   public var id: Gestures.GestureTraitID
   public var attributes: [Gestures.GestureTrait.AttributeKey : Gestures.GestureTrait.AttributeValue]
@@ -128,6 +196,71 @@ extension Swift.Array where Element == Gestures.GestureRelation {
     get
   }
 }
+public enum GesturePhase<Value> : Swift.Sendable where Value : Swift.Sendable {
+  case idle
+  case possible
+  case blocked(value: Value, blockedBy: Gestures.GestureNodeID)
+  case active(value: Value)
+  case ended(value: Value)
+  case failed(reason: Gestures.GestureFailureReason)
+}
+extension Gestures.GesturePhase {
+  public var isIdle: Swift.Bool {
+    get
+  }
+  public var isPossible: Swift.Bool {
+    get
+  }
+  public var isActive: Swift.Bool {
+    get
+  }
+  public var isBlocked: Swift.Bool {
+    get
+  }
+  public var isEnded: Swift.Bool {
+    get
+  }
+  public var isFailed: Swift.Bool {
+    get
+  }
+  public var isTerminal: Swift.Bool {
+    get
+  }
+  public var isRecognized: Swift.Bool {
+    get
+  }
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var value: Value? {
+    get
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var failureReason: Gestures.GestureFailureReason? {
+    get
+  }
+  #endif
+  public func mapValue<T>(_ transform: (Value) -> T) -> Gestures.GesturePhase<T> where T : Swift.Sendable
+}
+extension Gestures.GesturePhase : Swift.CustomStringConvertible {
+  public var description: Swift.String {
+    get
+  }
+}
+public enum GestureFailureReason : Swift.Sendable {
+  case excluded(by: Gestures.GestureNodeID)
+  case failureDependency(on: Gestures.GestureNodeID)
+  case custom(any Swift.Error)
+  case disabled
+  case removedFromContainer
+  case activationDenied
+  case aborted
+  case coordinatorChanged
+}
+extension Gestures.GestureFailureReason : Swift.CustomStringConvertible {
+  public var description: Swift.String {
+    get
+  }
+}
 public enum GestureNodeMatcher : Swift.Hashable, Swift.Sendable {
   case id(Gestures.GestureNodeID)
   case tag(Gestures.GestureTag)
@@ -234,6 +367,18 @@ public struct GestureUpdateDriverToken : Swift.Hashable, Swift.Sendable {
     get
   }
 }
+public struct UpdateRequest : Swift.Hashable, Swift.Sendable, Swift.Identifiable {
+  public let id: Swift.UInt32
+  public let creationTime: Gestures.Timestamp
+  public let targetTime: Gestures.Timestamp
+  public let tag: Swift.String?
+  public static func == (a: Gestures.UpdateRequest, b: Gestures.UpdateRequest) -> Swift.Bool
+  public typealias ID = Swift.UInt32
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
 public protocol TimeScheduler : AnyObject, Gestures.TimeSource {
   #if compiler(>=5.3) && $NonescapableTypes
   func schedule(after duration: Swift.Duration, handler: @escaping () -> Swift.Void, cancelHandler: (() -> Swift.Void)?) -> Gestures.TimeSchedulerToken
@@ -287,6 +432,10 @@ public struct UptimeTimeSource : Gestures.TimeSourceImpl, Swift.Sendable {
     get
   }
 }
+extension Gestures.GestureOutput : Swift.CustomStringConvertible {}
+extension Gestures.GestureOutput : Swift.CustomDebugStringConvertible {}
+extension Gestures.GestureOutputMetadata : Swift.CustomStringConvertible {}
+extension Gestures.GestureOutputMetadata : Swift.CustomDebugStringConvertible {}
 extension Gestures.GestureTrait : Swift.CustomStringConvertible {}
 extension Gestures.GestureTrait : Swift.CustomDebugStringConvertible {}
 extension Gestures.GestureTraitCollection : Swift.CustomStringConvertible {}

--- a/GF/2025/Gestures.xcframework/ios-arm64-x86_64-simulator/Gestures.framework/Modules/Gestures.swiftmodule/arm64-apple-ios-simulator.swiftinterface
+++ b/GF/2025/Gestures.xcframework/ios-arm64-x86_64-simulator/Gestures.framework/Modules/Gestures.swiftmodule/arm64-apple-ios-simulator.swiftinterface
@@ -39,12 +39,7 @@ public enum GestureOutputEmptyReason : Swift.Hashable, Swift.Sendable {
   }
 }
 public struct GestureOutputMetadata : Swift.Sendable {
-  public var updatesToSchedule: [Gestures.UpdateRequest]
-  public var updatesToCancel: [Gestures.UpdateRequest]
   public var traceAnnotation: Gestures.UpdateTraceAnnotation?
-  #if compiler(>=5.3) && $NonescapableTypes
-  public init(updatesToSchedule: [Gestures.UpdateRequest] = [], updatesToCancel: [Gestures.UpdateRequest] = [], traceAnnotation: Gestures.UpdateTraceAnnotation? = nil)
-  #endif
 }
 public struct UpdateTraceAnnotation : Swift.Sendable {
   public var value: Swift.String
@@ -367,17 +362,8 @@ public struct GestureUpdateDriverToken : Swift.Hashable, Swift.Sendable {
     get
   }
 }
-public struct UpdateRequest : Swift.Hashable, Swift.Sendable, Swift.Identifiable {
-  public let id: Swift.UInt32
-  public let creationTime: Gestures.Timestamp
-  public let targetTime: Gestures.Timestamp
-  public let tag: Swift.String?
-  public static func == (a: Gestures.UpdateRequest, b: Gestures.UpdateRequest) -> Swift.Bool
-  public typealias ID = Swift.UInt32
-  public func hash(into hasher: inout Swift.Hasher)
-  public var hashValue: Swift.Int {
-    get
-  }
+@_hasMissingDesignatedInitializers final public class UpdateScheduler {
+  @objc deinit
 }
 public protocol TimeScheduler : AnyObject, Gestures.TimeSource {
   #if compiler(>=5.3) && $NonescapableTypes

--- a/GF/2025/Gestures.xcframework/ios-arm64-x86_64-simulator/Gestures.framework/Modules/Gestures.swiftmodule/arm64-apple-ios-simulator.swiftinterface
+++ b/GF/2025/Gestures.xcframework/ios-arm64-x86_64-simulator/Gestures.framework/Modules/Gestures.swiftmodule/arm64-apple-ios-simulator.swiftinterface
@@ -8,12 +8,10 @@ public import Swift
 public import _Concurrency
 public import _StringProcessing
 public import _SwiftConcurrencyShims
-public enum GestureOutput<Value> {
+public enum GestureOutput<Value> : Swift.Sendable where Value : Swift.Sendable {
   case empty(Gestures.GestureOutputEmptyReason, metadata: Gestures.GestureOutputMetadata?)
   case value(Value, metadata: Gestures.GestureOutputMetadata?)
   case finalValue(Value, metadata: Gestures.GestureOutputMetadata?)
-}
-extension Gestures.GestureOutput : Swift.Sendable where Value : Swift.Sendable {
 }
 extension Gestures.GestureOutput {
   #if compiler(>=5.3) && $NonescapableTypes
@@ -39,11 +37,6 @@ public enum GestureOutputEmptyReason : Swift.Hashable, Swift.Sendable {
   }
 }
 public struct GestureOutputMetadata : Swift.Sendable {
-  public var traceAnnotation: Gestures.UpdateTraceAnnotation?
-}
-public struct UpdateTraceAnnotation : Swift.Sendable {
-  public var value: Swift.String
-  public init(value: Swift.String)
 }
 public enum GestureOutputStatus : Swift.Hashable, Swift.Sendable {
   case empty

--- a/GF/2025/Gestures.xcframework/ios-arm64-x86_64-simulator/Gestures.framework/Modules/Gestures.swiftmodule/x86_64-apple-ios-simulator.swiftinterface
+++ b/GF/2025/Gestures.xcframework/ios-arm64-x86_64-simulator/Gestures.framework/Modules/Gestures.swiftmodule/x86_64-apple-ios-simulator.swiftinterface
@@ -8,6 +8,74 @@ public import Swift
 public import _Concurrency
 public import _StringProcessing
 public import _SwiftConcurrencyShims
+public enum GestureOutput<Value> {
+  case empty(Gestures.GestureOutputEmptyReason, metadata: Gestures.GestureOutputMetadata?)
+  case value(Value, metadata: Gestures.GestureOutputMetadata?)
+  case finalValue(Value, metadata: Gestures.GestureOutputMetadata?)
+}
+extension Gestures.GestureOutput : Swift.Sendable where Value : Swift.Sendable {
+}
+extension Gestures.GestureOutput {
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var value: Value? {
+    get
+  }
+  #endif
+  public var isEmpty: Swift.Bool {
+    get
+  }
+  public var isFinal: Swift.Bool {
+    get
+  }
+}
+public enum GestureOutputEmptyReason : Swift.Hashable, Swift.Sendable {
+  case noData
+  case filtered
+  case timeUpdate
+  public static func == (a: Gestures.GestureOutputEmptyReason, b: Gestures.GestureOutputEmptyReason) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+public struct GestureOutputMetadata : Swift.Sendable {
+  public var updatesToSchedule: [Gestures.UpdateRequest]
+  public var updatesToCancel: [Gestures.UpdateRequest]
+  public var traceAnnotation: Gestures.UpdateTraceAnnotation?
+  #if compiler(>=5.3) && $NonescapableTypes
+  public init(updatesToSchedule: [Gestures.UpdateRequest] = [], updatesToCancel: [Gestures.UpdateRequest] = [], traceAnnotation: Gestures.UpdateTraceAnnotation? = nil)
+  #endif
+}
+public struct UpdateTraceAnnotation : Swift.Sendable {
+  public var value: Swift.String
+  public init(value: Swift.String)
+}
+public enum GestureOutputStatus : Swift.Hashable, Swift.Sendable {
+  case empty
+  case value
+  case finalValue
+  public static func == (a: Gestures.GestureOutputStatus, b: Gestures.GestureOutputStatus) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+public struct GestureOutputStatusCombiner : Swift.Sendable {
+  public var combine: @Sendable ([Gestures.GestureOutputStatus]) throws -> Gestures.GestureOutputStatus
+  public init(combine: @escaping @Sendable ([Gestures.GestureOutputStatus]) throws -> Gestures.GestureOutputStatus)
+}
+public struct GestureOutputArrayCombiner<A> : Swift.Sendable where A : Swift.Sendable {
+  public let statusCombiner: Gestures.GestureOutputStatusCombiner
+  public init(statusCombiner: Gestures.GestureOutputStatusCombiner)
+}
+public struct GestureOutputCombiner<each A, B> : Swift.Sendable where repeat each A : Swift.Sendable, B : Swift.Sendable {
+  public let combineValues: (@Sendable (repeat each A) throws -> B)?
+  public let combineOptionals: (@Sendable (repeat (each A)?) throws -> B)?
+  public let statusCombiner: Gestures.GestureOutputStatusCombiner
+  #if compiler(>=5.3) && $NonescapableTypes
+  public init(combineValues: (@Sendable (repeat each A) throws -> B)?, combineOptionals: (@Sendable (repeat (each A)?) throws -> B)?, statusCombiner: Gestures.GestureOutputStatusCombiner)
+  #endif
+}
 public struct GestureTrait : Swift.Hashable, Swift.Identifiable, Swift.Sendable {
   public var id: Gestures.GestureTraitID
   public var attributes: [Gestures.GestureTrait.AttributeKey : Gestures.GestureTrait.AttributeValue]
@@ -128,6 +196,71 @@ extension Swift.Array where Element == Gestures.GestureRelation {
     get
   }
 }
+public enum GesturePhase<Value> : Swift.Sendable where Value : Swift.Sendable {
+  case idle
+  case possible
+  case blocked(value: Value, blockedBy: Gestures.GestureNodeID)
+  case active(value: Value)
+  case ended(value: Value)
+  case failed(reason: Gestures.GestureFailureReason)
+}
+extension Gestures.GesturePhase {
+  public var isIdle: Swift.Bool {
+    get
+  }
+  public var isPossible: Swift.Bool {
+    get
+  }
+  public var isActive: Swift.Bool {
+    get
+  }
+  public var isBlocked: Swift.Bool {
+    get
+  }
+  public var isEnded: Swift.Bool {
+    get
+  }
+  public var isFailed: Swift.Bool {
+    get
+  }
+  public var isTerminal: Swift.Bool {
+    get
+  }
+  public var isRecognized: Swift.Bool {
+    get
+  }
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var value: Value? {
+    get
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var failureReason: Gestures.GestureFailureReason? {
+    get
+  }
+  #endif
+  public func mapValue<T>(_ transform: (Value) -> T) -> Gestures.GesturePhase<T> where T : Swift.Sendable
+}
+extension Gestures.GesturePhase : Swift.CustomStringConvertible {
+  public var description: Swift.String {
+    get
+  }
+}
+public enum GestureFailureReason : Swift.Sendable {
+  case excluded(by: Gestures.GestureNodeID)
+  case failureDependency(on: Gestures.GestureNodeID)
+  case custom(any Swift.Error)
+  case disabled
+  case removedFromContainer
+  case activationDenied
+  case aborted
+  case coordinatorChanged
+}
+extension Gestures.GestureFailureReason : Swift.CustomStringConvertible {
+  public var description: Swift.String {
+    get
+  }
+}
 public enum GestureNodeMatcher : Swift.Hashable, Swift.Sendable {
   case id(Gestures.GestureNodeID)
   case tag(Gestures.GestureTag)
@@ -234,6 +367,18 @@ public struct GestureUpdateDriverToken : Swift.Hashable, Swift.Sendable {
     get
   }
 }
+public struct UpdateRequest : Swift.Hashable, Swift.Sendable, Swift.Identifiable {
+  public let id: Swift.UInt32
+  public let creationTime: Gestures.Timestamp
+  public let targetTime: Gestures.Timestamp
+  public let tag: Swift.String?
+  public static func == (a: Gestures.UpdateRequest, b: Gestures.UpdateRequest) -> Swift.Bool
+  public typealias ID = Swift.UInt32
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
 public protocol TimeScheduler : AnyObject, Gestures.TimeSource {
   #if compiler(>=5.3) && $NonescapableTypes
   func schedule(after duration: Swift.Duration, handler: @escaping () -> Swift.Void, cancelHandler: (() -> Swift.Void)?) -> Gestures.TimeSchedulerToken
@@ -287,6 +432,10 @@ public struct UptimeTimeSource : Gestures.TimeSourceImpl, Swift.Sendable {
     get
   }
 }
+extension Gestures.GestureOutput : Swift.CustomStringConvertible {}
+extension Gestures.GestureOutput : Swift.CustomDebugStringConvertible {}
+extension Gestures.GestureOutputMetadata : Swift.CustomStringConvertible {}
+extension Gestures.GestureOutputMetadata : Swift.CustomDebugStringConvertible {}
 extension Gestures.GestureTrait : Swift.CustomStringConvertible {}
 extension Gestures.GestureTrait : Swift.CustomDebugStringConvertible {}
 extension Gestures.GestureTraitCollection : Swift.CustomStringConvertible {}

--- a/GF/2025/Gestures.xcframework/ios-arm64-x86_64-simulator/Gestures.framework/Modules/Gestures.swiftmodule/x86_64-apple-ios-simulator.swiftinterface
+++ b/GF/2025/Gestures.xcframework/ios-arm64-x86_64-simulator/Gestures.framework/Modules/Gestures.swiftmodule/x86_64-apple-ios-simulator.swiftinterface
@@ -39,12 +39,7 @@ public enum GestureOutputEmptyReason : Swift.Hashable, Swift.Sendable {
   }
 }
 public struct GestureOutputMetadata : Swift.Sendable {
-  public var updatesToSchedule: [Gestures.UpdateRequest]
-  public var updatesToCancel: [Gestures.UpdateRequest]
   public var traceAnnotation: Gestures.UpdateTraceAnnotation?
-  #if compiler(>=5.3) && $NonescapableTypes
-  public init(updatesToSchedule: [Gestures.UpdateRequest] = [], updatesToCancel: [Gestures.UpdateRequest] = [], traceAnnotation: Gestures.UpdateTraceAnnotation? = nil)
-  #endif
 }
 public struct UpdateTraceAnnotation : Swift.Sendable {
   public var value: Swift.String
@@ -367,17 +362,8 @@ public struct GestureUpdateDriverToken : Swift.Hashable, Swift.Sendable {
     get
   }
 }
-public struct UpdateRequest : Swift.Hashable, Swift.Sendable, Swift.Identifiable {
-  public let id: Swift.UInt32
-  public let creationTime: Gestures.Timestamp
-  public let targetTime: Gestures.Timestamp
-  public let tag: Swift.String?
-  public static func == (a: Gestures.UpdateRequest, b: Gestures.UpdateRequest) -> Swift.Bool
-  public typealias ID = Swift.UInt32
-  public func hash(into hasher: inout Swift.Hasher)
-  public var hashValue: Swift.Int {
-    get
-  }
+@_hasMissingDesignatedInitializers final public class UpdateScheduler {
+  @objc deinit
 }
 public protocol TimeScheduler : AnyObject, Gestures.TimeSource {
   #if compiler(>=5.3) && $NonescapableTypes

--- a/GF/2025/Gestures.xcframework/ios-arm64-x86_64-simulator/Gestures.framework/Modules/Gestures.swiftmodule/x86_64-apple-ios-simulator.swiftinterface
+++ b/GF/2025/Gestures.xcframework/ios-arm64-x86_64-simulator/Gestures.framework/Modules/Gestures.swiftmodule/x86_64-apple-ios-simulator.swiftinterface
@@ -8,12 +8,10 @@ public import Swift
 public import _Concurrency
 public import _StringProcessing
 public import _SwiftConcurrencyShims
-public enum GestureOutput<Value> {
+public enum GestureOutput<Value> : Swift.Sendable where Value : Swift.Sendable {
   case empty(Gestures.GestureOutputEmptyReason, metadata: Gestures.GestureOutputMetadata?)
   case value(Value, metadata: Gestures.GestureOutputMetadata?)
   case finalValue(Value, metadata: Gestures.GestureOutputMetadata?)
-}
-extension Gestures.GestureOutput : Swift.Sendable where Value : Swift.Sendable {
 }
 extension Gestures.GestureOutput {
   #if compiler(>=5.3) && $NonescapableTypes
@@ -39,11 +37,6 @@ public enum GestureOutputEmptyReason : Swift.Hashable, Swift.Sendable {
   }
 }
 public struct GestureOutputMetadata : Swift.Sendable {
-  public var traceAnnotation: Gestures.UpdateTraceAnnotation?
-}
-public struct UpdateTraceAnnotation : Swift.Sendable {
-  public var value: Swift.String
-  public init(value: Swift.String)
 }
 public enum GestureOutputStatus : Swift.Hashable, Swift.Sendable {
   case empty

--- a/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/arm64-apple-macos.swiftinterface
+++ b/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/arm64-apple-macos.swiftinterface
@@ -8,6 +8,74 @@ public import Swift
 public import _Concurrency
 public import _StringProcessing
 public import _SwiftConcurrencyShims
+public enum GestureOutput<Value> {
+  case empty(Gestures.GestureOutputEmptyReason, metadata: Gestures.GestureOutputMetadata?)
+  case value(Value, metadata: Gestures.GestureOutputMetadata?)
+  case finalValue(Value, metadata: Gestures.GestureOutputMetadata?)
+}
+extension Gestures.GestureOutput : Swift.Sendable where Value : Swift.Sendable {
+}
+extension Gestures.GestureOutput {
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var value: Value? {
+    get
+  }
+  #endif
+  public var isEmpty: Swift.Bool {
+    get
+  }
+  public var isFinal: Swift.Bool {
+    get
+  }
+}
+public enum GestureOutputEmptyReason : Swift.Hashable, Swift.Sendable {
+  case noData
+  case filtered
+  case timeUpdate
+  public static func == (a: Gestures.GestureOutputEmptyReason, b: Gestures.GestureOutputEmptyReason) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+public struct GestureOutputMetadata : Swift.Sendable {
+  public var updatesToSchedule: [Gestures.UpdateRequest]
+  public var updatesToCancel: [Gestures.UpdateRequest]
+  public var traceAnnotation: Gestures.UpdateTraceAnnotation?
+  #if compiler(>=5.3) && $NonescapableTypes
+  public init(updatesToSchedule: [Gestures.UpdateRequest] = [], updatesToCancel: [Gestures.UpdateRequest] = [], traceAnnotation: Gestures.UpdateTraceAnnotation? = nil)
+  #endif
+}
+public struct UpdateTraceAnnotation : Swift.Sendable {
+  public var value: Swift.String
+  public init(value: Swift.String)
+}
+public enum GestureOutputStatus : Swift.Hashable, Swift.Sendable {
+  case empty
+  case value
+  case finalValue
+  public static func == (a: Gestures.GestureOutputStatus, b: Gestures.GestureOutputStatus) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+public struct GestureOutputStatusCombiner : Swift.Sendable {
+  public var combine: @Sendable ([Gestures.GestureOutputStatus]) throws -> Gestures.GestureOutputStatus
+  public init(combine: @escaping @Sendable ([Gestures.GestureOutputStatus]) throws -> Gestures.GestureOutputStatus)
+}
+public struct GestureOutputArrayCombiner<A> : Swift.Sendable where A : Swift.Sendable {
+  public let statusCombiner: Gestures.GestureOutputStatusCombiner
+  public init(statusCombiner: Gestures.GestureOutputStatusCombiner)
+}
+public struct GestureOutputCombiner<each A, B> : Swift.Sendable where repeat each A : Swift.Sendable, B : Swift.Sendable {
+  public let combineValues: (@Sendable (repeat each A) throws -> B)?
+  public let combineOptionals: (@Sendable (repeat (each A)?) throws -> B)?
+  public let statusCombiner: Gestures.GestureOutputStatusCombiner
+  #if compiler(>=5.3) && $NonescapableTypes
+  public init(combineValues: (@Sendable (repeat each A) throws -> B)?, combineOptionals: (@Sendable (repeat (each A)?) throws -> B)?, statusCombiner: Gestures.GestureOutputStatusCombiner)
+  #endif
+}
 public struct GestureTrait : Swift.Hashable, Swift.Identifiable, Swift.Sendable {
   public var id: Gestures.GestureTraitID
   public var attributes: [Gestures.GestureTrait.AttributeKey : Gestures.GestureTrait.AttributeValue]
@@ -128,6 +196,71 @@ extension Swift.Array where Element == Gestures.GestureRelation {
     get
   }
 }
+public enum GesturePhase<Value> : Swift.Sendable where Value : Swift.Sendable {
+  case idle
+  case possible
+  case blocked(value: Value, blockedBy: Gestures.GestureNodeID)
+  case active(value: Value)
+  case ended(value: Value)
+  case failed(reason: Gestures.GestureFailureReason)
+}
+extension Gestures.GesturePhase {
+  public var isIdle: Swift.Bool {
+    get
+  }
+  public var isPossible: Swift.Bool {
+    get
+  }
+  public var isActive: Swift.Bool {
+    get
+  }
+  public var isBlocked: Swift.Bool {
+    get
+  }
+  public var isEnded: Swift.Bool {
+    get
+  }
+  public var isFailed: Swift.Bool {
+    get
+  }
+  public var isTerminal: Swift.Bool {
+    get
+  }
+  public var isRecognized: Swift.Bool {
+    get
+  }
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var value: Value? {
+    get
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var failureReason: Gestures.GestureFailureReason? {
+    get
+  }
+  #endif
+  public func mapValue<T>(_ transform: (Value) -> T) -> Gestures.GesturePhase<T> where T : Swift.Sendable
+}
+extension Gestures.GesturePhase : Swift.CustomStringConvertible {
+  public var description: Swift.String {
+    get
+  }
+}
+public enum GestureFailureReason : Swift.Sendable {
+  case excluded(by: Gestures.GestureNodeID)
+  case failureDependency(on: Gestures.GestureNodeID)
+  case custom(any Swift.Error)
+  case disabled
+  case removedFromContainer
+  case activationDenied
+  case aborted
+  case coordinatorChanged
+}
+extension Gestures.GestureFailureReason : Swift.CustomStringConvertible {
+  public var description: Swift.String {
+    get
+  }
+}
 public enum GestureNodeMatcher : Swift.Hashable, Swift.Sendable {
   case id(Gestures.GestureNodeID)
   case tag(Gestures.GestureTag)
@@ -234,6 +367,18 @@ public struct GestureUpdateDriverToken : Swift.Hashable, Swift.Sendable {
     get
   }
 }
+public struct UpdateRequest : Swift.Hashable, Swift.Sendable, Swift.Identifiable {
+  public let id: Swift.UInt32
+  public let creationTime: Gestures.Timestamp
+  public let targetTime: Gestures.Timestamp
+  public let tag: Swift.String?
+  public static func == (a: Gestures.UpdateRequest, b: Gestures.UpdateRequest) -> Swift.Bool
+  public typealias ID = Swift.UInt32
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
 public protocol TimeScheduler : AnyObject, Gestures.TimeSource {
   #if compiler(>=5.3) && $NonescapableTypes
   func schedule(after duration: Swift.Duration, handler: @escaping () -> Swift.Void, cancelHandler: (() -> Swift.Void)?) -> Gestures.TimeSchedulerToken
@@ -287,6 +432,10 @@ public struct UptimeTimeSource : Gestures.TimeSourceImpl, Swift.Sendable {
     get
   }
 }
+extension Gestures.GestureOutput : Swift.CustomStringConvertible {}
+extension Gestures.GestureOutput : Swift.CustomDebugStringConvertible {}
+extension Gestures.GestureOutputMetadata : Swift.CustomStringConvertible {}
+extension Gestures.GestureOutputMetadata : Swift.CustomDebugStringConvertible {}
 extension Gestures.GestureTrait : Swift.CustomStringConvertible {}
 extension Gestures.GestureTrait : Swift.CustomDebugStringConvertible {}
 extension Gestures.GestureTraitCollection : Swift.CustomStringConvertible {}

--- a/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/arm64-apple-macos.swiftinterface
+++ b/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/arm64-apple-macos.swiftinterface
@@ -39,12 +39,7 @@ public enum GestureOutputEmptyReason : Swift.Hashable, Swift.Sendable {
   }
 }
 public struct GestureOutputMetadata : Swift.Sendable {
-  public var updatesToSchedule: [Gestures.UpdateRequest]
-  public var updatesToCancel: [Gestures.UpdateRequest]
   public var traceAnnotation: Gestures.UpdateTraceAnnotation?
-  #if compiler(>=5.3) && $NonescapableTypes
-  public init(updatesToSchedule: [Gestures.UpdateRequest] = [], updatesToCancel: [Gestures.UpdateRequest] = [], traceAnnotation: Gestures.UpdateTraceAnnotation? = nil)
-  #endif
 }
 public struct UpdateTraceAnnotation : Swift.Sendable {
   public var value: Swift.String
@@ -367,17 +362,8 @@ public struct GestureUpdateDriverToken : Swift.Hashable, Swift.Sendable {
     get
   }
 }
-public struct UpdateRequest : Swift.Hashable, Swift.Sendable, Swift.Identifiable {
-  public let id: Swift.UInt32
-  public let creationTime: Gestures.Timestamp
-  public let targetTime: Gestures.Timestamp
-  public let tag: Swift.String?
-  public static func == (a: Gestures.UpdateRequest, b: Gestures.UpdateRequest) -> Swift.Bool
-  public typealias ID = Swift.UInt32
-  public func hash(into hasher: inout Swift.Hasher)
-  public var hashValue: Swift.Int {
-    get
-  }
+@_hasMissingDesignatedInitializers final public class UpdateScheduler {
+  @objc deinit
 }
 public protocol TimeScheduler : AnyObject, Gestures.TimeSource {
   #if compiler(>=5.3) && $NonescapableTypes

--- a/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/arm64-apple-macos.swiftinterface
+++ b/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/arm64-apple-macos.swiftinterface
@@ -8,12 +8,10 @@ public import Swift
 public import _Concurrency
 public import _StringProcessing
 public import _SwiftConcurrencyShims
-public enum GestureOutput<Value> {
+public enum GestureOutput<Value> : Swift.Sendable where Value : Swift.Sendable {
   case empty(Gestures.GestureOutputEmptyReason, metadata: Gestures.GestureOutputMetadata?)
   case value(Value, metadata: Gestures.GestureOutputMetadata?)
   case finalValue(Value, metadata: Gestures.GestureOutputMetadata?)
-}
-extension Gestures.GestureOutput : Swift.Sendable where Value : Swift.Sendable {
 }
 extension Gestures.GestureOutput {
   #if compiler(>=5.3) && $NonescapableTypes
@@ -39,11 +37,6 @@ public enum GestureOutputEmptyReason : Swift.Hashable, Swift.Sendable {
   }
 }
 public struct GestureOutputMetadata : Swift.Sendable {
-  public var traceAnnotation: Gestures.UpdateTraceAnnotation?
-}
-public struct UpdateTraceAnnotation : Swift.Sendable {
-  public var value: Swift.String
-  public init(value: Swift.String)
 }
 public enum GestureOutputStatus : Swift.Hashable, Swift.Sendable {
   case empty

--- a/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/arm64e-apple-macos.swiftinterface
+++ b/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/arm64e-apple-macos.swiftinterface
@@ -8,6 +8,74 @@ public import Swift
 public import _Concurrency
 public import _StringProcessing
 public import _SwiftConcurrencyShims
+public enum GestureOutput<Value> {
+  case empty(Gestures.GestureOutputEmptyReason, metadata: Gestures.GestureOutputMetadata?)
+  case value(Value, metadata: Gestures.GestureOutputMetadata?)
+  case finalValue(Value, metadata: Gestures.GestureOutputMetadata?)
+}
+extension Gestures.GestureOutput : Swift.Sendable where Value : Swift.Sendable {
+}
+extension Gestures.GestureOutput {
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var value: Value? {
+    get
+  }
+  #endif
+  public var isEmpty: Swift.Bool {
+    get
+  }
+  public var isFinal: Swift.Bool {
+    get
+  }
+}
+public enum GestureOutputEmptyReason : Swift.Hashable, Swift.Sendable {
+  case noData
+  case filtered
+  case timeUpdate
+  public static func == (a: Gestures.GestureOutputEmptyReason, b: Gestures.GestureOutputEmptyReason) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+public struct GestureOutputMetadata : Swift.Sendable {
+  public var updatesToSchedule: [Gestures.UpdateRequest]
+  public var updatesToCancel: [Gestures.UpdateRequest]
+  public var traceAnnotation: Gestures.UpdateTraceAnnotation?
+  #if compiler(>=5.3) && $NonescapableTypes
+  public init(updatesToSchedule: [Gestures.UpdateRequest] = [], updatesToCancel: [Gestures.UpdateRequest] = [], traceAnnotation: Gestures.UpdateTraceAnnotation? = nil)
+  #endif
+}
+public struct UpdateTraceAnnotation : Swift.Sendable {
+  public var value: Swift.String
+  public init(value: Swift.String)
+}
+public enum GestureOutputStatus : Swift.Hashable, Swift.Sendable {
+  case empty
+  case value
+  case finalValue
+  public static func == (a: Gestures.GestureOutputStatus, b: Gestures.GestureOutputStatus) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+public struct GestureOutputStatusCombiner : Swift.Sendable {
+  public var combine: @Sendable ([Gestures.GestureOutputStatus]) throws -> Gestures.GestureOutputStatus
+  public init(combine: @escaping @Sendable ([Gestures.GestureOutputStatus]) throws -> Gestures.GestureOutputStatus)
+}
+public struct GestureOutputArrayCombiner<A> : Swift.Sendable where A : Swift.Sendable {
+  public let statusCombiner: Gestures.GestureOutputStatusCombiner
+  public init(statusCombiner: Gestures.GestureOutputStatusCombiner)
+}
+public struct GestureOutputCombiner<each A, B> : Swift.Sendable where repeat each A : Swift.Sendable, B : Swift.Sendable {
+  public let combineValues: (@Sendable (repeat each A) throws -> B)?
+  public let combineOptionals: (@Sendable (repeat (each A)?) throws -> B)?
+  public let statusCombiner: Gestures.GestureOutputStatusCombiner
+  #if compiler(>=5.3) && $NonescapableTypes
+  public init(combineValues: (@Sendable (repeat each A) throws -> B)?, combineOptionals: (@Sendable (repeat (each A)?) throws -> B)?, statusCombiner: Gestures.GestureOutputStatusCombiner)
+  #endif
+}
 public struct GestureTrait : Swift.Hashable, Swift.Identifiable, Swift.Sendable {
   public var id: Gestures.GestureTraitID
   public var attributes: [Gestures.GestureTrait.AttributeKey : Gestures.GestureTrait.AttributeValue]
@@ -128,6 +196,71 @@ extension Swift.Array where Element == Gestures.GestureRelation {
     get
   }
 }
+public enum GesturePhase<Value> : Swift.Sendable where Value : Swift.Sendable {
+  case idle
+  case possible
+  case blocked(value: Value, blockedBy: Gestures.GestureNodeID)
+  case active(value: Value)
+  case ended(value: Value)
+  case failed(reason: Gestures.GestureFailureReason)
+}
+extension Gestures.GesturePhase {
+  public var isIdle: Swift.Bool {
+    get
+  }
+  public var isPossible: Swift.Bool {
+    get
+  }
+  public var isActive: Swift.Bool {
+    get
+  }
+  public var isBlocked: Swift.Bool {
+    get
+  }
+  public var isEnded: Swift.Bool {
+    get
+  }
+  public var isFailed: Swift.Bool {
+    get
+  }
+  public var isTerminal: Swift.Bool {
+    get
+  }
+  public var isRecognized: Swift.Bool {
+    get
+  }
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var value: Value? {
+    get
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var failureReason: Gestures.GestureFailureReason? {
+    get
+  }
+  #endif
+  public func mapValue<T>(_ transform: (Value) -> T) -> Gestures.GesturePhase<T> where T : Swift.Sendable
+}
+extension Gestures.GesturePhase : Swift.CustomStringConvertible {
+  public var description: Swift.String {
+    get
+  }
+}
+public enum GestureFailureReason : Swift.Sendable {
+  case excluded(by: Gestures.GestureNodeID)
+  case failureDependency(on: Gestures.GestureNodeID)
+  case custom(any Swift.Error)
+  case disabled
+  case removedFromContainer
+  case activationDenied
+  case aborted
+  case coordinatorChanged
+}
+extension Gestures.GestureFailureReason : Swift.CustomStringConvertible {
+  public var description: Swift.String {
+    get
+  }
+}
 public enum GestureNodeMatcher : Swift.Hashable, Swift.Sendable {
   case id(Gestures.GestureNodeID)
   case tag(Gestures.GestureTag)
@@ -234,6 +367,18 @@ public struct GestureUpdateDriverToken : Swift.Hashable, Swift.Sendable {
     get
   }
 }
+public struct UpdateRequest : Swift.Hashable, Swift.Sendable, Swift.Identifiable {
+  public let id: Swift.UInt32
+  public let creationTime: Gestures.Timestamp
+  public let targetTime: Gestures.Timestamp
+  public let tag: Swift.String?
+  public static func == (a: Gestures.UpdateRequest, b: Gestures.UpdateRequest) -> Swift.Bool
+  public typealias ID = Swift.UInt32
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
 public protocol TimeScheduler : AnyObject, Gestures.TimeSource {
   #if compiler(>=5.3) && $NonescapableTypes
   func schedule(after duration: Swift.Duration, handler: @escaping () -> Swift.Void, cancelHandler: (() -> Swift.Void)?) -> Gestures.TimeSchedulerToken
@@ -287,6 +432,10 @@ public struct UptimeTimeSource : Gestures.TimeSourceImpl, Swift.Sendable {
     get
   }
 }
+extension Gestures.GestureOutput : Swift.CustomStringConvertible {}
+extension Gestures.GestureOutput : Swift.CustomDebugStringConvertible {}
+extension Gestures.GestureOutputMetadata : Swift.CustomStringConvertible {}
+extension Gestures.GestureOutputMetadata : Swift.CustomDebugStringConvertible {}
 extension Gestures.GestureTrait : Swift.CustomStringConvertible {}
 extension Gestures.GestureTrait : Swift.CustomDebugStringConvertible {}
 extension Gestures.GestureTraitCollection : Swift.CustomStringConvertible {}

--- a/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/arm64e-apple-macos.swiftinterface
+++ b/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/arm64e-apple-macos.swiftinterface
@@ -39,12 +39,7 @@ public enum GestureOutputEmptyReason : Swift.Hashable, Swift.Sendable {
   }
 }
 public struct GestureOutputMetadata : Swift.Sendable {
-  public var updatesToSchedule: [Gestures.UpdateRequest]
-  public var updatesToCancel: [Gestures.UpdateRequest]
   public var traceAnnotation: Gestures.UpdateTraceAnnotation?
-  #if compiler(>=5.3) && $NonescapableTypes
-  public init(updatesToSchedule: [Gestures.UpdateRequest] = [], updatesToCancel: [Gestures.UpdateRequest] = [], traceAnnotation: Gestures.UpdateTraceAnnotation? = nil)
-  #endif
 }
 public struct UpdateTraceAnnotation : Swift.Sendable {
   public var value: Swift.String
@@ -367,17 +362,8 @@ public struct GestureUpdateDriverToken : Swift.Hashable, Swift.Sendable {
     get
   }
 }
-public struct UpdateRequest : Swift.Hashable, Swift.Sendable, Swift.Identifiable {
-  public let id: Swift.UInt32
-  public let creationTime: Gestures.Timestamp
-  public let targetTime: Gestures.Timestamp
-  public let tag: Swift.String?
-  public static func == (a: Gestures.UpdateRequest, b: Gestures.UpdateRequest) -> Swift.Bool
-  public typealias ID = Swift.UInt32
-  public func hash(into hasher: inout Swift.Hasher)
-  public var hashValue: Swift.Int {
-    get
-  }
+@_hasMissingDesignatedInitializers final public class UpdateScheduler {
+  @objc deinit
 }
 public protocol TimeScheduler : AnyObject, Gestures.TimeSource {
   #if compiler(>=5.3) && $NonescapableTypes

--- a/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/arm64e-apple-macos.swiftinterface
+++ b/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/arm64e-apple-macos.swiftinterface
@@ -8,12 +8,10 @@ public import Swift
 public import _Concurrency
 public import _StringProcessing
 public import _SwiftConcurrencyShims
-public enum GestureOutput<Value> {
+public enum GestureOutput<Value> : Swift.Sendable where Value : Swift.Sendable {
   case empty(Gestures.GestureOutputEmptyReason, metadata: Gestures.GestureOutputMetadata?)
   case value(Value, metadata: Gestures.GestureOutputMetadata?)
   case finalValue(Value, metadata: Gestures.GestureOutputMetadata?)
-}
-extension Gestures.GestureOutput : Swift.Sendable where Value : Swift.Sendable {
 }
 extension Gestures.GestureOutput {
   #if compiler(>=5.3) && $NonescapableTypes
@@ -39,11 +37,6 @@ public enum GestureOutputEmptyReason : Swift.Hashable, Swift.Sendable {
   }
 }
 public struct GestureOutputMetadata : Swift.Sendable {
-  public var traceAnnotation: Gestures.UpdateTraceAnnotation?
-}
-public struct UpdateTraceAnnotation : Swift.Sendable {
-  public var value: Swift.String
-  public init(value: Swift.String)
 }
 public enum GestureOutputStatus : Swift.Hashable, Swift.Sendable {
   case empty

--- a/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/x86_64-apple-macos.swiftinterface
+++ b/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/x86_64-apple-macos.swiftinterface
@@ -8,6 +8,74 @@ public import Swift
 public import _Concurrency
 public import _StringProcessing
 public import _SwiftConcurrencyShims
+public enum GestureOutput<Value> {
+  case empty(Gestures.GestureOutputEmptyReason, metadata: Gestures.GestureOutputMetadata?)
+  case value(Value, metadata: Gestures.GestureOutputMetadata?)
+  case finalValue(Value, metadata: Gestures.GestureOutputMetadata?)
+}
+extension Gestures.GestureOutput : Swift.Sendable where Value : Swift.Sendable {
+}
+extension Gestures.GestureOutput {
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var value: Value? {
+    get
+  }
+  #endif
+  public var isEmpty: Swift.Bool {
+    get
+  }
+  public var isFinal: Swift.Bool {
+    get
+  }
+}
+public enum GestureOutputEmptyReason : Swift.Hashable, Swift.Sendable {
+  case noData
+  case filtered
+  case timeUpdate
+  public static func == (a: Gestures.GestureOutputEmptyReason, b: Gestures.GestureOutputEmptyReason) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+public struct GestureOutputMetadata : Swift.Sendable {
+  public var updatesToSchedule: [Gestures.UpdateRequest]
+  public var updatesToCancel: [Gestures.UpdateRequest]
+  public var traceAnnotation: Gestures.UpdateTraceAnnotation?
+  #if compiler(>=5.3) && $NonescapableTypes
+  public init(updatesToSchedule: [Gestures.UpdateRequest] = [], updatesToCancel: [Gestures.UpdateRequest] = [], traceAnnotation: Gestures.UpdateTraceAnnotation? = nil)
+  #endif
+}
+public struct UpdateTraceAnnotation : Swift.Sendable {
+  public var value: Swift.String
+  public init(value: Swift.String)
+}
+public enum GestureOutputStatus : Swift.Hashable, Swift.Sendable {
+  case empty
+  case value
+  case finalValue
+  public static func == (a: Gestures.GestureOutputStatus, b: Gestures.GestureOutputStatus) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+public struct GestureOutputStatusCombiner : Swift.Sendable {
+  public var combine: @Sendable ([Gestures.GestureOutputStatus]) throws -> Gestures.GestureOutputStatus
+  public init(combine: @escaping @Sendable ([Gestures.GestureOutputStatus]) throws -> Gestures.GestureOutputStatus)
+}
+public struct GestureOutputArrayCombiner<A> : Swift.Sendable where A : Swift.Sendable {
+  public let statusCombiner: Gestures.GestureOutputStatusCombiner
+  public init(statusCombiner: Gestures.GestureOutputStatusCombiner)
+}
+public struct GestureOutputCombiner<each A, B> : Swift.Sendable where repeat each A : Swift.Sendable, B : Swift.Sendable {
+  public let combineValues: (@Sendable (repeat each A) throws -> B)?
+  public let combineOptionals: (@Sendable (repeat (each A)?) throws -> B)?
+  public let statusCombiner: Gestures.GestureOutputStatusCombiner
+  #if compiler(>=5.3) && $NonescapableTypes
+  public init(combineValues: (@Sendable (repeat each A) throws -> B)?, combineOptionals: (@Sendable (repeat (each A)?) throws -> B)?, statusCombiner: Gestures.GestureOutputStatusCombiner)
+  #endif
+}
 public struct GestureTrait : Swift.Hashable, Swift.Identifiable, Swift.Sendable {
   public var id: Gestures.GestureTraitID
   public var attributes: [Gestures.GestureTrait.AttributeKey : Gestures.GestureTrait.AttributeValue]
@@ -128,6 +196,71 @@ extension Swift.Array where Element == Gestures.GestureRelation {
     get
   }
 }
+public enum GesturePhase<Value> : Swift.Sendable where Value : Swift.Sendable {
+  case idle
+  case possible
+  case blocked(value: Value, blockedBy: Gestures.GestureNodeID)
+  case active(value: Value)
+  case ended(value: Value)
+  case failed(reason: Gestures.GestureFailureReason)
+}
+extension Gestures.GesturePhase {
+  public var isIdle: Swift.Bool {
+    get
+  }
+  public var isPossible: Swift.Bool {
+    get
+  }
+  public var isActive: Swift.Bool {
+    get
+  }
+  public var isBlocked: Swift.Bool {
+    get
+  }
+  public var isEnded: Swift.Bool {
+    get
+  }
+  public var isFailed: Swift.Bool {
+    get
+  }
+  public var isTerminal: Swift.Bool {
+    get
+  }
+  public var isRecognized: Swift.Bool {
+    get
+  }
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var value: Value? {
+    get
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var failureReason: Gestures.GestureFailureReason? {
+    get
+  }
+  #endif
+  public func mapValue<T>(_ transform: (Value) -> T) -> Gestures.GesturePhase<T> where T : Swift.Sendable
+}
+extension Gestures.GesturePhase : Swift.CustomStringConvertible {
+  public var description: Swift.String {
+    get
+  }
+}
+public enum GestureFailureReason : Swift.Sendable {
+  case excluded(by: Gestures.GestureNodeID)
+  case failureDependency(on: Gestures.GestureNodeID)
+  case custom(any Swift.Error)
+  case disabled
+  case removedFromContainer
+  case activationDenied
+  case aborted
+  case coordinatorChanged
+}
+extension Gestures.GestureFailureReason : Swift.CustomStringConvertible {
+  public var description: Swift.String {
+    get
+  }
+}
 public enum GestureNodeMatcher : Swift.Hashable, Swift.Sendable {
   case id(Gestures.GestureNodeID)
   case tag(Gestures.GestureTag)
@@ -234,6 +367,18 @@ public struct GestureUpdateDriverToken : Swift.Hashable, Swift.Sendable {
     get
   }
 }
+public struct UpdateRequest : Swift.Hashable, Swift.Sendable, Swift.Identifiable {
+  public let id: Swift.UInt32
+  public let creationTime: Gestures.Timestamp
+  public let targetTime: Gestures.Timestamp
+  public let tag: Swift.String?
+  public static func == (a: Gestures.UpdateRequest, b: Gestures.UpdateRequest) -> Swift.Bool
+  public typealias ID = Swift.UInt32
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
 public protocol TimeScheduler : AnyObject, Gestures.TimeSource {
   #if compiler(>=5.3) && $NonescapableTypes
   func schedule(after duration: Swift.Duration, handler: @escaping () -> Swift.Void, cancelHandler: (() -> Swift.Void)?) -> Gestures.TimeSchedulerToken
@@ -287,6 +432,10 @@ public struct UptimeTimeSource : Gestures.TimeSourceImpl, Swift.Sendable {
     get
   }
 }
+extension Gestures.GestureOutput : Swift.CustomStringConvertible {}
+extension Gestures.GestureOutput : Swift.CustomDebugStringConvertible {}
+extension Gestures.GestureOutputMetadata : Swift.CustomStringConvertible {}
+extension Gestures.GestureOutputMetadata : Swift.CustomDebugStringConvertible {}
 extension Gestures.GestureTrait : Swift.CustomStringConvertible {}
 extension Gestures.GestureTrait : Swift.CustomDebugStringConvertible {}
 extension Gestures.GestureTraitCollection : Swift.CustomStringConvertible {}

--- a/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/x86_64-apple-macos.swiftinterface
+++ b/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/x86_64-apple-macos.swiftinterface
@@ -39,12 +39,7 @@ public enum GestureOutputEmptyReason : Swift.Hashable, Swift.Sendable {
   }
 }
 public struct GestureOutputMetadata : Swift.Sendable {
-  public var updatesToSchedule: [Gestures.UpdateRequest]
-  public var updatesToCancel: [Gestures.UpdateRequest]
   public var traceAnnotation: Gestures.UpdateTraceAnnotation?
-  #if compiler(>=5.3) && $NonescapableTypes
-  public init(updatesToSchedule: [Gestures.UpdateRequest] = [], updatesToCancel: [Gestures.UpdateRequest] = [], traceAnnotation: Gestures.UpdateTraceAnnotation? = nil)
-  #endif
 }
 public struct UpdateTraceAnnotation : Swift.Sendable {
   public var value: Swift.String
@@ -367,17 +362,8 @@ public struct GestureUpdateDriverToken : Swift.Hashable, Swift.Sendable {
     get
   }
 }
-public struct UpdateRequest : Swift.Hashable, Swift.Sendable, Swift.Identifiable {
-  public let id: Swift.UInt32
-  public let creationTime: Gestures.Timestamp
-  public let targetTime: Gestures.Timestamp
-  public let tag: Swift.String?
-  public static func == (a: Gestures.UpdateRequest, b: Gestures.UpdateRequest) -> Swift.Bool
-  public typealias ID = Swift.UInt32
-  public func hash(into hasher: inout Swift.Hasher)
-  public var hashValue: Swift.Int {
-    get
-  }
+@_hasMissingDesignatedInitializers final public class UpdateScheduler {
+  @objc deinit
 }
 public protocol TimeScheduler : AnyObject, Gestures.TimeSource {
   #if compiler(>=5.3) && $NonescapableTypes

--- a/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/x86_64-apple-macos.swiftinterface
+++ b/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/x86_64-apple-macos.swiftinterface
@@ -8,12 +8,10 @@ public import Swift
 public import _Concurrency
 public import _StringProcessing
 public import _SwiftConcurrencyShims
-public enum GestureOutput<Value> {
+public enum GestureOutput<Value> : Swift.Sendable where Value : Swift.Sendable {
   case empty(Gestures.GestureOutputEmptyReason, metadata: Gestures.GestureOutputMetadata?)
   case value(Value, metadata: Gestures.GestureOutputMetadata?)
   case finalValue(Value, metadata: Gestures.GestureOutputMetadata?)
-}
-extension Gestures.GestureOutput : Swift.Sendable where Value : Swift.Sendable {
 }
 extension Gestures.GestureOutput {
   #if compiler(>=5.3) && $NonescapableTypes
@@ -39,11 +37,6 @@ public enum GestureOutputEmptyReason : Swift.Hashable, Swift.Sendable {
   }
 }
 public struct GestureOutputMetadata : Swift.Sendable {
-  public var traceAnnotation: Gestures.UpdateTraceAnnotation?
-}
-public struct UpdateTraceAnnotation : Swift.Sendable {
-  public var value: Swift.String
-  public init(value: Swift.String)
 }
 public enum GestureOutputStatus : Swift.Hashable, Swift.Sendable {
   case empty

--- a/GF/2025/Sources/Modules/Gestures.swiftmodule/template.swiftinterface
+++ b/GF/2025/Sources/Modules/Gestures.swiftmodule/template.swiftinterface
@@ -35,12 +35,7 @@ public enum GestureOutputEmptyReason : Swift.Hashable, Swift.Sendable {
   }
 }
 public struct GestureOutputMetadata : Swift.Sendable {
-  public var updatesToSchedule: [Gestures.UpdateRequest]
-  public var updatesToCancel: [Gestures.UpdateRequest]
   public var traceAnnotation: Gestures.UpdateTraceAnnotation?
-  #if compiler(>=5.3) && $NonescapableTypes
-  public init(updatesToSchedule: [Gestures.UpdateRequest] = [], updatesToCancel: [Gestures.UpdateRequest] = [], traceAnnotation: Gestures.UpdateTraceAnnotation? = nil)
-  #endif
 }
 public struct UpdateTraceAnnotation : Swift.Sendable {
   public var value: Swift.String
@@ -363,17 +358,8 @@ public struct GestureUpdateDriverToken : Swift.Hashable, Swift.Sendable {
     get
   }
 }
-public struct UpdateRequest : Swift.Hashable, Swift.Sendable, Swift.Identifiable {
-  public let id: Swift.UInt32
-  public let creationTime: Gestures.Timestamp
-  public let targetTime: Gestures.Timestamp
-  public let tag: Swift.String?
-  public static func == (a: Gestures.UpdateRequest, b: Gestures.UpdateRequest) -> Swift.Bool
-  public typealias ID = Swift.UInt32
-  public func hash(into hasher: inout Swift.Hasher)
-  public var hashValue: Swift.Int {
-    get
-  }
+@_hasMissingDesignatedInitializers final public class UpdateScheduler {
+  @objc deinit
 }
 public protocol TimeScheduler : AnyObject, Gestures.TimeSource {
   #if compiler(>=5.3) && $NonescapableTypes

--- a/GF/2025/Sources/Modules/Gestures.swiftmodule/template.swiftinterface
+++ b/GF/2025/Sources/Modules/Gestures.swiftmodule/template.swiftinterface
@@ -4,12 +4,10 @@ public import Swift
 public import _Concurrency
 public import _StringProcessing
 public import _SwiftConcurrencyShims
-public enum GestureOutput<Value> {
+public enum GestureOutput<Value> : Swift.Sendable where Value : Swift.Sendable {
   case empty(Gestures.GestureOutputEmptyReason, metadata: Gestures.GestureOutputMetadata?)
   case value(Value, metadata: Gestures.GestureOutputMetadata?)
   case finalValue(Value, metadata: Gestures.GestureOutputMetadata?)
-}
-extension Gestures.GestureOutput : Swift.Sendable where Value : Swift.Sendable {
 }
 extension Gestures.GestureOutput {
   #if compiler(>=5.3) && $NonescapableTypes
@@ -35,11 +33,6 @@ public enum GestureOutputEmptyReason : Swift.Hashable, Swift.Sendable {
   }
 }
 public struct GestureOutputMetadata : Swift.Sendable {
-  public var traceAnnotation: Gestures.UpdateTraceAnnotation?
-}
-public struct UpdateTraceAnnotation : Swift.Sendable {
-  public var value: Swift.String
-  public init(value: Swift.String)
 }
 public enum GestureOutputStatus : Swift.Hashable, Swift.Sendable {
   case empty

--- a/GF/2025/Sources/Modules/Gestures.swiftmodule/template.swiftinterface
+++ b/GF/2025/Sources/Modules/Gestures.swiftmodule/template.swiftinterface
@@ -4,6 +4,74 @@ public import Swift
 public import _Concurrency
 public import _StringProcessing
 public import _SwiftConcurrencyShims
+public enum GestureOutput<Value> {
+  case empty(Gestures.GestureOutputEmptyReason, metadata: Gestures.GestureOutputMetadata?)
+  case value(Value, metadata: Gestures.GestureOutputMetadata?)
+  case finalValue(Value, metadata: Gestures.GestureOutputMetadata?)
+}
+extension Gestures.GestureOutput : Swift.Sendable where Value : Swift.Sendable {
+}
+extension Gestures.GestureOutput {
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var value: Value? {
+    get
+  }
+  #endif
+  public var isEmpty: Swift.Bool {
+    get
+  }
+  public var isFinal: Swift.Bool {
+    get
+  }
+}
+public enum GestureOutputEmptyReason : Swift.Hashable, Swift.Sendable {
+  case noData
+  case filtered
+  case timeUpdate
+  public static func == (a: Gestures.GestureOutputEmptyReason, b: Gestures.GestureOutputEmptyReason) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+public struct GestureOutputMetadata : Swift.Sendable {
+  public var updatesToSchedule: [Gestures.UpdateRequest]
+  public var updatesToCancel: [Gestures.UpdateRequest]
+  public var traceAnnotation: Gestures.UpdateTraceAnnotation?
+  #if compiler(>=5.3) && $NonescapableTypes
+  public init(updatesToSchedule: [Gestures.UpdateRequest] = [], updatesToCancel: [Gestures.UpdateRequest] = [], traceAnnotation: Gestures.UpdateTraceAnnotation? = nil)
+  #endif
+}
+public struct UpdateTraceAnnotation : Swift.Sendable {
+  public var value: Swift.String
+  public init(value: Swift.String)
+}
+public enum GestureOutputStatus : Swift.Hashable, Swift.Sendable {
+  case empty
+  case value
+  case finalValue
+  public static func == (a: Gestures.GestureOutputStatus, b: Gestures.GestureOutputStatus) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
+public struct GestureOutputStatusCombiner : Swift.Sendable {
+  public var combine: @Sendable ([Gestures.GestureOutputStatus]) throws -> Gestures.GestureOutputStatus
+  public init(combine: @escaping @Sendable ([Gestures.GestureOutputStatus]) throws -> Gestures.GestureOutputStatus)
+}
+public struct GestureOutputArrayCombiner<A> : Swift.Sendable where A : Swift.Sendable {
+  public let statusCombiner: Gestures.GestureOutputStatusCombiner
+  public init(statusCombiner: Gestures.GestureOutputStatusCombiner)
+}
+public struct GestureOutputCombiner<each A, B> : Swift.Sendable where repeat each A : Swift.Sendable, B : Swift.Sendable {
+  public let combineValues: (@Sendable (repeat each A) throws -> B)?
+  public let combineOptionals: (@Sendable (repeat (each A)?) throws -> B)?
+  public let statusCombiner: Gestures.GestureOutputStatusCombiner
+  #if compiler(>=5.3) && $NonescapableTypes
+  public init(combineValues: (@Sendable (repeat each A) throws -> B)?, combineOptionals: (@Sendable (repeat (each A)?) throws -> B)?, statusCombiner: Gestures.GestureOutputStatusCombiner)
+  #endif
+}
 public struct GestureTrait : Swift.Hashable, Swift.Identifiable, Swift.Sendable {
   public var id: Gestures.GestureTraitID
   public var attributes: [Gestures.GestureTrait.AttributeKey : Gestures.GestureTrait.AttributeValue]
@@ -124,6 +192,71 @@ extension Swift.Array where Element == Gestures.GestureRelation {
     get
   }
 }
+public enum GesturePhase<Value> : Swift.Sendable where Value : Swift.Sendable {
+  case idle
+  case possible
+  case blocked(value: Value, blockedBy: Gestures.GestureNodeID)
+  case active(value: Value)
+  case ended(value: Value)
+  case failed(reason: Gestures.GestureFailureReason)
+}
+extension Gestures.GesturePhase {
+  public var isIdle: Swift.Bool {
+    get
+  }
+  public var isPossible: Swift.Bool {
+    get
+  }
+  public var isActive: Swift.Bool {
+    get
+  }
+  public var isBlocked: Swift.Bool {
+    get
+  }
+  public var isEnded: Swift.Bool {
+    get
+  }
+  public var isFailed: Swift.Bool {
+    get
+  }
+  public var isTerminal: Swift.Bool {
+    get
+  }
+  public var isRecognized: Swift.Bool {
+    get
+  }
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var value: Value? {
+    get
+  }
+  #endif
+  #if compiler(>=5.3) && $NonescapableTypes
+  public var failureReason: Gestures.GestureFailureReason? {
+    get
+  }
+  #endif
+  public func mapValue<T>(_ transform: (Value) -> T) -> Gestures.GesturePhase<T> where T : Swift.Sendable
+}
+extension Gestures.GesturePhase : Swift.CustomStringConvertible {
+  public var description: Swift.String {
+    get
+  }
+}
+public enum GestureFailureReason : Swift.Sendable {
+  case excluded(by: Gestures.GestureNodeID)
+  case failureDependency(on: Gestures.GestureNodeID)
+  case custom(any Swift.Error)
+  case disabled
+  case removedFromContainer
+  case activationDenied
+  case aborted
+  case coordinatorChanged
+}
+extension Gestures.GestureFailureReason : Swift.CustomStringConvertible {
+  public var description: Swift.String {
+    get
+  }
+}
 public enum GestureNodeMatcher : Swift.Hashable, Swift.Sendable {
   case id(Gestures.GestureNodeID)
   case tag(Gestures.GestureTag)
@@ -230,6 +363,18 @@ public struct GestureUpdateDriverToken : Swift.Hashable, Swift.Sendable {
     get
   }
 }
+public struct UpdateRequest : Swift.Hashable, Swift.Sendable, Swift.Identifiable {
+  public let id: Swift.UInt32
+  public let creationTime: Gestures.Timestamp
+  public let targetTime: Gestures.Timestamp
+  public let tag: Swift.String?
+  public static func == (a: Gestures.UpdateRequest, b: Gestures.UpdateRequest) -> Swift.Bool
+  public typealias ID = Swift.UInt32
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
 public protocol TimeScheduler : AnyObject, Gestures.TimeSource {
   #if compiler(>=5.3) && $NonescapableTypes
   func schedule(after duration: Swift.Duration, handler: @escaping () -> Swift.Void, cancelHandler: (() -> Swift.Void)?) -> Gestures.TimeSchedulerToken
@@ -283,6 +428,10 @@ public struct UptimeTimeSource : Gestures.TimeSourceImpl, Swift.Sendable {
     get
   }
 }
+extension Gestures.GestureOutput : Swift.CustomStringConvertible {}
+extension Gestures.GestureOutput : Swift.CustomDebugStringConvertible {}
+extension Gestures.GestureOutputMetadata : Swift.CustomStringConvertible {}
+extension Gestures.GestureOutputMetadata : Swift.CustomDebugStringConvertible {}
 extension Gestures.GestureTrait : Swift.CustomStringConvertible {}
 extension Gestures.GestureTrait : Swift.CustomDebugStringConvertible {}
 extension Gestures.GestureTraitCollection : Swift.CustomStringConvertible {}

--- a/GF/DeviceSwiftShims/Core/GestureOutput.swift
+++ b/GF/DeviceSwiftShims/Core/GestureOutput.swift
@@ -64,11 +64,11 @@ public enum GestureOutputEmptyReason: Hashable, Sendable {
 // MARK: - GestureOutputMetadata
 
 public struct GestureOutputMetadata: Sendable {
-    public var updatesToSchedule: [UpdateRequest]
-    public var updatesToCancel: [UpdateRequest]
+    package var updatesToSchedule: [UpdateRequest]
+    package var updatesToCancel: [UpdateRequest]
     public var traceAnnotation: UpdateTraceAnnotation?
 
-    public init(
+    package init(
         updatesToSchedule: [UpdateRequest] = [],
         updatesToCancel: [UpdateRequest] = [],
         traceAnnotation: UpdateTraceAnnotation? = nil

--- a/GF/DeviceSwiftShims/Core/GestureOutput.swift
+++ b/GF/DeviceSwiftShims/Core/GestureOutput.swift
@@ -7,31 +7,33 @@
 
 // MARK: - GestureOutput
 
-public enum GestureOutput<Value> {
+public enum GestureOutput<Value: Sendable>: Sendable {
     case empty(GestureOutputEmptyReason, metadata: GestureOutputMetadata?)
     case value(Value, metadata: GestureOutputMetadata?)
     case finalValue(Value, metadata: GestureOutputMetadata?)
 }
 
-extension GestureOutput: Sendable where Value: Sendable {}
-
 extension GestureOutput {
     public var value: Value? {
         switch self {
-        case .value(let v, _): v
-        case .finalValue(let v, _): v
+        case let .value(v, _): v
+        case let .finalValue(v, _): v
         case .empty: nil
         }
     }
 
     public var isEmpty: Bool {
-        if case .empty = self { return true }
-        return false
+        switch self {
+        case .empty: true
+        default: false
+        }
     }
 
     public var isFinal: Bool {
-        if case .finalValue = self { return true }
-        return false
+        switch self {
+        case .finalValue: true
+        default: false
+        }
     }
 }
 
@@ -39,16 +41,20 @@ extension GestureOutput {
 
 extension GestureOutput: NestedCustomStringConvertible {
     package func populateNestedDescription(_ nested: inout NestedDescription) {
-        nested.options.formUnion([.hideTypeName, .compact])
-        nested.customPrefix = ""
-        nested.customSuffix = ""
+        let metadata: GestureOutputMetadata?
         switch self {
-        case .empty(let reason, _):
-            nested.append("empty(\(reason))")
-        case .value(_, _):
-            nested.append("value")
-        case .finalValue(_, _):
-            nested.append("finalValue")
+        case let .empty(reason, m):
+            nested.append(reason, label: "emptyReason")
+            metadata = m
+        case let .value(v, m):
+            nested.append(v, label: "value")
+            metadata = m
+        case let .finalValue(v, m):
+            nested.append(v, label: "finalValue")
+            metadata = m
+        }
+        if let metadata {
+            nested.append(metadata, label: "metadata")
         }
     }
 }
@@ -66,7 +72,7 @@ public enum GestureOutputEmptyReason: Hashable, Sendable {
 public struct GestureOutputMetadata: Sendable {
     package var updatesToSchedule: [UpdateRequest]
     package var updatesToCancel: [UpdateRequest]
-    public var traceAnnotation: UpdateTraceAnnotation?
+    package var traceAnnotation: UpdateTraceAnnotation?
 
     package init(
         updatesToSchedule: [UpdateRequest] = [],
@@ -100,15 +106,15 @@ extension GestureOutputMetadata: NestedCustomStringConvertible {
 
 // MARK: - UpdateTraceAnnotation
 
-public struct UpdateTraceAnnotation: Sendable {
-    public var value: String
+package struct UpdateTraceAnnotation: Sendable {
+    package var value: String
 
-    public init(value: String) {
+    package init(value: String) {
         self.value = value
     }
 }
 
-// MARK: - GestureOutputStatus
+// MARK: - GestureOutputStatus [TBA]
 
 public enum GestureOutputStatus: Hashable, Sendable {
     case empty
@@ -116,7 +122,7 @@ public enum GestureOutputStatus: Hashable, Sendable {
     case finalValue
 }
 
-// MARK: - GestureOutputStatusCombiner
+// MARK: - GestureOutputStatusCombiner [TBA]
 
 public struct GestureOutputStatusCombiner: Sendable {
     public var combine: @Sendable ([GestureOutputStatus]) throws -> GestureOutputStatus
@@ -126,7 +132,7 @@ public struct GestureOutputStatusCombiner: Sendable {
     }
 }
 
-// MARK: - GestureOutputArrayCombiner
+// MARK: - GestureOutputArrayCombiner [TBA]
 
 public struct GestureOutputArrayCombiner<A: Sendable>: Sendable {
     public let statusCombiner: GestureOutputStatusCombiner
@@ -136,7 +142,7 @@ public struct GestureOutputArrayCombiner<A: Sendable>: Sendable {
     }
 }
 
-// MARK: - GestureOutputCombiner
+// MARK: - GestureOutputCombiner [TBA]
 
 public struct GestureOutputCombiner<each A: Sendable, B: Sendable>: Sendable {
     public let combineValues: (@Sendable (repeat each A) throws -> B)?

--- a/GF/DeviceSwiftShims/Core/GestureOutput.swift
+++ b/GF/DeviceSwiftShims/Core/GestureOutput.swift
@@ -114,42 +114,43 @@ package struct UpdateTraceAnnotation: Sendable {
     }
 }
 
-// MARK: - GestureOutputStatus [TBA]
 
-public enum GestureOutputStatus: Hashable, Sendable {
+// MARK: - GestureOutputStatusCombiner
+
+package struct GestureOutputStatusCombiner: Sendable {
+    package var combine: @Sendable ([GestureOutputStatus]) throws -> GestureOutputStatus
+
+    package init(combine: @escaping @Sendable ([GestureOutputStatus]) throws -> GestureOutputStatus) {
+        self.combine = combine
+    }
+}
+
+// MARK: - GestureOutputStatus
+
+package enum GestureOutputStatus: Hashable, Sendable {
     case empty
     case value
     case finalValue
 }
 
-// MARK: - GestureOutputStatusCombiner [TBA]
+// MARK: - GestureOutputArrayCombiner
 
-public struct GestureOutputStatusCombiner: Sendable {
-    public var combine: @Sendable ([GestureOutputStatus]) throws -> GestureOutputStatus
+package struct GestureOutputArrayCombiner<A: Sendable>: Sendable {
+    package let statusCombiner: GestureOutputStatusCombiner
 
-    public init(combine: @escaping @Sendable ([GestureOutputStatus]) throws -> GestureOutputStatus) {
-        self.combine = combine
-    }
-}
-
-// MARK: - GestureOutputArrayCombiner [TBA]
-
-public struct GestureOutputArrayCombiner<A: Sendable>: Sendable {
-    public let statusCombiner: GestureOutputStatusCombiner
-
-    public init(statusCombiner: GestureOutputStatusCombiner) {
+    package init(statusCombiner: GestureOutputStatusCombiner) {
         self.statusCombiner = statusCombiner
     }
 }
 
-// MARK: - GestureOutputCombiner [TBA]
+// MARK: - GestureOutputCombiner
 
-public struct GestureOutputCombiner<each A: Sendable, B: Sendable>: Sendable {
-    public let combineValues: (@Sendable (repeat each A) throws -> B)?
-    public let combineOptionals: (@Sendable (repeat (each A)?) throws -> B)?
-    public let statusCombiner: GestureOutputStatusCombiner
+package struct GestureOutputCombiner<each A: Sendable, B: Sendable>: Sendable {
+    package let combineValues: (@Sendable (repeat each A) throws -> B)?
+    package let combineOptionals: (@Sendable (repeat (each A)?) throws -> B)?
+    package let statusCombiner: GestureOutputStatusCombiner
 
-    public init(
+    package init(
         combineValues: (@Sendable (repeat each A) throws -> B)?,
         combineOptionals: (@Sendable (repeat (each A)?) throws -> B)?,
         statusCombiner: GestureOutputStatusCombiner

--- a/GF/DeviceSwiftShims/Core/GestureOutput.swift
+++ b/GF/DeviceSwiftShims/Core/GestureOutput.swift
@@ -1,0 +1,155 @@
+//
+//  GestureOutput.swift
+//  Gestures
+//
+//  Audited for 9126.1.5
+//  Status: Complete
+
+// MARK: - GestureOutput
+
+public enum GestureOutput<Value> {
+    case empty(GestureOutputEmptyReason, metadata: GestureOutputMetadata?)
+    case value(Value, metadata: GestureOutputMetadata?)
+    case finalValue(Value, metadata: GestureOutputMetadata?)
+}
+
+extension GestureOutput: Sendable where Value: Sendable {}
+
+extension GestureOutput {
+    public var value: Value? {
+        switch self {
+        case .value(let v, _): v
+        case .finalValue(let v, _): v
+        case .empty: nil
+        }
+    }
+
+    public var isEmpty: Bool {
+        if case .empty = self { return true }
+        return false
+    }
+
+    public var isFinal: Bool {
+        if case .finalValue = self { return true }
+        return false
+    }
+}
+
+// MARK: - GestureOutput + NestedCustomStringConvertible
+
+extension GestureOutput: NestedCustomStringConvertible {
+    package func populateNestedDescription(_ nested: inout NestedDescription) {
+        nested.options.formUnion([.hideTypeName, .compact])
+        nested.customPrefix = ""
+        nested.customSuffix = ""
+        switch self {
+        case .empty(let reason, _):
+            nested.append("empty(\(reason))")
+        case .value(_, _):
+            nested.append("value")
+        case .finalValue(_, _):
+            nested.append("finalValue")
+        }
+    }
+}
+
+// MARK: - GestureOutputEmptyReason
+
+public enum GestureOutputEmptyReason: Hashable, Sendable {
+    case noData
+    case filtered
+    case timeUpdate
+}
+
+// MARK: - GestureOutputMetadata
+
+public struct GestureOutputMetadata: Sendable {
+    public var updatesToSchedule: [UpdateRequest]
+    public var updatesToCancel: [UpdateRequest]
+    public var traceAnnotation: UpdateTraceAnnotation?
+
+    public init(
+        updatesToSchedule: [UpdateRequest] = [],
+        updatesToCancel: [UpdateRequest] = [],
+        traceAnnotation: UpdateTraceAnnotation? = nil
+    ) {
+        self.updatesToSchedule = updatesToSchedule
+        self.updatesToCancel = updatesToCancel
+        self.traceAnnotation = traceAnnotation
+    }
+}
+
+// MARK: - GestureOutputMetadata + NestedCustomStringConvertible
+
+extension GestureOutputMetadata: NestedCustomStringConvertible {
+    package func populateNestedDescription(_ nested: inout NestedDescription) {
+        nested.options.formUnion([.hideTypeName, .compact])
+        nested.customPrefix = ""
+        nested.customSuffix = ""
+        if !updatesToSchedule.isEmpty {
+            nested.append("\(updatesToSchedule)", label: "updatesToSchedule")
+        }
+        if !updatesToCancel.isEmpty {
+            nested.append("\(updatesToCancel)", label: "updatesToCancel")
+        }
+        if let traceAnnotation {
+            nested.append(traceAnnotation.value, label: "traceAnnotation")
+        }
+    }
+}
+
+// MARK: - UpdateTraceAnnotation
+
+public struct UpdateTraceAnnotation: Sendable {
+    public var value: String
+
+    public init(value: String) {
+        self.value = value
+    }
+}
+
+// MARK: - GestureOutputStatus
+
+public enum GestureOutputStatus: Hashable, Sendable {
+    case empty
+    case value
+    case finalValue
+}
+
+// MARK: - GestureOutputStatusCombiner
+
+public struct GestureOutputStatusCombiner: Sendable {
+    public var combine: @Sendable ([GestureOutputStatus]) throws -> GestureOutputStatus
+
+    public init(combine: @escaping @Sendable ([GestureOutputStatus]) throws -> GestureOutputStatus) {
+        self.combine = combine
+    }
+}
+
+// MARK: - GestureOutputArrayCombiner
+
+public struct GestureOutputArrayCombiner<A: Sendable>: Sendable {
+    public let statusCombiner: GestureOutputStatusCombiner
+
+    public init(statusCombiner: GestureOutputStatusCombiner) {
+        self.statusCombiner = statusCombiner
+    }
+}
+
+// MARK: - GestureOutputCombiner
+
+public struct GestureOutputCombiner<each A: Sendable, B: Sendable>: Sendable {
+    public let combineValues: (@Sendable (repeat each A) throws -> B)?
+    public let combineOptionals: (@Sendable (repeat (each A)?) throws -> B)?
+    public let statusCombiner: GestureOutputStatusCombiner
+
+    public init(
+        combineValues: (@Sendable (repeat each A) throws -> B)?,
+        combineOptionals: (@Sendable (repeat (each A)?) throws -> B)?,
+        statusCombiner: GestureOutputStatusCombiner
+    ) {
+        self.combineValues = combineValues
+        self.combineOptionals = combineOptionals
+        self.statusCombiner = statusCombiner
+    }
+}

--- a/GF/DeviceSwiftShims/Core/GesturePhase.swift
+++ b/GF/DeviceSwiftShims/Core/GesturePhase.swift
@@ -1,0 +1,233 @@
+//
+//  GesturePhase.swift
+//  Gestures
+//
+//  Audited for 9126.1.5
+//  Status: Complete
+
+// MARK: - GesturePhase
+
+/// The phase of a gesture recognition state machine.
+///
+/// A gesture progresses through phases as it processes events:
+///
+/// ```
+///          ┌──────────┐
+///          │   idle   │
+///          └────┬─────┘
+///               ▼
+///          ┌──────────┐
+///          │ possible │
+///          └──┬────┬──┘
+///             ▼    └────►┌─────────┐
+///          ┌────────┐◄──►│ blocked │
+///          │ active │    └────┬────┘
+///          └───┬────┘        ▼
+///              ▼          ┌────────┐
+///          ┌───────┐      │ failed │
+///          │ ended │      └────────┘
+///          └───────┘
+/// ```
+///
+/// - `idle`: The gesture is not participating in recognition.
+/// - `possible`: The gesture is evaluating incoming events.
+/// - `active`: The gesture is actively recognized and producing values.
+/// - `blocked`: The gesture is recognized but blocked by another gesture.
+///   Can transition to `active` when the blocking gesture resolves.
+/// - `ended`: The gesture completed successfully with a final value.
+/// - `failed`: The gesture failed for a specific reason.
+public enum GesturePhase<Value: Sendable>: Sendable {
+
+    /// The gesture is not participating in recognition.
+    case idle
+
+    /// The gesture is evaluating incoming events.
+    case possible
+
+    /// The gesture is recognized but blocked by another gesture.
+    case blocked(value: Value, blockedBy: GestureNodeID)
+
+    /// The gesture is actively recognized and producing values.
+    case active(value: Value)
+
+    /// The gesture completed successfully.
+    case ended(value: Value)
+
+    /// The gesture failed.
+    case failed(reason: GestureFailureReason)
+}
+
+extension GesturePhase {
+    /// Whether the phase is ``idle``.
+    public var isIdle: Bool {
+        switch self {
+        case .idle: true
+        default: false
+        }
+    }
+
+    /// Whether the phase is ``possible``.
+    public var isPossible: Bool {
+        switch self {
+        case .possible: true
+        default: false
+        }
+    }
+
+    /// Whether the phase is ``active(value:)``.
+    public var isActive: Bool {
+        switch self {
+        case .active: true
+        default: false
+        }
+    }
+
+    /// Whether the phase is ``blocked(value:blockedBy:)``.
+    public var isBlocked: Bool {
+        switch self {
+        case .blocked: true
+        default: false
+        }
+    }
+
+    /// Whether the phase is ``ended(value:)``.
+    public var isEnded: Bool {
+        switch self {
+        case .ended: true
+        default: false
+        }
+    }
+
+    /// Whether the phase is ``failed(reason:)``.
+    public var isFailed: Bool {
+        switch self {
+        case .failed: true
+        default: false
+        }
+    }
+
+    /// Whether the phase is terminal (``ended(value:)`` or ``failed(reason:)``).
+    ///
+    /// A terminal phase indicates the gesture has finished processing
+    /// and will not produce further updates.
+    public var isTerminal: Bool {
+        switch self {
+        case .ended, .failed: true
+        default: false
+        }
+    }
+
+    /// Whether the gesture has been recognized.
+    ///
+    /// Returns `true` for ``blocked(value:blockedBy:)``, ``active(value:)``,
+    /// and ``ended(value:)`` — all phases where the gesture has produced a value.
+    public var isRecognized: Bool {
+        switch self {
+        case .blocked, .active, .ended: true
+        default: false
+        }
+    }
+
+    /// The associated value, if the phase carries one.
+    ///
+    /// Returns a value for ``blocked(value:blockedBy:)``, ``active(value:)``,
+    /// and ``ended(value:)``. Returns `nil` for all other phases.
+    public var value: Value? {
+        switch self {
+        case .blocked(let v, _): v
+        case .active(let v): v
+        case .ended(let v): v
+        default: nil
+        }
+    }
+
+    /// The failure reason, if the phase is ``failed(reason:)``.
+    public var failureReason: GestureFailureReason? {
+        if case .failed(let reason) = self { return reason }
+        return nil
+    }
+
+    /// Returns a new phase with the value transformed by the given closure.
+    ///
+    /// For phases that carry a value (``blocked(value:blockedBy:)``,
+    /// ``active(value:)``, ``ended(value:)``), the closure is applied to
+    /// produce the new value. Other phases are passed through unchanged.
+    public func mapValue<T: Sendable>(_ transform: (Value) -> T) -> GesturePhase<T> {
+        switch self {
+        case .blocked(let v, let id): .blocked(value: transform(v), blockedBy: id)
+        case .active(let v): .active(value: transform(v))
+        case .ended(let v): .ended(value: transform(v))
+        case .failed(let r): .failed(reason: r)
+        case .idle: .idle
+        case .possible: .possible
+        }
+    }
+}
+
+// MARK: - GesturePhase + CustomStringConvertible
+
+extension GesturePhase: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .blocked(_, let id): "blocked(by: \(id))"
+        case .active: "active"
+        case .ended: "ended"
+        case .failed(let reason): "failed(\(reason))"
+        case .idle: "idle"
+        case .possible: "possible"
+        }
+    }
+}
+
+// MARK: - GestureFailureReason
+
+/// The reason a gesture recognition failed.
+///
+/// Failure reasons fall into two categories:
+/// - **External**: caused by another gesture (``excluded(by:)``, ``failureDependency(on:)``).
+/// - **Internal**: caused by the gesture system or component logic
+///   (``disabled``, ``removedFromContainer``, ``activationDenied``,
+///   ``aborted``, ``coordinatorChanged``, ``custom(_:)``).
+public enum GestureFailureReason: Sendable {
+
+    /// The gesture was excluded by another gesture's exclusion relation.
+    case excluded(by: GestureNodeID)
+
+    /// The gesture failed because a required gesture dependency failed.
+    case failureDependency(on: GestureNodeID)
+
+    /// The gesture failed with a custom error from the component.
+    case custom(any Error)
+
+    /// The gesture node is disabled.
+    case disabled
+
+    /// The gesture node was removed from its container.
+    case removedFromContainer
+
+    /// The gesture's activation was denied by the coordinator.
+    case activationDenied
+
+    /// The gesture was aborted.
+    case aborted
+
+    /// The gesture's coordinator changed.
+    case coordinatorChanged
+}
+
+// MARK: - GestureFailureReason + CustomStringConvertible
+
+extension GestureFailureReason: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .excluded(let id): "excludedBy: \(id)"
+        case .failureDependency(let id): "failureDependency(on: \(id))"
+        case .custom(let error): "\(error)"
+        case .disabled: "disabled"
+        case .removedFromContainer: "removedFromContainer"
+        case .activationDenied: "activationDenied"
+        case .aborted: "aborted"
+        case .coordinatorChanged: "coordinatorChanged"
+        }
+    }
+}

--- a/GF/DeviceSwiftShims/Time/UpdateScheduler.swift
+++ b/GF/DeviceSwiftShims/Time/UpdateScheduler.swift
@@ -1,0 +1,21 @@
+// MARK: - UpdateRequest
+
+public struct UpdateRequest: Hashable, Sendable, Identifiable {
+    public let id: UInt32
+    public let creationTime: Timestamp
+    public let targetTime: Timestamp
+    public let tag: String?
+}
+
+@_spi(Private)
+extension UpdateRequest: CustomStringConvertible {
+    public var description: String {
+        let duration = targetTime - creationTime
+        var result = "{ \(id)"
+        if let tag {
+            result += " \"\(tag)\""
+        }
+        result += ", \(duration) }"
+        return result
+    }
+}

--- a/GF/DeviceSwiftShims/Time/UpdateScheduler.swift
+++ b/GF/DeviceSwiftShims/Time/UpdateScheduler.swift
@@ -1,15 +1,54 @@
-// MARK: - UpdateRequest
+//
+//  UpdateScheduler.swift
+//  Gestures
+//
+//  Audited for 9126.1.5
+//  Status: Complete
 
-public struct UpdateRequest: Hashable, Sendable, Identifiable {
-    public let id: UInt32
-    public let creationTime: Timestamp
-    public let targetTime: Timestamp
-    public let tag: String?
+// MARK: - UpdateScheduler
+
+public final class UpdateScheduler {
+    package let timeScheduler: any TimeScheduler
+
+    package var scheduledRequests: [UpdateRequest: TimeSchedulerToken]
+
+    package init(
+        timeScheduler: any TimeScheduler,
+        scheduledRequests: [UpdateRequest : TimeSchedulerToken]
+    ) {
+        self.timeScheduler = timeScheduler
+        self.scheduledRequests = scheduledRequests
+    }
 }
 
 @_spi(Private)
-extension UpdateRequest: CustomStringConvertible {
-    public var description: String {
+extension UpdateScheduler: TimeSource {
+    public var timestamp: Timestamp {
+        timeScheduler.timestamp
+    }
+}
+
+// MARK: - UpdateRequest
+
+package struct UpdateRequest: Hashable, Identifiable, CustomStringConvertible {
+    package let id: UInt32
+    package let creationTime: Timestamp
+    package let targetTime: Timestamp
+    package let tag: String?
+
+    package init(
+        id: UInt32,
+        creationTime: Timestamp,
+        targetTime: Timestamp,
+        tag: String?
+    ) {
+        self.id = id
+        self.creationTime = creationTime
+        self.targetTime = targetTime
+        self.tag = tag
+    }
+
+    package var description: String {
         let duration = targetTime - creationTime
         var result = "{ \(id)"
         if let tag {


### PR DESCRIPTION
## Summary
- Add `GesturePhase`, `GestureOutput` Core types with full swiftinterface
- Add `UpdateScheduler`, `UpdateRequest` with description
- Add `GestureOutputStatus`, combiners, `UpdateTraceAnnotation`
- Sync access levels (`package`/`@_spi`) from OpenGestures audit

## Test plan
- [x] Companion PR: OpenSwiftUIProject/OpenGestures#8
- [x] Compat tests pass on iPhone 17 Pro (iOS 26.2 Simulator)