### PR TITLE
[Bug Fix] [RB] Fix path callback Swift name

### DIFF
--- a/RB/2024/RenderBox.xcframework/ios-arm64-arm64e/RenderBox.framework/Headers/RBPathCallbacks.h
+++ b/RB/2024/RenderBox.xcframework/ios-arm64-arm64e/RenderBox.framework/Headers/RBPathCallbacks.h
@@ -16,7 +16,7 @@ RB_ASSUME_NONNULL_BEGIN
 RB_EXTERN_C_BEGIN
 
 /// Flags for path callbacks
-typedef struct RB_SWIFT_NAME(RBPath.Callbacks.Flags) RBPathCallbacksFlags {
+typedef struct RB_SWIFT_NAME(RBPath.CallbacksFlags) RBPathCallbacksFlags {
     uint8_t unknown0;
     uint8_t unknown1;
     bool isExtended;

--- a/RB/2024/RenderBox.xcframework/ios-arm64-x86_64-simulator/RenderBox.framework/Headers/RBPathCallbacks.h
+++ b/RB/2024/RenderBox.xcframework/ios-arm64-x86_64-simulator/RenderBox.framework/Headers/RBPathCallbacks.h
@@ -16,7 +16,7 @@ RB_ASSUME_NONNULL_BEGIN
 RB_EXTERN_C_BEGIN
 
 /// Flags for path callbacks
-typedef struct RB_SWIFT_NAME(RBPath.Callbacks.Flags) RBPathCallbacksFlags {
+typedef struct RB_SWIFT_NAME(RBPath.CallbacksFlags) RBPathCallbacksFlags {
     uint8_t unknown0;
     uint8_t unknown1;
     bool isExtended;

--- a/RB/2024/RenderBox.xcframework/macos-arm64e-arm64-x86_64/RenderBox.framework/Versions/A/Headers/RBPathCallbacks.h
+++ b/RB/2024/RenderBox.xcframework/macos-arm64e-arm64-x86_64/RenderBox.framework/Versions/A/Headers/RBPathCallbacks.h
@@ -16,7 +16,7 @@ RB_ASSUME_NONNULL_BEGIN
 RB_EXTERN_C_BEGIN
 
 /// Flags for path callbacks
-typedef struct RB_SWIFT_NAME(RBPath.Callbacks.Flags) RBPathCallbacksFlags {
+typedef struct RB_SWIFT_NAME(RBPath.CallbacksFlags) RBPathCallbacksFlags {
     uint8_t unknown0;
     uint8_t unknown1;
     bool isExtended;

--- a/RB/2024/RenderBox.xcframework/xros-arm64-x86_64-simulator/RenderBox.framework/Headers/RBPathCallbacks.h
+++ b/RB/2024/RenderBox.xcframework/xros-arm64-x86_64-simulator/RenderBox.framework/Headers/RBPathCallbacks.h
@@ -16,7 +16,7 @@ RB_ASSUME_NONNULL_BEGIN
 RB_EXTERN_C_BEGIN
 
 /// Flags for path callbacks
-typedef struct RB_SWIFT_NAME(RBPath.Callbacks.Flags) RBPathCallbacksFlags {
+typedef struct RB_SWIFT_NAME(RBPath.CallbacksFlags) RBPathCallbacksFlags {
     uint8_t unknown0;
     uint8_t unknown1;
     bool isExtended;

--- a/RB/2024/Sources/Headers/RBPathCallbacks.h
+++ b/RB/2024/Sources/Headers/RBPathCallbacks.h
@@ -16,7 +16,7 @@ RB_ASSUME_NONNULL_BEGIN
 RB_EXTERN_C_BEGIN
 
 /// Flags for path callbacks
-typedef struct RB_SWIFT_NAME(RBPath.Callbacks.Flags) RBPathCallbacksFlags {
+typedef struct RB_SWIFT_NAME(RBPath.CallbacksFlags) RBPathCallbacksFlags {
     uint8_t unknown0;
     uint8_t unknown1;
     bool isExtended;


### PR DESCRIPTION
## Summary

Fix the RenderBox path callback flags Swift importer name by using the valid nested type name `RBPath.CallbacksFlags` instead of the unsupported `RBPath.Callbacks.Flags` spelling.

The source header and packaged RenderBox framework header copies are updated together so consumers no longer see the invalid Swift name warning.

## Root Cause

The Swift importer accepts the `RBPath.Callbacks` record mapping, but rejects the deeper `RBPath.Callbacks.Flags` record name and reports an invalid base identifier warning.

## Validation

- Typechecked the packaged RenderBox framework header through `swiftc -typecheck -import-objc-header` and verified `RBPath.CallbacksFlags` imports without the warning.
- Built OpenSwiftUI with local dependencies enabled:
  `OPENSWIFTUI_USE_LOCAL_DEPS=1 OPENRENDERBOX_USE_LOCAL_DEPS=1 OPENATTRIBUTEGRAPH_USE_LOCAL_DEPS=1 swift build --target OpenSwiftUI`
- Confirmed the local-dependency build log has no `Callbacks.Flags` or invalid `swift_name` warning matches.