### PR TITLE
Default Swift 6.2 target release to 2024

### DIFF
--- a/Package@swift-6.2.swift
+++ b/Package@swift-6.2.swift
@@ -124,7 +124,7 @@ let buildForDarwinPlatform = envBoolValue("BUILD_FOR_DARWIN_PLATFORM", default: 
 let buildForDarwinPlatform = envBoolValue("BUILD_FOR_DARWIN_PLATFORM")
 #endif
 
-let releaseVersion = envIntValue("TARGET_RELEASE", default: 2025)
+let releaseVersion = envIntValue("TARGET_RELEASE", default: 2024)
 let libraryEvolutionCondition = envBoolValue("LIBRARY_EVOLUTION", default: buildForDarwinPlatform)
 
 


### PR DESCRIPTION
## Summary
- Default the Swift 6.2 package manifest `TARGET_RELEASE` value back to `2024`.
- Keeps the manifest's default binary framework paths and platform requirements aligned with the 2024 release set.

## Why
OpenSwiftUI currently defaults to the 2024 release/platform matrix. With this manifest defaulting DarwinPrivateFrameworks to 2025, downstream package resolution can select macOS 26-era binary products while OpenSwiftUI expects macOS 15-era products.

## Validation
- `swift package describe`