### PR TITLE
Make AttributeBodyVisitor visit mutating

### DIFF
--- a/AG/2021/AttributeGraph.xcframework/ios-arm64-x86_64-simulator/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/arm64-apple-ios-simulator.swiftinterface
+++ b/AG/2021/AttributeGraph.xcframework/ios-arm64-x86_64-simulator/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/arm64-apple-ios-simulator.swiftinterface
@@ -170,7 +170,7 @@ extension AttributeGraph.Attribute {
 @_silgen_name("AGGraphSetValue")
 @inline(__always) @inlinable internal func AGGraphSetValue<Value>(_ attribute: AttributeGraph.AnyAttribute, valuePointer: Swift.UnsafePointer<Value>) -> Swift.Bool
 public protocol AttributeBodyVisitor {
-  func visit<Body>(body: Swift.UnsafePointer<Body>) where Body : AttributeGraph._AttributeBody
+  mutating func visit<Body>(body: Swift.UnsafePointer<Body>) where Body : AttributeGraph._AttributeBody
 }
 public protocol ObservedAttribute : AttributeGraph._AttributeBody {
   mutating func destroy()

--- a/AG/2021/AttributeGraph.xcframework/ios-arm64-x86_64-simulator/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/x86_64-apple-ios-simulator.swiftinterface
+++ b/AG/2021/AttributeGraph.xcframework/ios-arm64-x86_64-simulator/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/x86_64-apple-ios-simulator.swiftinterface
@@ -170,7 +170,7 @@ extension AttributeGraph.Attribute {
 @_silgen_name("AGGraphSetValue")
 @inline(__always) @inlinable internal func AGGraphSetValue<Value>(_ attribute: AttributeGraph.AnyAttribute, valuePointer: Swift.UnsafePointer<Value>) -> Swift.Bool
 public protocol AttributeBodyVisitor {
-  func visit<Body>(body: Swift.UnsafePointer<Body>) where Body : AttributeGraph._AttributeBody
+  mutating func visit<Body>(body: Swift.UnsafePointer<Body>) where Body : AttributeGraph._AttributeBody
 }
 public protocol ObservedAttribute : AttributeGraph._AttributeBody {
   mutating func destroy()

--- a/AG/2021/AttributeGraph.xcframework/macos-arm64e-arm64-x86_64/AttributeGraph.framework/Versions/A/Modules/AttributeGraph.swiftmodule/arm64-apple-macos.swiftinterface
+++ b/AG/2021/AttributeGraph.xcframework/macos-arm64e-arm64-x86_64/AttributeGraph.framework/Versions/A/Modules/AttributeGraph.swiftmodule/arm64-apple-macos.swiftinterface
@@ -170,7 +170,7 @@ extension AttributeGraph.Attribute {
 @_silgen_name("AGGraphSetValue")
 @inline(__always) @inlinable internal func AGGraphSetValue<Value>(_ attribute: AttributeGraph.AnyAttribute, valuePointer: Swift.UnsafePointer<Value>) -> Swift.Bool
 public protocol AttributeBodyVisitor {
-  func visit<Body>(body: Swift.UnsafePointer<Body>) where Body : AttributeGraph._AttributeBody
+  mutating func visit<Body>(body: Swift.UnsafePointer<Body>) where Body : AttributeGraph._AttributeBody
 }
 public protocol ObservedAttribute : AttributeGraph._AttributeBody {
   mutating func destroy()

--- a/AG/2021/AttributeGraph.xcframework/macos-arm64e-arm64-x86_64/AttributeGraph.framework/Versions/A/Modules/AttributeGraph.swiftmodule/arm64e-apple-macos.swiftinterface
+++ b/AG/2021/AttributeGraph.xcframework/macos-arm64e-arm64-x86_64/AttributeGraph.framework/Versions/A/Modules/AttributeGraph.swiftmodule/arm64e-apple-macos.swiftinterface
@@ -170,7 +170,7 @@ extension AttributeGraph.Attribute {
 @_silgen_name("AGGraphSetValue")
 @inline(__always) @inlinable internal func AGGraphSetValue<Value>(_ attribute: AttributeGraph.AnyAttribute, valuePointer: Swift.UnsafePointer<Value>) -> Swift.Bool
 public protocol AttributeBodyVisitor {
-  func visit<Body>(body: Swift.UnsafePointer<Body>) where Body : AttributeGraph._AttributeBody
+  mutating func visit<Body>(body: Swift.UnsafePointer<Body>) where Body : AttributeGraph._AttributeBody
 }
 public protocol ObservedAttribute : AttributeGraph._AttributeBody {
   mutating func destroy()

--- a/AG/2021/AttributeGraph.xcframework/macos-arm64e-arm64-x86_64/AttributeGraph.framework/Versions/A/Modules/AttributeGraph.swiftmodule/x86_64-apple-macos.swiftinterface
+++ b/AG/2021/AttributeGraph.xcframework/macos-arm64e-arm64-x86_64/AttributeGraph.framework/Versions/A/Modules/AttributeGraph.swiftmodule/x86_64-apple-macos.swiftinterface
@@ -170,7 +170,7 @@ extension AttributeGraph.Attribute {
 @_silgen_name("AGGraphSetValue")
 @inline(__always) @inlinable internal func AGGraphSetValue<Value>(_ attribute: AttributeGraph.AnyAttribute, valuePointer: Swift.UnsafePointer<Value>) -> Swift.Bool
 public protocol AttributeBodyVisitor {
-  func visit<Body>(body: Swift.UnsafePointer<Body>) where Body : AttributeGraph._AttributeBody
+  mutating func visit<Body>(body: Swift.UnsafePointer<Body>) where Body : AttributeGraph._AttributeBody
 }
 public protocol ObservedAttribute : AttributeGraph._AttributeBody {
   mutating func destroy()

--- a/AG/2024/AttributeGraph.xcframework/ios-arm64-x86_64-simulator/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/arm64-apple-ios-simulator.swiftinterface
+++ b/AG/2024/AttributeGraph.xcframework/ios-arm64-x86_64-simulator/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/arm64-apple-ios-simulator.swiftinterface
@@ -170,7 +170,7 @@ extension AttributeGraph.Attribute {
 @_silgen_name("AGGraphSetValue")
 @inline(__always) @inlinable internal func AGGraphSetValue<Value>(_ attribute: AttributeGraph.AnyAttribute, valuePointer: Swift.UnsafePointer<Value>) -> Swift.Bool
 public protocol AttributeBodyVisitor {
-  func visit<Body>(body: Swift.UnsafePointer<Body>) where Body : AttributeGraph._AttributeBody
+  mutating func visit<Body>(body: Swift.UnsafePointer<Body>) where Body : AttributeGraph._AttributeBody
 }
 public protocol ObservedAttribute : AttributeGraph._AttributeBody {
   mutating func destroy()

--- a/AG/2024/AttributeGraph.xcframework/ios-arm64-x86_64-simulator/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/x86_64-apple-ios-simulator.swiftinterface
+++ b/AG/2024/AttributeGraph.xcframework/ios-arm64-x86_64-simulator/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/x86_64-apple-ios-simulator.swiftinterface
@@ -170,7 +170,7 @@ extension AttributeGraph.Attribute {
 @_silgen_name("AGGraphSetValue")
 @inline(__always) @inlinable internal func AGGraphSetValue<Value>(_ attribute: AttributeGraph.AnyAttribute, valuePointer: Swift.UnsafePointer<Value>) -> Swift.Bool
 public protocol AttributeBodyVisitor {
-  func visit<Body>(body: Swift.UnsafePointer<Body>) where Body : AttributeGraph._AttributeBody
+  mutating func visit<Body>(body: Swift.UnsafePointer<Body>) where Body : AttributeGraph._AttributeBody
 }
 public protocol ObservedAttribute : AttributeGraph._AttributeBody {
   mutating func destroy()

--- a/AG/2024/AttributeGraph.xcframework/macos-arm64e-arm64-x86_64/AttributeGraph.framework/Versions/A/Modules/AttributeGraph.swiftmodule/arm64-apple-macos.swiftinterface
+++ b/AG/2024/AttributeGraph.xcframework/macos-arm64e-arm64-x86_64/AttributeGraph.framework/Versions/A/Modules/AttributeGraph.swiftmodule/arm64-apple-macos.swiftinterface
@@ -170,7 +170,7 @@ extension AttributeGraph.Attribute {
 @_silgen_name("AGGraphSetValue")
 @inline(__always) @inlinable internal func AGGraphSetValue<Value>(_ attribute: AttributeGraph.AnyAttribute, valuePointer: Swift.UnsafePointer<Value>) -> Swift.Bool
 public protocol AttributeBodyVisitor {
-  func visit<Body>(body: Swift.UnsafePointer<Body>) where Body : AttributeGraph._AttributeBody
+  mutating func visit<Body>(body: Swift.UnsafePointer<Body>) where Body : AttributeGraph._AttributeBody
 }
 public protocol ObservedAttribute : AttributeGraph._AttributeBody {
   mutating func destroy()

--- a/AG/2024/AttributeGraph.xcframework/macos-arm64e-arm64-x86_64/AttributeGraph.framework/Versions/A/Modules/AttributeGraph.swiftmodule/arm64e-apple-macos.swiftinterface
+++ b/AG/2024/AttributeGraph.xcframework/macos-arm64e-arm64-x86_64/AttributeGraph.framework/Versions/A/Modules/AttributeGraph.swiftmodule/arm64e-apple-macos.swiftinterface
@@ -170,7 +170,7 @@ extension AttributeGraph.Attribute {
 @_silgen_name("AGGraphSetValue")
 @inline(__always) @inlinable internal func AGGraphSetValue<Value>(_ attribute: AttributeGraph.AnyAttribute, valuePointer: Swift.UnsafePointer<Value>) -> Swift.Bool
 public protocol AttributeBodyVisitor {
-  func visit<Body>(body: Swift.UnsafePointer<Body>) where Body : AttributeGraph._AttributeBody
+  mutating func visit<Body>(body: Swift.UnsafePointer<Body>) where Body : AttributeGraph._AttributeBody
 }
 public protocol ObservedAttribute : AttributeGraph._AttributeBody {
   mutating func destroy()

--- a/AG/2024/AttributeGraph.xcframework/macos-arm64e-arm64-x86_64/AttributeGraph.framework/Versions/A/Modules/AttributeGraph.swiftmodule/x86_64-apple-macos.swiftinterface
+++ b/AG/2024/AttributeGraph.xcframework/macos-arm64e-arm64-x86_64/AttributeGraph.framework/Versions/A/Modules/AttributeGraph.swiftmodule/x86_64-apple-macos.swiftinterface
@@ -170,7 +170,7 @@ extension AttributeGraph.Attribute {
 @_silgen_name("AGGraphSetValue")
 @inline(__always) @inlinable internal func AGGraphSetValue<Value>(_ attribute: AttributeGraph.AnyAttribute, valuePointer: Swift.UnsafePointer<Value>) -> Swift.Bool
 public protocol AttributeBodyVisitor {
-  func visit<Body>(body: Swift.UnsafePointer<Body>) where Body : AttributeGraph._AttributeBody
+  mutating func visit<Body>(body: Swift.UnsafePointer<Body>) where Body : AttributeGraph._AttributeBody
 }
 public protocol ObservedAttribute : AttributeGraph._AttributeBody {
   mutating func destroy()

--- a/AG/2024/AttributeGraph.xcframework/xros-arm64-x86_64-simulator/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/arm64-apple-xros-simulator.swiftinterface
+++ b/AG/2024/AttributeGraph.xcframework/xros-arm64-x86_64-simulator/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/arm64-apple-xros-simulator.swiftinterface
@@ -170,7 +170,7 @@ extension AttributeGraph.Attribute {
 @_silgen_name("AGGraphSetValue")
 @inline(__always) @inlinable internal func AGGraphSetValue<Value>(_ attribute: AttributeGraph.AnyAttribute, valuePointer: Swift.UnsafePointer<Value>) -> Swift.Bool
 public protocol AttributeBodyVisitor {
-  func visit<Body>(body: Swift.UnsafePointer<Body>) where Body : AttributeGraph._AttributeBody
+  mutating func visit<Body>(body: Swift.UnsafePointer<Body>) where Body : AttributeGraph._AttributeBody
 }
 public protocol ObservedAttribute : AttributeGraph._AttributeBody {
   mutating func destroy()

--- a/AG/2024/AttributeGraph.xcframework/xros-arm64-x86_64-simulator/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/x86_64-apple-xros-simulator.swiftinterface
+++ b/AG/2024/AttributeGraph.xcframework/xros-arm64-x86_64-simulator/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/x86_64-apple-xros-simulator.swiftinterface
@@ -170,7 +170,7 @@ extension AttributeGraph.Attribute {
 @_silgen_name("AGGraphSetValue")
 @inline(__always) @inlinable internal func AGGraphSetValue<Value>(_ attribute: AttributeGraph.AnyAttribute, valuePointer: Swift.UnsafePointer<Value>) -> Swift.Bool
 public protocol AttributeBodyVisitor {
-  func visit<Body>(body: Swift.UnsafePointer<Body>) where Body : AttributeGraph._AttributeBody
+  mutating func visit<Body>(body: Swift.UnsafePointer<Body>) where Body : AttributeGraph._AttributeBody
 }
 public protocol ObservedAttribute : AttributeGraph._AttributeBody {
   mutating func destroy()

--- a/AG/DeviceSwiftShims/Attribute/Body/AttributeBodyVisitor.swift
+++ b/AG/DeviceSwiftShims/Attribute/Body/AttributeBodyVisitor.swift
@@ -5,5 +5,5 @@
 //  Status: WIP
 
 public protocol AttributeBodyVisitor {
-    func visit<Body: _AttributeBody>(body: UnsafePointer<Body>)
+    mutating func visit<Body: _AttributeBody>(body: UnsafePointer<Body>)
 }


### PR DESCRIPTION
## Summary
- Mark `AttributeBodyVisitor.visit` in AttributeGraph `DeviceSwiftShims` as `mutating`.
- Regenerate the tracked AttributeGraph swiftinterfaces for the 2024 and 2021 release bundles.