### PR TITLE
[Feature] [SFSymbols] Add SFSymbols availability and metadata API

### DIFF
--- a/Example/SFSymbolsExample/ContentView.swift
+++ b/Example/SFSymbolsExample/ContentView.swift
@@ -9,20 +9,64 @@ import SFSymbols
 import SwiftUI
 
 struct ContentView: View {
+    @State private var searchText = ""
+    @State private var symbolScope = SymbolScope.publicSymbols
+    @State private var selectedSymbol: SymbolCatalog.Item?
+
+    private let catalog = SymbolCatalog.system
+    private let gridColumns = [
+        GridItem(.adaptive(minimum: 120), spacing: 12),
+    ]
+
     var body: some View {
-        VStack {
-            Section("Public") {
-                Text("Symbols count: \(SFSymbols.symbol_order.count)")
-                Text("Name alias count: \(SFSymbols.name_aliases.count)")
-                Text("No-fill-to-fill count: \(SFSymbols.nofill_to_fill.count)")
+        let matchingSymbols = catalog.symbols(
+            matching: searchText,
+            scope: symbolScope
+        )
+
+        NavigationStack {
+            ScrollView {
+                if matchingSymbols.isEmpty {
+                    ContentUnavailableView(
+                        "No Symbols Found",
+                        systemImage: "magnifyingglass",
+                        description: Text("Try another name or search scope.")
+                    )
+                    .frame(maxWidth: .infinity, minHeight: 300)
+                } else {
+                    LazyVGrid(columns: gridColumns, spacing: 12) {
+                        ForEach(matchingSymbols) { symbol in
+                            Button {
+                                selectedSymbol = symbol
+                            } label: {
+                                SymbolTile(symbol: symbol)
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+                    .padding()
+                }
             }
-            
-            Divider()
-            
-            Section("Private") {
-                Text("Symbols count: \(SFSymbols.private_symbol_order.count)")
-                Text("Name alias count: \(SFSymbols.private_name_aliases.count)")
-                Text("No-fill-to-fill count: \(SFSymbols.private_nofill_to_fill.count)")
+            .navigationTitle("SF Symbols")
+            .searchable(text: $searchText, prompt: "Search names and aliases")
+            .toolbar {
+                ToolbarItem(placement: .primaryAction) {
+                    Picker("Symbol scope", selection: $symbolScope) {
+                        ForEach(SymbolScope.allCases) { scope in
+                            Text(scope.title).tag(scope)
+                        }
+                    }
+                    .pickerStyle(.menu)
+                }
+                
+                ToolbarItem(placement: .status) {
+                    Text("Showing \(matchingSymbols.count) of \(catalog.count(for: symbolScope)) symbols")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .sheet(item: $selectedSymbol) { symbol in
+                SymbolDetailsView(symbol: symbol)
             }
         }
     }

--- a/Example/SFSymbolsExample/Support/SymbolAvailabilityItem.swift
+++ b/Example/SFSymbolsExample/Support/SymbolAvailabilityItem.swift
@@ -1,0 +1,90 @@
+//
+//  SymbolAvailabilityItem.swift
+//  Example
+//
+//  Created by Yanan Li on 2026/7/11.
+//
+
+import Foundation
+import SFSymbols
+
+struct SymbolCatalog {
+    static let system = SymbolCatalog()
+
+    private let publicSymbols: [SymbolCatalog.Item]
+    private let privateSymbols: [SymbolCatalog.Item]
+
+    private init() {
+        let publicAliases = Dictionary(grouping: SFSymbols.name_aliases.keys) {
+            SFSymbols.name_aliases[$0] ?? ""
+        }
+        let privateAliases = Dictionary(grouping: SFSymbols.private_name_aliases.keys) {
+            SFSymbols.private_name_aliases[$0] ?? ""
+        }
+
+        publicSymbols = SFSymbols.symbol_order.map { name in
+            SymbolCatalog.Item(
+                name: name,
+                aliases: publicAliases[name, default: []].sorted(),
+                filledSymbolName: SFSymbols.nofill_to_fill[name],
+                isPrivate: false,
+                availability: SFSymbols.SymbolMetadataStore.system.availability(forSystemName: name)
+            )
+        }
+        privateSymbols = SFSymbols.private_symbol_order.map { name in
+            SymbolCatalog.Item(
+                name: name,
+                aliases: privateAliases[name, default: []].sorted(),
+                filledSymbolName: SFSymbols.private_nofill_to_fill[name],
+                isPrivate: true,
+                availability: SFSymbols.SymbolMetadataStore.system.availability(forSystemName: name)
+            )
+        }
+    }
+
+    func symbols(matching searchText: String, scope: SymbolScope) -> [SymbolCatalog.Item] {
+        let symbols: [SymbolCatalog.Item]
+        switch scope {
+        case .publicSymbols:
+            symbols = publicSymbols
+        case .privateSymbols:
+            symbols = privateSymbols
+        case .allSymbols:
+            symbols = publicSymbols + privateSymbols
+        }
+
+        guard !searchText.isEmpty else {
+            return symbols
+        }
+
+        return symbols.filter { symbol in
+            symbol.name.localizedCaseInsensitiveContains(searchText)
+                || symbol.aliases.contains {
+                    $0.localizedCaseInsensitiveContains(searchText)
+                }
+        }
+    }
+
+    func count(for scope: SymbolScope) -> Int {
+        switch scope {
+        case .publicSymbols:
+            publicSymbols.count
+        case .privateSymbols:
+            privateSymbols.count
+        case .allSymbols:
+            publicSymbols.count + privateSymbols.count
+        }
+    }
+    
+    struct Item: Identifiable {
+        let name: String
+        let aliases: [String]
+        let filledSymbolName: String?
+        let isPrivate: Bool
+        let availability: SFSymbols.Availability?
+
+        var id: String {
+            "\(isPrivate ? "private" : "public"):\(name)"
+        }
+    }
+}

--- a/Example/SFSymbolsExample/Support/SymbolScope.swift
+++ b/Example/SFSymbolsExample/Support/SymbolScope.swift
@@ -1,0 +1,27 @@
+//
+//  SymbolScope.swift
+//  Example
+//
+//  Created by Yanan Li on 2026/7/11.
+//
+
+import Foundation
+
+enum SymbolScope: String, CaseIterable, Identifiable {
+    case publicSymbols
+    case privateSymbols
+    case allSymbols
+
+    var id: Self { self }
+
+    var title: String {
+        switch self {
+        case .publicSymbols:
+            "Public"
+        case .privateSymbols:
+            "Private"
+        case .allSymbols:
+            "All"
+        }
+    }
+}

--- a/Example/SFSymbolsExample/SymbolDetailsView.swift
+++ b/Example/SFSymbolsExample/SymbolDetailsView.swift
@@ -39,7 +39,13 @@ struct SymbolDetailsView: View {
             ScrollView {
                 VStack(alignment: .leading, spacing: 24) {
                     VStack(spacing: 16) {
-                        Image(systemName: symbol.name)
+                        Group {
+                            if symbol.isPrivate {
+                                Image(_internalSystemName: symbol.name)
+                            } else {
+                                Image(systemName: symbol.name)
+                            }
+                        }
                             .font(.system(size: 72))
                             .frame(height: 84)
                             .accessibilityHidden(true)
@@ -94,7 +100,13 @@ struct SymbolDetailsView: View {
                     if let filledSymbolName = symbol.filledSymbolName {
                         DetailSection(title: "Filled Variant") {
                             HStack(spacing: 12) {
-                                Image(systemName: filledSymbolName)
+                                Group {
+                                    if symbol.isPrivate {
+                                        Image(_internalSystemName: filledSymbolName)
+                                    } else {
+                                        Image(systemName: filledSymbolName)
+                                    }
+                                }
                                     .font(.title2)
                                     .frame(width: 32)
 

--- a/Example/SFSymbolsExample/SymbolDetailsView.swift
+++ b/Example/SFSymbolsExample/SymbolDetailsView.swift
@@ -1,0 +1,138 @@
+//
+//  SymbolDetailsView.swift
+//  Example
+//
+//  Created by Yanan Li on 2026/7/11.
+//
+
+import SFSymbols
+import SwiftUI
+
+struct SymbolDetailsView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    let symbol: SymbolCatalog.Item
+
+    private let availabilityPlatforms: [SFSymbols.Availability.Platform] = [
+        .sfSymbols,
+        .iOS,
+        .macOS,
+        .macCatalyst,
+        .watchOS,
+        .tvOS,
+        .visionOS,
+    ]
+
+    var body: some View {
+        #if os(macOS)
+        detailsContent
+            .frame(width: 600, height: 640)
+        #else
+        detailsContent
+            .presentationDetents([.medium, .large])
+            .presentationDragIndicator(.visible)
+        #endif
+    }
+
+    private var detailsContent: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 24) {
+                    VStack(spacing: 16) {
+                        Image(systemName: symbol.name)
+                            .font(.system(size: 72))
+                            .frame(height: 84)
+                            .accessibilityHidden(true)
+
+                        Text(symbol.name)
+                            .font(.title3.monospaced())
+                            .fontWeight(.medium)
+                            .multilineTextAlignment(.center)
+                            .textSelection(.enabled)
+
+                        if !symbol.aliases.isEmpty {
+                            Text("Previously: \(symbol.aliases.joined(separator: ", "))")
+                                .font(.callout)
+                                .foregroundStyle(.secondary)
+                                .multilineTextAlignment(.center)
+                                .textSelection(.enabled)
+                        }
+
+                        Text(symbol.isPrivate ? "Private" : "Public")
+                            .font(.caption.weight(.medium))
+                            .foregroundStyle(.secondary)
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 5)
+                            .background(.quaternary, in: Capsule())
+                    }
+                    .frame(maxWidth: .infinity)
+
+                    if let availability = symbol.availability {
+                        DetailSection(title: "Availability") {
+                            LazyVGrid(
+                                columns: [GridItem(.adaptive(minimum: 150), spacing: 12)],
+                                spacing: 12
+                            ) {
+                                ForEach(availabilityPlatforms, id: \.rawValue) { platform in
+                                    if let version = availability.earliestSupportedRelease(for: platform) {
+                                        VStack(alignment: .leading, spacing: 4) {
+                                            Text(platform.rawValue)
+                                                .font(.caption)
+                                                .foregroundStyle(.secondary)
+                                            Text(version.description)
+                                                .font(.body.monospacedDigit())
+                                        }
+                                        .frame(maxWidth: .infinity, alignment: .leading)
+                                        .padding(12)
+                                        .background(.quaternary, in: RoundedRectangle(cornerRadius: 10))
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    if let filledSymbolName = symbol.filledSymbolName {
+                        DetailSection(title: "Filled Variant") {
+                            HStack(spacing: 12) {
+                                Image(systemName: filledSymbolName)
+                                    .font(.title2)
+                                    .frame(width: 32)
+
+                                Text(filledSymbolName)
+                                    .font(.body.monospaced())
+                                    .textSelection(.enabled)
+
+                                Spacer()
+                            }
+                            .padding(14)
+                            .background(.quaternary, in: RoundedRectangle(cornerRadius: 10))
+                        }
+                    }
+                }
+                .padding(24)
+            }
+            .navigationTitle("Symbol Details")
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") {
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
+
+    struct DetailSection<Content: View>: View {
+        let title: String
+        @ViewBuilder let content: Content
+
+        var body: some View {
+            VStack(alignment: .leading, spacing: 10) {
+                Text(title)
+                    .font(.headline)
+
+                content
+            }
+        }
+    }
+}

--- a/Example/SFSymbolsExample/SymbolTile.swift
+++ b/Example/SFSymbolsExample/SymbolTile.swift
@@ -1,0 +1,53 @@
+//
+//  SymbolTile.swift
+//  Example
+//
+//  Created by Yanan Li on 2026/7/11.
+//
+
+import SwiftUI
+
+struct SymbolTile: View {
+    let symbol: SymbolCatalog.Item
+
+    var body: some View {
+        VStack(spacing: 12) {
+            Group {
+                if symbol.isPrivate {
+                    Image(_internalSystemName: symbol.name)
+                } else {
+                    Image(systemName: symbol.name)
+                }
+            }
+            .font(.system(size: 30))
+            .frame(height: 36)
+            .accessibilityHidden(true)
+
+            Text(symbol.name)
+                .font(.caption)
+                .lineLimit(2)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: .infinity)
+
+            if !symbol.aliases.isEmpty {
+                Text(symbol.aliases.joined(separator: "\n"))
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: .infinity)
+            }
+
+            if symbol.isPrivate {
+                Text("Private")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding()
+        .frame(maxWidth: .infinity)
+        .frame(height: 120)
+        .background(.fill.secondary, in: .rect(cornerRadius: 12))
+        .contentShape(RoundedRectangle(cornerRadius: 12))
+    }
+}

--- a/SFSymbols/2024/SFSymbols.xcframework/ios-arm64-arm64e/SFSymbols.framework/Modules/SFSymbols.swiftmodule/arm64-apple-ios.swiftinterface
+++ b/SFSymbols/2024/SFSymbols.xcframework/ios-arm64-arm64e/SFSymbols.framework/Modules/SFSymbols.swiftmodule/arm64-apple-ios.swiftinterface
@@ -17,13 +17,67 @@ public var private_nofill_to_fill: [String : String] { get }
 public var private_symbol_order: [String] { get }
 public var private_name_aliases: [String : String] { get }
 
+public struct Availability {
+    public enum Platform: RawRepresentable {
+        case sfSymbols
+        case macOS
+        case macCatalyst
+        case iOS
+        case watchOS
+        case tvOS
+        case visionOS
+
+        public init?(rawValue: Swift.String)
+
+        public var rawValue: Swift.String {
+            get
+        }
+    }
+    let earliestYear: SFSymbols.Version
+    let platformLookup: [SFSymbols.Version : [SFSymbols.Availability.Platform : SFSymbols.Version]]
+
+    public func earliestSupportedRelease(for: SFSymbols.Availability.Platform) -> SFSymbols.Version?
+}
+
+public struct Version: Codable, Hashable, Equatable, Comparable {
+    public enum DecodingError: Error {
+        case invalidVersionString(Swift.String)
+    }
+    
+    public let major: Swift.Int
+    public let minor: Swift.Int
+    public let patch: Swift.Int
+
+    public init(from: Swift.Decoder) throws
+    public init(major: Swift.Int, minor: Swift.Int, patch: Swift.Int)
+    public init?(string: Swift.String)
+
+    public var hashValue: Swift.Int {
+        get
+    }
+    public var description: Swift.String {
+        get
+    }
+
+    public func hash(into: inout Swift.Hasher)
+    public func encode(to: Swift.Encoder) throws
+
+    static public var sfSymbolsHost: SFSymbols.Version {
+        get
+    }
+
+    static public func < (_: SFSymbols.Version, _: SFSymbols.Version) -> Swift.Bool
+    static public func == (_: SFSymbols.Version, _: SFSymbols.Version) -> Swift.Bool
+}
 
 public struct SymbolMetadataStore {
     static public var system: SymbolMetadataStore { get set }
 
     public var localizationOverrideBundle : Foundation.Bundle? { get set }
     public var localizationOverrideTableName : Swift.String? { get set }
+    
     public func modernSystemName(forAlias: Swift.String) -> Swift.String?
+    public func availability(forSystemName: Swift.String) -> SFSymbols.Availability?
 }
 
 public struct SystemSymbolCSVRow: Swift.Equatable {

--- a/SFSymbols/2024/SFSymbols.xcframework/ios-arm64-arm64e/SFSymbols.framework/Modules/SFSymbols.swiftmodule/arm64-apple-ios.swiftinterface
+++ b/SFSymbols/2024/SFSymbols.xcframework/ios-arm64-arm64e/SFSymbols.framework/Modules/SFSymbols.swiftmodule/arm64-apple-ios.swiftinterface
@@ -18,7 +18,7 @@ public var private_symbol_order: [String] { get }
 public var private_name_aliases: [String : String] { get }
 
 public struct Availability {
-    public enum Platform: RawRepresentable {
+    public enum Platform: Swift.RawRepresentable, Swift.Hashable, Swift.Equatable {
         case sfSymbols
         case macOS
         case macCatalyst
@@ -33,13 +33,11 @@ public struct Availability {
             get
         }
     }
-    let earliestYear: SFSymbols.Version
-    let platformLookup: [SFSymbols.Version : [SFSymbols.Availability.Platform : SFSymbols.Version]]
 
     public func earliestSupportedRelease(for: SFSymbols.Availability.Platform) -> SFSymbols.Version?
 }
 
-public struct Version: Codable, Hashable, Equatable, Comparable {
+public struct Version: Swift.Codable, Swift.Hashable, Swift.Equatable, Swift.Comparable, Swift.CustomStringConvertible {
     public enum DecodingError: Error {
         case invalidVersionString(Swift.String)
     }
@@ -52,19 +50,13 @@ public struct Version: Codable, Hashable, Equatable, Comparable {
     public init(major: Swift.Int, minor: Swift.Int, patch: Swift.Int)
     public init?(string: Swift.String)
 
-    public var hashValue: Swift.Int {
-        get
-    }
-    public var description: Swift.String {
-        get
-    }
+    public var hashValue: Swift.Int { get }
+    public var description: Swift.String { get }
 
     public func hash(into: inout Swift.Hasher)
     public func encode(to: Swift.Encoder) throws
 
-    static public var sfSymbolsHost: SFSymbols.Version {
-        get
-    }
+    static public var sfSymbolsHost: SFSymbols.Version { get }
 
     static public func < (_: SFSymbols.Version, _: SFSymbols.Version) -> Swift.Bool
     static public func == (_: SFSymbols.Version, _: SFSymbols.Version) -> Swift.Bool
@@ -72,12 +64,33 @@ public struct Version: Codable, Hashable, Equatable, Comparable {
 
 public struct SymbolMetadataStore {
     static public var system: SymbolMetadataStore { get set }
-
+    
+    public init()
+    
+    public var customSymbols: [SFSymbols.CustomSymbol]
+    
+    public var categories: [SFSymbols.SymbolCategory] { get }
     public var localizationOverrideBundle : Foundation.Bundle? { get set }
     public var localizationOverrideTableName : Swift.String? { get set }
     
     public func modernSystemName(forAlias: Swift.String) -> Swift.String?
     public func availability(forSystemName: Swift.String) -> SFSymbols.Availability?
+    public func symbolMetadata(forSystemName: Swift.String) -> SFSymbols.SymbolMetadata?
+    public func symbolMetadata(for: SFSymbols.SymbolKey) -> SFSymbols.SymbolMetadata?
+    
+    public func load(from: Foundation.URL, decryptor: @escaping (_: Foundation.Data) throws -> Foundation.Data) throws
+    public func load(from: Foundation.URL) throws
+}
+
+public struct SymbolCategory {
+    public struct Key: Swift.Hashable, Swift.RawRepresentable {
+        public let rawValue: Swift.String
+
+        static public var all: SFSymbols.SymbolCategory.Key { get }
+    }
+    public let key: SFSymbols.SymbolCategory.Key
+    public let iconName: Swift.String
+    public let localizedTitle: Swift.String
 }
 
 public struct SystemSymbolCSVRow: Swift.Equatable {
@@ -121,4 +134,56 @@ public enum RenderingMode: Swift.Hashable, Swift.Equatable, Swift.RawRepresentab
 public struct Crypton {
     static public func decryptObfuscatedFontTable(tableTag: Swift.UInt32, from: CoreText.CTFont) -> Foundation.Data?
     static public func encryptObfuscateFontTable(tableTag: Swift.UInt32, from: CoreText.CTFont) -> Foundation.Data?
+}
+
+public struct Alias {
+    public let name: Swift.String
+    public let availability: SFSymbols.Availability?
+}
+
+public struct SymbolMetadata {
+    public var accessLevel: SFSymbols.AccessLevel { get }
+    public var additionalCSVColumns: [Swift.String : Swift.String] { get }
+    public var aliases: [SFSymbols.Alias] { get }
+    public var csvRow: SFSymbols.SystemSymbolCSVRow? { get }
+    public var defaultRenderingMode: SFSymbols.RenderingMode? { get }
+    public var functions: [Swift.String] { get }
+    public var glyphOrder: Swift.Int? { get }
+    public var key: SFSymbols.SymbolKey { get }
+    public var localeSuffix: Swift.String? { get }
+    public var mirrorForRTL: Swift.Bool { get }
+    public var name: Swift.String { get }
+    public var privateScalar: Swift.Unicode.Scalar? { get }
+    public var publicScalars: [Swift.Unicode.Scalar] { get }
+    public var tags: Swift.Set<Swift.String> { get }
+    public var useRestrictionsDescription: Swift.String? { get }
+    public var useRestrictionsLocalizedDescription: Swift.String? { get }
+
+    public func availability(for: SFSymbols.SymbolFeature) -> SFSymbols.Availability?
+    public func string(for: SFSymbols.SymbolProperty) -> Swift.String?
+}
+
+public enum SymbolKey: Swift.Hashable, Swift.Equatable {
+    case systemPrivateScalar(Swift.Unicode.Scalar)
+    case customUUID(Foundation.UUID)
+}
+
+public struct SymbolFeature: Swift.RawRepresentable, Swift.Hashable, Swift.Equatable {
+    public let rawValue: Swift.String
+
+    static var hierarchical: SFSymbols.SymbolFeature { get }
+    static var monochrome: SFSymbols.SymbolFeature { get }
+    static var multicolor: SFSymbols.SymbolFeature { get }
+    static var name: SFSymbols.SymbolFeature { get }
+}
+
+public struct SymbolProperty: Swift.RawRepresentable, Swift.Hashable, Swift.Equatable {
+    public let rawValue: Swift.String
+}
+
+public struct CustomSymbol {
+    public let uuid: Foundation.UUID
+    public var name: Swift.String
+
+    public init(uuid: Foundation.UUID, name: Swift.String)
 }

--- a/SFSymbols/2024/SFSymbols.xcframework/ios-arm64-arm64e/SFSymbols.framework/Modules/SFSymbols.swiftmodule/arm64e-apple-ios.swiftinterface
+++ b/SFSymbols/2024/SFSymbols.xcframework/ios-arm64-arm64e/SFSymbols.framework/Modules/SFSymbols.swiftmodule/arm64e-apple-ios.swiftinterface
@@ -17,13 +17,67 @@ public var private_nofill_to_fill: [String : String] { get }
 public var private_symbol_order: [String] { get }
 public var private_name_aliases: [String : String] { get }
 
+public struct Availability {
+    public enum Platform: RawRepresentable {
+        case sfSymbols
+        case macOS
+        case macCatalyst
+        case iOS
+        case watchOS
+        case tvOS
+        case visionOS
+
+        public init?(rawValue: Swift.String)
+
+        public var rawValue: Swift.String {
+            get
+        }
+    }
+    let earliestYear: SFSymbols.Version
+    let platformLookup: [SFSymbols.Version : [SFSymbols.Availability.Platform : SFSymbols.Version]]
+
+    public func earliestSupportedRelease(for: SFSymbols.Availability.Platform) -> SFSymbols.Version?
+}
+
+public struct Version: Codable, Hashable, Equatable, Comparable {
+    public enum DecodingError: Error {
+        case invalidVersionString(Swift.String)
+    }
+    
+    public let major: Swift.Int
+    public let minor: Swift.Int
+    public let patch: Swift.Int
+
+    public init(from: Swift.Decoder) throws
+    public init(major: Swift.Int, minor: Swift.Int, patch: Swift.Int)
+    public init?(string: Swift.String)
+
+    public var hashValue: Swift.Int {
+        get
+    }
+    public var description: Swift.String {
+        get
+    }
+
+    public func hash(into: inout Swift.Hasher)
+    public func encode(to: Swift.Encoder) throws
+
+    static public var sfSymbolsHost: SFSymbols.Version {
+        get
+    }
+
+    static public func < (_: SFSymbols.Version, _: SFSymbols.Version) -> Swift.Bool
+    static public func == (_: SFSymbols.Version, _: SFSymbols.Version) -> Swift.Bool
+}
 
 public struct SymbolMetadataStore {
     static public var system: SymbolMetadataStore { get set }
 
     public var localizationOverrideBundle : Foundation.Bundle? { get set }
     public var localizationOverrideTableName : Swift.String? { get set }
+    
     public func modernSystemName(forAlias: Swift.String) -> Swift.String?
+    public func availability(forSystemName: Swift.String) -> SFSymbols.Availability?
 }
 
 public struct SystemSymbolCSVRow: Swift.Equatable {

--- a/SFSymbols/2024/SFSymbols.xcframework/ios-arm64-arm64e/SFSymbols.framework/Modules/SFSymbols.swiftmodule/arm64e-apple-ios.swiftinterface
+++ b/SFSymbols/2024/SFSymbols.xcframework/ios-arm64-arm64e/SFSymbols.framework/Modules/SFSymbols.swiftmodule/arm64e-apple-ios.swiftinterface
@@ -18,7 +18,7 @@ public var private_symbol_order: [String] { get }
 public var private_name_aliases: [String : String] { get }
 
 public struct Availability {
-    public enum Platform: RawRepresentable {
+    public enum Platform: Swift.RawRepresentable, Swift.Hashable, Swift.Equatable {
         case sfSymbols
         case macOS
         case macCatalyst
@@ -33,13 +33,11 @@ public struct Availability {
             get
         }
     }
-    let earliestYear: SFSymbols.Version
-    let platformLookup: [SFSymbols.Version : [SFSymbols.Availability.Platform : SFSymbols.Version]]
 
     public func earliestSupportedRelease(for: SFSymbols.Availability.Platform) -> SFSymbols.Version?
 }
 
-public struct Version: Codable, Hashable, Equatable, Comparable {
+public struct Version: Swift.Codable, Swift.Hashable, Swift.Equatable, Swift.Comparable, Swift.CustomStringConvertible {
     public enum DecodingError: Error {
         case invalidVersionString(Swift.String)
     }
@@ -52,19 +50,13 @@ public struct Version: Codable, Hashable, Equatable, Comparable {
     public init(major: Swift.Int, minor: Swift.Int, patch: Swift.Int)
     public init?(string: Swift.String)
 
-    public var hashValue: Swift.Int {
-        get
-    }
-    public var description: Swift.String {
-        get
-    }
+    public var hashValue: Swift.Int { get }
+    public var description: Swift.String { get }
 
     public func hash(into: inout Swift.Hasher)
     public func encode(to: Swift.Encoder) throws
 
-    static public var sfSymbolsHost: SFSymbols.Version {
-        get
-    }
+    static public var sfSymbolsHost: SFSymbols.Version { get }
 
     static public func < (_: SFSymbols.Version, _: SFSymbols.Version) -> Swift.Bool
     static public func == (_: SFSymbols.Version, _: SFSymbols.Version) -> Swift.Bool
@@ -72,12 +64,33 @@ public struct Version: Codable, Hashable, Equatable, Comparable {
 
 public struct SymbolMetadataStore {
     static public var system: SymbolMetadataStore { get set }
-
+    
+    public init()
+    
+    public var customSymbols: [SFSymbols.CustomSymbol]
+    
+    public var categories: [SFSymbols.SymbolCategory] { get }
     public var localizationOverrideBundle : Foundation.Bundle? { get set }
     public var localizationOverrideTableName : Swift.String? { get set }
     
     public func modernSystemName(forAlias: Swift.String) -> Swift.String?
     public func availability(forSystemName: Swift.String) -> SFSymbols.Availability?
+    public func symbolMetadata(forSystemName: Swift.String) -> SFSymbols.SymbolMetadata?
+    public func symbolMetadata(for: SFSymbols.SymbolKey) -> SFSymbols.SymbolMetadata?
+    
+    public func load(from: Foundation.URL, decryptor: @escaping (_: Foundation.Data) throws -> Foundation.Data) throws
+    public func load(from: Foundation.URL) throws
+}
+
+public struct SymbolCategory {
+    public struct Key: Swift.Hashable, Swift.RawRepresentable {
+        public let rawValue: Swift.String
+
+        static public var all: SFSymbols.SymbolCategory.Key { get }
+    }
+    public let key: SFSymbols.SymbolCategory.Key
+    public let iconName: Swift.String
+    public let localizedTitle: Swift.String
 }
 
 public struct SystemSymbolCSVRow: Swift.Equatable {
@@ -121,4 +134,56 @@ public enum RenderingMode: Swift.Hashable, Swift.Equatable, Swift.RawRepresentab
 public struct Crypton {
     static public func decryptObfuscatedFontTable(tableTag: Swift.UInt32, from: CoreText.CTFont) -> Foundation.Data?
     static public func encryptObfuscateFontTable(tableTag: Swift.UInt32, from: CoreText.CTFont) -> Foundation.Data?
+}
+
+public struct Alias {
+    public let name: Swift.String
+    public let availability: SFSymbols.Availability?
+}
+
+public struct SymbolMetadata {
+    public var accessLevel: SFSymbols.AccessLevel { get }
+    public var additionalCSVColumns: [Swift.String : Swift.String] { get }
+    public var aliases: [SFSymbols.Alias] { get }
+    public var csvRow: SFSymbols.SystemSymbolCSVRow? { get }
+    public var defaultRenderingMode: SFSymbols.RenderingMode? { get }
+    public var functions: [Swift.String] { get }
+    public var glyphOrder: Swift.Int? { get }
+    public var key: SFSymbols.SymbolKey { get }
+    public var localeSuffix: Swift.String? { get }
+    public var mirrorForRTL: Swift.Bool { get }
+    public var name: Swift.String { get }
+    public var privateScalar: Swift.Unicode.Scalar? { get }
+    public var publicScalars: [Swift.Unicode.Scalar] { get }
+    public var tags: Swift.Set<Swift.String> { get }
+    public var useRestrictionsDescription: Swift.String? { get }
+    public var useRestrictionsLocalizedDescription: Swift.String? { get }
+
+    public func availability(for: SFSymbols.SymbolFeature) -> SFSymbols.Availability?
+    public func string(for: SFSymbols.SymbolProperty) -> Swift.String?
+}
+
+public enum SymbolKey: Swift.Hashable, Swift.Equatable {
+    case systemPrivateScalar(Swift.Unicode.Scalar)
+    case customUUID(Foundation.UUID)
+}
+
+public struct SymbolFeature: Swift.RawRepresentable, Swift.Hashable, Swift.Equatable {
+    public let rawValue: Swift.String
+
+    static var hierarchical: SFSymbols.SymbolFeature { get }
+    static var monochrome: SFSymbols.SymbolFeature { get }
+    static var multicolor: SFSymbols.SymbolFeature { get }
+    static var name: SFSymbols.SymbolFeature { get }
+}
+
+public struct SymbolProperty: Swift.RawRepresentable, Swift.Hashable, Swift.Equatable {
+    public let rawValue: Swift.String
+}
+
+public struct CustomSymbol {
+    public let uuid: Foundation.UUID
+    public var name: Swift.String
+
+    public init(uuid: Foundation.UUID, name: Swift.String)
 }

--- a/SFSymbols/2024/SFSymbols.xcframework/ios-arm64-x86_64-simulator/SFSymbols.framework/Modules/SFSymbols.swiftmodule/arm64-apple-ios-simulator.swiftinterface
+++ b/SFSymbols/2024/SFSymbols.xcframework/ios-arm64-x86_64-simulator/SFSymbols.framework/Modules/SFSymbols.swiftmodule/arm64-apple-ios-simulator.swiftinterface
@@ -17,13 +17,67 @@ public var private_nofill_to_fill: [String : String] { get }
 public var private_symbol_order: [String] { get }
 public var private_name_aliases: [String : String] { get }
 
+public struct Availability {
+    public enum Platform: RawRepresentable {
+        case sfSymbols
+        case macOS
+        case macCatalyst
+        case iOS
+        case watchOS
+        case tvOS
+        case visionOS
+
+        public init?(rawValue: Swift.String)
+
+        public var rawValue: Swift.String {
+            get
+        }
+    }
+    let earliestYear: SFSymbols.Version
+    let platformLookup: [SFSymbols.Version : [SFSymbols.Availability.Platform : SFSymbols.Version]]
+
+    public func earliestSupportedRelease(for: SFSymbols.Availability.Platform) -> SFSymbols.Version?
+}
+
+public struct Version: Codable, Hashable, Equatable, Comparable {
+    public enum DecodingError: Error {
+        case invalidVersionString(Swift.String)
+    }
+    
+    public let major: Swift.Int
+    public let minor: Swift.Int
+    public let patch: Swift.Int
+
+    public init(from: Swift.Decoder) throws
+    public init(major: Swift.Int, minor: Swift.Int, patch: Swift.Int)
+    public init?(string: Swift.String)
+
+    public var hashValue: Swift.Int {
+        get
+    }
+    public var description: Swift.String {
+        get
+    }
+
+    public func hash(into: inout Swift.Hasher)
+    public func encode(to: Swift.Encoder) throws
+
+    static public var sfSymbolsHost: SFSymbols.Version {
+        get
+    }
+
+    static public func < (_: SFSymbols.Version, _: SFSymbols.Version) -> Swift.Bool
+    static public func == (_: SFSymbols.Version, _: SFSymbols.Version) -> Swift.Bool
+}
 
 public struct SymbolMetadataStore {
     static public var system: SymbolMetadataStore { get set }
 
     public var localizationOverrideBundle : Foundation.Bundle? { get set }
     public var localizationOverrideTableName : Swift.String? { get set }
+    
     public func modernSystemName(forAlias: Swift.String) -> Swift.String?
+    public func availability(forSystemName: Swift.String) -> SFSymbols.Availability?
 }
 
 public struct SystemSymbolCSVRow: Swift.Equatable {

--- a/SFSymbols/2024/SFSymbols.xcframework/ios-arm64-x86_64-simulator/SFSymbols.framework/Modules/SFSymbols.swiftmodule/arm64-apple-ios-simulator.swiftinterface
+++ b/SFSymbols/2024/SFSymbols.xcframework/ios-arm64-x86_64-simulator/SFSymbols.framework/Modules/SFSymbols.swiftmodule/arm64-apple-ios-simulator.swiftinterface
@@ -18,7 +18,7 @@ public var private_symbol_order: [String] { get }
 public var private_name_aliases: [String : String] { get }
 
 public struct Availability {
-    public enum Platform: RawRepresentable {
+    public enum Platform: Swift.RawRepresentable, Swift.Hashable, Swift.Equatable {
         case sfSymbols
         case macOS
         case macCatalyst
@@ -33,13 +33,11 @@ public struct Availability {
             get
         }
     }
-    let earliestYear: SFSymbols.Version
-    let platformLookup: [SFSymbols.Version : [SFSymbols.Availability.Platform : SFSymbols.Version]]
 
     public func earliestSupportedRelease(for: SFSymbols.Availability.Platform) -> SFSymbols.Version?
 }
 
-public struct Version: Codable, Hashable, Equatable, Comparable {
+public struct Version: Swift.Codable, Swift.Hashable, Swift.Equatable, Swift.Comparable, Swift.CustomStringConvertible {
     public enum DecodingError: Error {
         case invalidVersionString(Swift.String)
     }
@@ -52,19 +50,13 @@ public struct Version: Codable, Hashable, Equatable, Comparable {
     public init(major: Swift.Int, minor: Swift.Int, patch: Swift.Int)
     public init?(string: Swift.String)
 
-    public var hashValue: Swift.Int {
-        get
-    }
-    public var description: Swift.String {
-        get
-    }
+    public var hashValue: Swift.Int { get }
+    public var description: Swift.String { get }
 
     public func hash(into: inout Swift.Hasher)
     public func encode(to: Swift.Encoder) throws
 
-    static public var sfSymbolsHost: SFSymbols.Version {
-        get
-    }
+    static public var sfSymbolsHost: SFSymbols.Version { get }
 
     static public func < (_: SFSymbols.Version, _: SFSymbols.Version) -> Swift.Bool
     static public func == (_: SFSymbols.Version, _: SFSymbols.Version) -> Swift.Bool
@@ -72,12 +64,33 @@ public struct Version: Codable, Hashable, Equatable, Comparable {
 
 public struct SymbolMetadataStore {
     static public var system: SymbolMetadataStore { get set }
-
+    
+    public init()
+    
+    public var customSymbols: [SFSymbols.CustomSymbol]
+    
+    public var categories: [SFSymbols.SymbolCategory] { get }
     public var localizationOverrideBundle : Foundation.Bundle? { get set }
     public var localizationOverrideTableName : Swift.String? { get set }
     
     public func modernSystemName(forAlias: Swift.String) -> Swift.String?
     public func availability(forSystemName: Swift.String) -> SFSymbols.Availability?
+    public func symbolMetadata(forSystemName: Swift.String) -> SFSymbols.SymbolMetadata?
+    public func symbolMetadata(for: SFSymbols.SymbolKey) -> SFSymbols.SymbolMetadata?
+    
+    public func load(from: Foundation.URL, decryptor: @escaping (_: Foundation.Data) throws -> Foundation.Data) throws
+    public func load(from: Foundation.URL) throws
+}
+
+public struct SymbolCategory {
+    public struct Key: Swift.Hashable, Swift.RawRepresentable {
+        public let rawValue: Swift.String
+
+        static public var all: SFSymbols.SymbolCategory.Key { get }
+    }
+    public let key: SFSymbols.SymbolCategory.Key
+    public let iconName: Swift.String
+    public let localizedTitle: Swift.String
 }
 
 public struct SystemSymbolCSVRow: Swift.Equatable {
@@ -121,4 +134,56 @@ public enum RenderingMode: Swift.Hashable, Swift.Equatable, Swift.RawRepresentab
 public struct Crypton {
     static public func decryptObfuscatedFontTable(tableTag: Swift.UInt32, from: CoreText.CTFont) -> Foundation.Data?
     static public func encryptObfuscateFontTable(tableTag: Swift.UInt32, from: CoreText.CTFont) -> Foundation.Data?
+}
+
+public struct Alias {
+    public let name: Swift.String
+    public let availability: SFSymbols.Availability?
+}
+
+public struct SymbolMetadata {
+    public var accessLevel: SFSymbols.AccessLevel { get }
+    public var additionalCSVColumns: [Swift.String : Swift.String] { get }
+    public var aliases: [SFSymbols.Alias] { get }
+    public var csvRow: SFSymbols.SystemSymbolCSVRow? { get }
+    public var defaultRenderingMode: SFSymbols.RenderingMode? { get }
+    public var functions: [Swift.String] { get }
+    public var glyphOrder: Swift.Int? { get }
+    public var key: SFSymbols.SymbolKey { get }
+    public var localeSuffix: Swift.String? { get }
+    public var mirrorForRTL: Swift.Bool { get }
+    public var name: Swift.String { get }
+    public var privateScalar: Swift.Unicode.Scalar? { get }
+    public var publicScalars: [Swift.Unicode.Scalar] { get }
+    public var tags: Swift.Set<Swift.String> { get }
+    public var useRestrictionsDescription: Swift.String? { get }
+    public var useRestrictionsLocalizedDescription: Swift.String? { get }
+
+    public func availability(for: SFSymbols.SymbolFeature) -> SFSymbols.Availability?
+    public func string(for: SFSymbols.SymbolProperty) -> Swift.String?
+}
+
+public enum SymbolKey: Swift.Hashable, Swift.Equatable {
+    case systemPrivateScalar(Swift.Unicode.Scalar)
+    case customUUID(Foundation.UUID)
+}
+
+public struct SymbolFeature: Swift.RawRepresentable, Swift.Hashable, Swift.Equatable {
+    public let rawValue: Swift.String
+
+    static var hierarchical: SFSymbols.SymbolFeature { get }
+    static var monochrome: SFSymbols.SymbolFeature { get }
+    static var multicolor: SFSymbols.SymbolFeature { get }
+    static var name: SFSymbols.SymbolFeature { get }
+}
+
+public struct SymbolProperty: Swift.RawRepresentable, Swift.Hashable, Swift.Equatable {
+    public let rawValue: Swift.String
+}
+
+public struct CustomSymbol {
+    public let uuid: Foundation.UUID
+    public var name: Swift.String
+
+    public init(uuid: Foundation.UUID, name: Swift.String)
 }

--- a/SFSymbols/2024/SFSymbols.xcframework/ios-arm64-x86_64-simulator/SFSymbols.framework/Modules/SFSymbols.swiftmodule/x86_64-apple-ios-simulator.swiftinterface
+++ b/SFSymbols/2024/SFSymbols.xcframework/ios-arm64-x86_64-simulator/SFSymbols.framework/Modules/SFSymbols.swiftmodule/x86_64-apple-ios-simulator.swiftinterface
@@ -17,13 +17,67 @@ public var private_nofill_to_fill: [String : String] { get }
 public var private_symbol_order: [String] { get }
 public var private_name_aliases: [String : String] { get }
 
+public struct Availability {
+    public enum Platform: RawRepresentable {
+        case sfSymbols
+        case macOS
+        case macCatalyst
+        case iOS
+        case watchOS
+        case tvOS
+        case visionOS
+
+        public init?(rawValue: Swift.String)
+
+        public var rawValue: Swift.String {
+            get
+        }
+    }
+    let earliestYear: SFSymbols.Version
+    let platformLookup: [SFSymbols.Version : [SFSymbols.Availability.Platform : SFSymbols.Version]]
+
+    public func earliestSupportedRelease(for: SFSymbols.Availability.Platform) -> SFSymbols.Version?
+}
+
+public struct Version: Codable, Hashable, Equatable, Comparable {
+    public enum DecodingError: Error {
+        case invalidVersionString(Swift.String)
+    }
+    
+    public let major: Swift.Int
+    public let minor: Swift.Int
+    public let patch: Swift.Int
+
+    public init(from: Swift.Decoder) throws
+    public init(major: Swift.Int, minor: Swift.Int, patch: Swift.Int)
+    public init?(string: Swift.String)
+
+    public var hashValue: Swift.Int {
+        get
+    }
+    public var description: Swift.String {
+        get
+    }
+
+    public func hash(into: inout Swift.Hasher)
+    public func encode(to: Swift.Encoder) throws
+
+    static public var sfSymbolsHost: SFSymbols.Version {
+        get
+    }
+
+    static public func < (_: SFSymbols.Version, _: SFSymbols.Version) -> Swift.Bool
+    static public func == (_: SFSymbols.Version, _: SFSymbols.Version) -> Swift.Bool
+}
 
 public struct SymbolMetadataStore {
     static public var system: SymbolMetadataStore { get set }
 
     public var localizationOverrideBundle : Foundation.Bundle? { get set }
     public var localizationOverrideTableName : Swift.String? { get set }
+    
     public func modernSystemName(forAlias: Swift.String) -> Swift.String?
+    public func availability(forSystemName: Swift.String) -> SFSymbols.Availability?
 }
 
 public struct SystemSymbolCSVRow: Swift.Equatable {

--- a/SFSymbols/2024/SFSymbols.xcframework/ios-arm64-x86_64-simulator/SFSymbols.framework/Modules/SFSymbols.swiftmodule/x86_64-apple-ios-simulator.swiftinterface
+++ b/SFSymbols/2024/SFSymbols.xcframework/ios-arm64-x86_64-simulator/SFSymbols.framework/Modules/SFSymbols.swiftmodule/x86_64-apple-ios-simulator.swiftinterface
@@ -18,7 +18,7 @@ public var private_symbol_order: [String] { get }
 public var private_name_aliases: [String : String] { get }
 
 public struct Availability {
-    public enum Platform: RawRepresentable {
+    public enum Platform: Swift.RawRepresentable, Swift.Hashable, Swift.Equatable {
         case sfSymbols
         case macOS
         case macCatalyst
@@ -33,13 +33,11 @@ public struct Availability {
             get
         }
     }
-    let earliestYear: SFSymbols.Version
-    let platformLookup: [SFSymbols.Version : [SFSymbols.Availability.Platform : SFSymbols.Version]]
 
     public func earliestSupportedRelease(for: SFSymbols.Availability.Platform) -> SFSymbols.Version?
 }
 
-public struct Version: Codable, Hashable, Equatable, Comparable {
+public struct Version: Swift.Codable, Swift.Hashable, Swift.Equatable, Swift.Comparable, Swift.CustomStringConvertible {
     public enum DecodingError: Error {
         case invalidVersionString(Swift.String)
     }
@@ -52,19 +50,13 @@ public struct Version: Codable, Hashable, Equatable, Comparable {
     public init(major: Swift.Int, minor: Swift.Int, patch: Swift.Int)
     public init?(string: Swift.String)
 
-    public var hashValue: Swift.Int {
-        get
-    }
-    public var description: Swift.String {
-        get
-    }
+    public var hashValue: Swift.Int { get }
+    public var description: Swift.String { get }
 
     public func hash(into: inout Swift.Hasher)
     public func encode(to: Swift.Encoder) throws
 
-    static public var sfSymbolsHost: SFSymbols.Version {
-        get
-    }
+    static public var sfSymbolsHost: SFSymbols.Version { get }
 
     static public func < (_: SFSymbols.Version, _: SFSymbols.Version) -> Swift.Bool
     static public func == (_: SFSymbols.Version, _: SFSymbols.Version) -> Swift.Bool
@@ -72,12 +64,33 @@ public struct Version: Codable, Hashable, Equatable, Comparable {
 
 public struct SymbolMetadataStore {
     static public var system: SymbolMetadataStore { get set }
-
+    
+    public init()
+    
+    public var customSymbols: [SFSymbols.CustomSymbol]
+    
+    public var categories: [SFSymbols.SymbolCategory] { get }
     public var localizationOverrideBundle : Foundation.Bundle? { get set }
     public var localizationOverrideTableName : Swift.String? { get set }
     
     public func modernSystemName(forAlias: Swift.String) -> Swift.String?
     public func availability(forSystemName: Swift.String) -> SFSymbols.Availability?
+    public func symbolMetadata(forSystemName: Swift.String) -> SFSymbols.SymbolMetadata?
+    public func symbolMetadata(for: SFSymbols.SymbolKey) -> SFSymbols.SymbolMetadata?
+    
+    public func load(from: Foundation.URL, decryptor: @escaping (_: Foundation.Data) throws -> Foundation.Data) throws
+    public func load(from: Foundation.URL) throws
+}
+
+public struct SymbolCategory {
+    public struct Key: Swift.Hashable, Swift.RawRepresentable {
+        public let rawValue: Swift.String
+
+        static public var all: SFSymbols.SymbolCategory.Key { get }
+    }
+    public let key: SFSymbols.SymbolCategory.Key
+    public let iconName: Swift.String
+    public let localizedTitle: Swift.String
 }
 
 public struct SystemSymbolCSVRow: Swift.Equatable {
@@ -121,4 +134,56 @@ public enum RenderingMode: Swift.Hashable, Swift.Equatable, Swift.RawRepresentab
 public struct Crypton {
     static public func decryptObfuscatedFontTable(tableTag: Swift.UInt32, from: CoreText.CTFont) -> Foundation.Data?
     static public func encryptObfuscateFontTable(tableTag: Swift.UInt32, from: CoreText.CTFont) -> Foundation.Data?
+}
+
+public struct Alias {
+    public let name: Swift.String
+    public let availability: SFSymbols.Availability?
+}
+
+public struct SymbolMetadata {
+    public var accessLevel: SFSymbols.AccessLevel { get }
+    public var additionalCSVColumns: [Swift.String : Swift.String] { get }
+    public var aliases: [SFSymbols.Alias] { get }
+    public var csvRow: SFSymbols.SystemSymbolCSVRow? { get }
+    public var defaultRenderingMode: SFSymbols.RenderingMode? { get }
+    public var functions: [Swift.String] { get }
+    public var glyphOrder: Swift.Int? { get }
+    public var key: SFSymbols.SymbolKey { get }
+    public var localeSuffix: Swift.String? { get }
+    public var mirrorForRTL: Swift.Bool { get }
+    public var name: Swift.String { get }
+    public var privateScalar: Swift.Unicode.Scalar? { get }
+    public var publicScalars: [Swift.Unicode.Scalar] { get }
+    public var tags: Swift.Set<Swift.String> { get }
+    public var useRestrictionsDescription: Swift.String? { get }
+    public var useRestrictionsLocalizedDescription: Swift.String? { get }
+
+    public func availability(for: SFSymbols.SymbolFeature) -> SFSymbols.Availability?
+    public func string(for: SFSymbols.SymbolProperty) -> Swift.String?
+}
+
+public enum SymbolKey: Swift.Hashable, Swift.Equatable {
+    case systemPrivateScalar(Swift.Unicode.Scalar)
+    case customUUID(Foundation.UUID)
+}
+
+public struct SymbolFeature: Swift.RawRepresentable, Swift.Hashable, Swift.Equatable {
+    public let rawValue: Swift.String
+
+    static var hierarchical: SFSymbols.SymbolFeature { get }
+    static var monochrome: SFSymbols.SymbolFeature { get }
+    static var multicolor: SFSymbols.SymbolFeature { get }
+    static var name: SFSymbols.SymbolFeature { get }
+}
+
+public struct SymbolProperty: Swift.RawRepresentable, Swift.Hashable, Swift.Equatable {
+    public let rawValue: Swift.String
+}
+
+public struct CustomSymbol {
+    public let uuid: Foundation.UUID
+    public var name: Swift.String
+
+    public init(uuid: Foundation.UUID, name: Swift.String)
 }

--- a/SFSymbols/2024/SFSymbols.xcframework/macos-arm64e-arm64-x86_64/SFSymbols.framework/Versions/A/Modules/SFSymbols.swiftmodule/arm64-apple-macos.swiftinterface
+++ b/SFSymbols/2024/SFSymbols.xcframework/macos-arm64e-arm64-x86_64/SFSymbols.framework/Versions/A/Modules/SFSymbols.swiftmodule/arm64-apple-macos.swiftinterface
@@ -17,13 +17,67 @@ public var private_nofill_to_fill: [String : String] { get }
 public var private_symbol_order: [String] { get }
 public var private_name_aliases: [String : String] { get }
 
+public struct Availability {
+    public enum Platform: RawRepresentable {
+        case sfSymbols
+        case macOS
+        case macCatalyst
+        case iOS
+        case watchOS
+        case tvOS
+        case visionOS
+
+        public init?(rawValue: Swift.String)
+
+        public var rawValue: Swift.String {
+            get
+        }
+    }
+    let earliestYear: SFSymbols.Version
+    let platformLookup: [SFSymbols.Version : [SFSymbols.Availability.Platform : SFSymbols.Version]]
+
+    public func earliestSupportedRelease(for: SFSymbols.Availability.Platform) -> SFSymbols.Version?
+}
+
+public struct Version: Codable, Hashable, Equatable, Comparable {
+    public enum DecodingError: Error {
+        case invalidVersionString(Swift.String)
+    }
+    
+    public let major: Swift.Int
+    public let minor: Swift.Int
+    public let patch: Swift.Int
+
+    public init(from: Swift.Decoder) throws
+    public init(major: Swift.Int, minor: Swift.Int, patch: Swift.Int)
+    public init?(string: Swift.String)
+
+    public var hashValue: Swift.Int {
+        get
+    }
+    public var description: Swift.String {
+        get
+    }
+
+    public func hash(into: inout Swift.Hasher)
+    public func encode(to: Swift.Encoder) throws
+
+    static public var sfSymbolsHost: SFSymbols.Version {
+        get
+    }
+
+    static public func < (_: SFSymbols.Version, _: SFSymbols.Version) -> Swift.Bool
+    static public func == (_: SFSymbols.Version, _: SFSymbols.Version) -> Swift.Bool
+}
 
 public struct SymbolMetadataStore {
     static public var system: SymbolMetadataStore { get set }
 
     public var localizationOverrideBundle : Foundation.Bundle? { get set }
     public var localizationOverrideTableName : Swift.String? { get set }
+    
     public func modernSystemName(forAlias: Swift.String) -> Swift.String?
+    public func availability(forSystemName: Swift.String) -> SFSymbols.Availability?
 }
 
 public struct SystemSymbolCSVRow: Swift.Equatable {

--- a/SFSymbols/2024/SFSymbols.xcframework/macos-arm64e-arm64-x86_64/SFSymbols.framework/Versions/A/Modules/SFSymbols.swiftmodule/arm64-apple-macos.swiftinterface
+++ b/SFSymbols/2024/SFSymbols.xcframework/macos-arm64e-arm64-x86_64/SFSymbols.framework/Versions/A/Modules/SFSymbols.swiftmodule/arm64-apple-macos.swiftinterface
@@ -18,7 +18,7 @@ public var private_symbol_order: [String] { get }
 public var private_name_aliases: [String : String] { get }
 
 public struct Availability {
-    public enum Platform: RawRepresentable {
+    public enum Platform: Swift.RawRepresentable, Swift.Hashable, Swift.Equatable {
         case sfSymbols
         case macOS
         case macCatalyst
@@ -33,13 +33,11 @@ public struct Availability {
             get
         }
     }
-    let earliestYear: SFSymbols.Version
-    let platformLookup: [SFSymbols.Version : [SFSymbols.Availability.Platform : SFSymbols.Version]]
 
     public func earliestSupportedRelease(for: SFSymbols.Availability.Platform) -> SFSymbols.Version?
 }
 
-public struct Version: Codable, Hashable, Equatable, Comparable {
+public struct Version: Swift.Codable, Swift.Hashable, Swift.Equatable, Swift.Comparable, Swift.CustomStringConvertible {
     public enum DecodingError: Error {
         case invalidVersionString(Swift.String)
     }
@@ -52,19 +50,13 @@ public struct Version: Codable, Hashable, Equatable, Comparable {
     public init(major: Swift.Int, minor: Swift.Int, patch: Swift.Int)
     public init?(string: Swift.String)
 
-    public var hashValue: Swift.Int {
-        get
-    }
-    public var description: Swift.String {
-        get
-    }
+    public var hashValue: Swift.Int { get }
+    public var description: Swift.String { get }
 
     public func hash(into: inout Swift.Hasher)
     public func encode(to: Swift.Encoder) throws
 
-    static public var sfSymbolsHost: SFSymbols.Version {
-        get
-    }
+    static public var sfSymbolsHost: SFSymbols.Version { get }
 
     static public func < (_: SFSymbols.Version, _: SFSymbols.Version) -> Swift.Bool
     static public func == (_: SFSymbols.Version, _: SFSymbols.Version) -> Swift.Bool
@@ -72,12 +64,33 @@ public struct Version: Codable, Hashable, Equatable, Comparable {
 
 public struct SymbolMetadataStore {
     static public var system: SymbolMetadataStore { get set }
-
+    
+    public init()
+    
+    public var customSymbols: [SFSymbols.CustomSymbol]
+    
+    public var categories: [SFSymbols.SymbolCategory] { get }
     public var localizationOverrideBundle : Foundation.Bundle? { get set }
     public var localizationOverrideTableName : Swift.String? { get set }
     
     public func modernSystemName(forAlias: Swift.String) -> Swift.String?
     public func availability(forSystemName: Swift.String) -> SFSymbols.Availability?
+    public func symbolMetadata(forSystemName: Swift.String) -> SFSymbols.SymbolMetadata?
+    public func symbolMetadata(for: SFSymbols.SymbolKey) -> SFSymbols.SymbolMetadata?
+    
+    public func load(from: Foundation.URL, decryptor: @escaping (_: Foundation.Data) throws -> Foundation.Data) throws
+    public func load(from: Foundation.URL) throws
+}
+
+public struct SymbolCategory {
+    public struct Key: Swift.Hashable, Swift.RawRepresentable {
+        public let rawValue: Swift.String
+
+        static public var all: SFSymbols.SymbolCategory.Key { get }
+    }
+    public let key: SFSymbols.SymbolCategory.Key
+    public let iconName: Swift.String
+    public let localizedTitle: Swift.String
 }
 
 public struct SystemSymbolCSVRow: Swift.Equatable {
@@ -121,4 +134,56 @@ public enum RenderingMode: Swift.Hashable, Swift.Equatable, Swift.RawRepresentab
 public struct Crypton {
     static public func decryptObfuscatedFontTable(tableTag: Swift.UInt32, from: CoreText.CTFont) -> Foundation.Data?
     static public func encryptObfuscateFontTable(tableTag: Swift.UInt32, from: CoreText.CTFont) -> Foundation.Data?
+}
+
+public struct Alias {
+    public let name: Swift.String
+    public let availability: SFSymbols.Availability?
+}
+
+public struct SymbolMetadata {
+    public var accessLevel: SFSymbols.AccessLevel { get }
+    public var additionalCSVColumns: [Swift.String : Swift.String] { get }
+    public var aliases: [SFSymbols.Alias] { get }
+    public var csvRow: SFSymbols.SystemSymbolCSVRow? { get }
+    public var defaultRenderingMode: SFSymbols.RenderingMode? { get }
+    public var functions: [Swift.String] { get }
+    public var glyphOrder: Swift.Int? { get }
+    public var key: SFSymbols.SymbolKey { get }
+    public var localeSuffix: Swift.String? { get }
+    public var mirrorForRTL: Swift.Bool { get }
+    public var name: Swift.String { get }
+    public var privateScalar: Swift.Unicode.Scalar? { get }
+    public var publicScalars: [Swift.Unicode.Scalar] { get }
+    public var tags: Swift.Set<Swift.String> { get }
+    public var useRestrictionsDescription: Swift.String? { get }
+    public var useRestrictionsLocalizedDescription: Swift.String? { get }
+
+    public func availability(for: SFSymbols.SymbolFeature) -> SFSymbols.Availability?
+    public func string(for: SFSymbols.SymbolProperty) -> Swift.String?
+}
+
+public enum SymbolKey: Swift.Hashable, Swift.Equatable {
+    case systemPrivateScalar(Swift.Unicode.Scalar)
+    case customUUID(Foundation.UUID)
+}
+
+public struct SymbolFeature: Swift.RawRepresentable, Swift.Hashable, Swift.Equatable {
+    public let rawValue: Swift.String
+
+    static var hierarchical: SFSymbols.SymbolFeature { get }
+    static var monochrome: SFSymbols.SymbolFeature { get }
+    static var multicolor: SFSymbols.SymbolFeature { get }
+    static var name: SFSymbols.SymbolFeature { get }
+}
+
+public struct SymbolProperty: Swift.RawRepresentable, Swift.Hashable, Swift.Equatable {
+    public let rawValue: Swift.String
+}
+
+public struct CustomSymbol {
+    public let uuid: Foundation.UUID
+    public var name: Swift.String
+
+    public init(uuid: Foundation.UUID, name: Swift.String)
 }

--- a/SFSymbols/2024/SFSymbols.xcframework/macos-arm64e-arm64-x86_64/SFSymbols.framework/Versions/A/Modules/SFSymbols.swiftmodule/arm64e-apple-macos.swiftinterface
+++ b/SFSymbols/2024/SFSymbols.xcframework/macos-arm64e-arm64-x86_64/SFSymbols.framework/Versions/A/Modules/SFSymbols.swiftmodule/arm64e-apple-macos.swiftinterface
@@ -17,13 +17,67 @@ public var private_nofill_to_fill: [String : String] { get }
 public var private_symbol_order: [String] { get }
 public var private_name_aliases: [String : String] { get }
 
+public struct Availability {
+    public enum Platform: RawRepresentable {
+        case sfSymbols
+        case macOS
+        case macCatalyst
+        case iOS
+        case watchOS
+        case tvOS
+        case visionOS
+
+        public init?(rawValue: Swift.String)
+
+        public var rawValue: Swift.String {
+            get
+        }
+    }
+    let earliestYear: SFSymbols.Version
+    let platformLookup: [SFSymbols.Version : [SFSymbols.Availability.Platform : SFSymbols.Version]]
+
+    public func earliestSupportedRelease(for: SFSymbols.Availability.Platform) -> SFSymbols.Version?
+}
+
+public struct Version: Codable, Hashable, Equatable, Comparable {
+    public enum DecodingError: Error {
+        case invalidVersionString(Swift.String)
+    }
+    
+    public let major: Swift.Int
+    public let minor: Swift.Int
+    public let patch: Swift.Int
+
+    public init(from: Swift.Decoder) throws
+    public init(major: Swift.Int, minor: Swift.Int, patch: Swift.Int)
+    public init?(string: Swift.String)
+
+    public var hashValue: Swift.Int {
+        get
+    }
+    public var description: Swift.String {
+        get
+    }
+
+    public func hash(into: inout Swift.Hasher)
+    public func encode(to: Swift.Encoder) throws
+
+    static public var sfSymbolsHost: SFSymbols.Version {
+        get
+    }
+
+    static public func < (_: SFSymbols.Version, _: SFSymbols.Version) -> Swift.Bool
+    static public func == (_: SFSymbols.Version, _: SFSymbols.Version) -> Swift.Bool
+}
 
 public struct SymbolMetadataStore {
     static public var system: SymbolMetadataStore { get set }
 
     public var localizationOverrideBundle : Foundation.Bundle? { get set }
     public var localizationOverrideTableName : Swift.String? { get set }
+    
     public func modernSystemName(forAlias: Swift.String) -> Swift.String?
+    public func availability(forSystemName: Swift.String) -> SFSymbols.Availability?
 }
 
 public struct SystemSymbolCSVRow: Swift.Equatable {

--- a/SFSymbols/2024/SFSymbols.xcframework/macos-arm64e-arm64-x86_64/SFSymbols.framework/Versions/A/Modules/SFSymbols.swiftmodule/arm64e-apple-macos.swiftinterface
+++ b/SFSymbols/2024/SFSymbols.xcframework/macos-arm64e-arm64-x86_64/SFSymbols.framework/Versions/A/Modules/SFSymbols.swiftmodule/arm64e-apple-macos.swiftinterface
@@ -18,7 +18,7 @@ public var private_symbol_order: [String] { get }
 public var private_name_aliases: [String : String] { get }
 
 public struct Availability {
-    public enum Platform: RawRepresentable {
+    public enum Platform: Swift.RawRepresentable, Swift.Hashable, Swift.Equatable {
         case sfSymbols
         case macOS
         case macCatalyst
@@ -33,13 +33,11 @@ public struct Availability {
             get
         }
     }
-    let earliestYear: SFSymbols.Version
-    let platformLookup: [SFSymbols.Version : [SFSymbols.Availability.Platform : SFSymbols.Version]]
 
     public func earliestSupportedRelease(for: SFSymbols.Availability.Platform) -> SFSymbols.Version?
 }
 
-public struct Version: Codable, Hashable, Equatable, Comparable {
+public struct Version: Swift.Codable, Swift.Hashable, Swift.Equatable, Swift.Comparable, Swift.CustomStringConvertible {
     public enum DecodingError: Error {
         case invalidVersionString(Swift.String)
     }
@@ -52,19 +50,13 @@ public struct Version: Codable, Hashable, Equatable, Comparable {
     public init(major: Swift.Int, minor: Swift.Int, patch: Swift.Int)
     public init?(string: Swift.String)
 
-    public var hashValue: Swift.Int {
-        get
-    }
-    public var description: Swift.String {
-        get
-    }
+    public var hashValue: Swift.Int { get }
+    public var description: Swift.String { get }
 
     public func hash(into: inout Swift.Hasher)
     public func encode(to: Swift.Encoder) throws
 
-    static public var sfSymbolsHost: SFSymbols.Version {
-        get
-    }
+    static public var sfSymbolsHost: SFSymbols.Version { get }
 
     static public func < (_: SFSymbols.Version, _: SFSymbols.Version) -> Swift.Bool
     static public func == (_: SFSymbols.Version, _: SFSymbols.Version) -> Swift.Bool
@@ -72,12 +64,33 @@ public struct Version: Codable, Hashable, Equatable, Comparable {
 
 public struct SymbolMetadataStore {
     static public var system: SymbolMetadataStore { get set }
-
+    
+    public init()
+    
+    public var customSymbols: [SFSymbols.CustomSymbol]
+    
+    public var categories: [SFSymbols.SymbolCategory] { get }
     public var localizationOverrideBundle : Foundation.Bundle? { get set }
     public var localizationOverrideTableName : Swift.String? { get set }
     
     public func modernSystemName(forAlias: Swift.String) -> Swift.String?
     public func availability(forSystemName: Swift.String) -> SFSymbols.Availability?
+    public func symbolMetadata(forSystemName: Swift.String) -> SFSymbols.SymbolMetadata?
+    public func symbolMetadata(for: SFSymbols.SymbolKey) -> SFSymbols.SymbolMetadata?
+    
+    public func load(from: Foundation.URL, decryptor: @escaping (_: Foundation.Data) throws -> Foundation.Data) throws
+    public func load(from: Foundation.URL) throws
+}
+
+public struct SymbolCategory {
+    public struct Key: Swift.Hashable, Swift.RawRepresentable {
+        public let rawValue: Swift.String
+
+        static public var all: SFSymbols.SymbolCategory.Key { get }
+    }
+    public let key: SFSymbols.SymbolCategory.Key
+    public let iconName: Swift.String
+    public let localizedTitle: Swift.String
 }
 
 public struct SystemSymbolCSVRow: Swift.Equatable {
@@ -121,4 +134,56 @@ public enum RenderingMode: Swift.Hashable, Swift.Equatable, Swift.RawRepresentab
 public struct Crypton {
     static public func decryptObfuscatedFontTable(tableTag: Swift.UInt32, from: CoreText.CTFont) -> Foundation.Data?
     static public func encryptObfuscateFontTable(tableTag: Swift.UInt32, from: CoreText.CTFont) -> Foundation.Data?
+}
+
+public struct Alias {
+    public let name: Swift.String
+    public let availability: SFSymbols.Availability?
+}
+
+public struct SymbolMetadata {
+    public var accessLevel: SFSymbols.AccessLevel { get }
+    public var additionalCSVColumns: [Swift.String : Swift.String] { get }
+    public var aliases: [SFSymbols.Alias] { get }
+    public var csvRow: SFSymbols.SystemSymbolCSVRow? { get }
+    public var defaultRenderingMode: SFSymbols.RenderingMode? { get }
+    public var functions: [Swift.String] { get }
+    public var glyphOrder: Swift.Int? { get }
+    public var key: SFSymbols.SymbolKey { get }
+    public var localeSuffix: Swift.String? { get }
+    public var mirrorForRTL: Swift.Bool { get }
+    public var name: Swift.String { get }
+    public var privateScalar: Swift.Unicode.Scalar? { get }
+    public var publicScalars: [Swift.Unicode.Scalar] { get }
+    public var tags: Swift.Set<Swift.String> { get }
+    public var useRestrictionsDescription: Swift.String? { get }
+    public var useRestrictionsLocalizedDescription: Swift.String? { get }
+
+    public func availability(for: SFSymbols.SymbolFeature) -> SFSymbols.Availability?
+    public func string(for: SFSymbols.SymbolProperty) -> Swift.String?
+}
+
+public enum SymbolKey: Swift.Hashable, Swift.Equatable {
+    case systemPrivateScalar(Swift.Unicode.Scalar)
+    case customUUID(Foundation.UUID)
+}
+
+public struct SymbolFeature: Swift.RawRepresentable, Swift.Hashable, Swift.Equatable {
+    public let rawValue: Swift.String
+
+    static var hierarchical: SFSymbols.SymbolFeature { get }
+    static var monochrome: SFSymbols.SymbolFeature { get }
+    static var multicolor: SFSymbols.SymbolFeature { get }
+    static var name: SFSymbols.SymbolFeature { get }
+}
+
+public struct SymbolProperty: Swift.RawRepresentable, Swift.Hashable, Swift.Equatable {
+    public let rawValue: Swift.String
+}
+
+public struct CustomSymbol {
+    public let uuid: Foundation.UUID
+    public var name: Swift.String
+
+    public init(uuid: Foundation.UUID, name: Swift.String)
 }

--- a/SFSymbols/2024/SFSymbols.xcframework/macos-arm64e-arm64-x86_64/SFSymbols.framework/Versions/A/Modules/SFSymbols.swiftmodule/x86_64-apple-macos.swiftinterface
+++ b/SFSymbols/2024/SFSymbols.xcframework/macos-arm64e-arm64-x86_64/SFSymbols.framework/Versions/A/Modules/SFSymbols.swiftmodule/x86_64-apple-macos.swiftinterface
@@ -17,13 +17,67 @@ public var private_nofill_to_fill: [String : String] { get }
 public var private_symbol_order: [String] { get }
 public var private_name_aliases: [String : String] { get }
 
+public struct Availability {
+    public enum Platform: RawRepresentable {
+        case sfSymbols
+        case macOS
+        case macCatalyst
+        case iOS
+        case watchOS
+        case tvOS
+        case visionOS
+
+        public init?(rawValue: Swift.String)
+
+        public var rawValue: Swift.String {
+            get
+        }
+    }
+    let earliestYear: SFSymbols.Version
+    let platformLookup: [SFSymbols.Version : [SFSymbols.Availability.Platform : SFSymbols.Version]]
+
+    public func earliestSupportedRelease(for: SFSymbols.Availability.Platform) -> SFSymbols.Version?
+}
+
+public struct Version: Codable, Hashable, Equatable, Comparable {
+    public enum DecodingError: Error {
+        case invalidVersionString(Swift.String)
+    }
+    
+    public let major: Swift.Int
+    public let minor: Swift.Int
+    public let patch: Swift.Int
+
+    public init(from: Swift.Decoder) throws
+    public init(major: Swift.Int, minor: Swift.Int, patch: Swift.Int)
+    public init?(string: Swift.String)
+
+    public var hashValue: Swift.Int {
+        get
+    }
+    public var description: Swift.String {
+        get
+    }
+
+    public func hash(into: inout Swift.Hasher)
+    public func encode(to: Swift.Encoder) throws
+
+    static public var sfSymbolsHost: SFSymbols.Version {
+        get
+    }
+
+    static public func < (_: SFSymbols.Version, _: SFSymbols.Version) -> Swift.Bool
+    static public func == (_: SFSymbols.Version, _: SFSymbols.Version) -> Swift.Bool
+}
 
 public struct SymbolMetadataStore {
     static public var system: SymbolMetadataStore { get set }
 
     public var localizationOverrideBundle : Foundation.Bundle? { get set }
     public var localizationOverrideTableName : Swift.String? { get set }
+    
     public func modernSystemName(forAlias: Swift.String) -> Swift.String?
+    public func availability(forSystemName: Swift.String) -> SFSymbols.Availability?
 }
 
 public struct SystemSymbolCSVRow: Swift.Equatable {

--- a/SFSymbols/2024/SFSymbols.xcframework/macos-arm64e-arm64-x86_64/SFSymbols.framework/Versions/A/Modules/SFSymbols.swiftmodule/x86_64-apple-macos.swiftinterface
+++ b/SFSymbols/2024/SFSymbols.xcframework/macos-arm64e-arm64-x86_64/SFSymbols.framework/Versions/A/Modules/SFSymbols.swiftmodule/x86_64-apple-macos.swiftinterface
@@ -18,7 +18,7 @@ public var private_symbol_order: [String] { get }
 public var private_name_aliases: [String : String] { get }
 
 public struct Availability {
-    public enum Platform: RawRepresentable {
+    public enum Platform: Swift.RawRepresentable, Swift.Hashable, Swift.Equatable {
         case sfSymbols
         case macOS
         case macCatalyst
@@ -33,13 +33,11 @@ public struct Availability {
             get
         }
     }
-    let earliestYear: SFSymbols.Version
-    let platformLookup: [SFSymbols.Version : [SFSymbols.Availability.Platform : SFSymbols.Version]]
 
     public func earliestSupportedRelease(for: SFSymbols.Availability.Platform) -> SFSymbols.Version?
 }
 
-public struct Version: Codable, Hashable, Equatable, Comparable {
+public struct Version: Swift.Codable, Swift.Hashable, Swift.Equatable, Swift.Comparable, Swift.CustomStringConvertible {
     public enum DecodingError: Error {
         case invalidVersionString(Swift.String)
     }
@@ -52,19 +50,13 @@ public struct Version: Codable, Hashable, Equatable, Comparable {
     public init(major: Swift.Int, minor: Swift.Int, patch: Swift.Int)
     public init?(string: Swift.String)
 
-    public var hashValue: Swift.Int {
-        get
-    }
-    public var description: Swift.String {
-        get
-    }
+    public var hashValue: Swift.Int { get }
+    public var description: Swift.String { get }
 
     public func hash(into: inout Swift.Hasher)
     public func encode(to: Swift.Encoder) throws
 
-    static public var sfSymbolsHost: SFSymbols.Version {
-        get
-    }
+    static public var sfSymbolsHost: SFSymbols.Version { get }
 
     static public func < (_: SFSymbols.Version, _: SFSymbols.Version) -> Swift.Bool
     static public func == (_: SFSymbols.Version, _: SFSymbols.Version) -> Swift.Bool
@@ -72,12 +64,33 @@ public struct Version: Codable, Hashable, Equatable, Comparable {
 
 public struct SymbolMetadataStore {
     static public var system: SymbolMetadataStore { get set }
-
+    
+    public init()
+    
+    public var customSymbols: [SFSymbols.CustomSymbol]
+    
+    public var categories: [SFSymbols.SymbolCategory] { get }
     public var localizationOverrideBundle : Foundation.Bundle? { get set }
     public var localizationOverrideTableName : Swift.String? { get set }
     
     public func modernSystemName(forAlias: Swift.String) -> Swift.String?
     public func availability(forSystemName: Swift.String) -> SFSymbols.Availability?
+    public func symbolMetadata(forSystemName: Swift.String) -> SFSymbols.SymbolMetadata?
+    public func symbolMetadata(for: SFSymbols.SymbolKey) -> SFSymbols.SymbolMetadata?
+    
+    public func load(from: Foundation.URL, decryptor: @escaping (_: Foundation.Data) throws -> Foundation.Data) throws
+    public func load(from: Foundation.URL) throws
+}
+
+public struct SymbolCategory {
+    public struct Key: Swift.Hashable, Swift.RawRepresentable {
+        public let rawValue: Swift.String
+
+        static public var all: SFSymbols.SymbolCategory.Key { get }
+    }
+    public let key: SFSymbols.SymbolCategory.Key
+    public let iconName: Swift.String
+    public let localizedTitle: Swift.String
 }
 
 public struct SystemSymbolCSVRow: Swift.Equatable {
@@ -121,4 +134,56 @@ public enum RenderingMode: Swift.Hashable, Swift.Equatable, Swift.RawRepresentab
 public struct Crypton {
     static public func decryptObfuscatedFontTable(tableTag: Swift.UInt32, from: CoreText.CTFont) -> Foundation.Data?
     static public func encryptObfuscateFontTable(tableTag: Swift.UInt32, from: CoreText.CTFont) -> Foundation.Data?
+}
+
+public struct Alias {
+    public let name: Swift.String
+    public let availability: SFSymbols.Availability?
+}
+
+public struct SymbolMetadata {
+    public var accessLevel: SFSymbols.AccessLevel { get }
+    public var additionalCSVColumns: [Swift.String : Swift.String] { get }
+    public var aliases: [SFSymbols.Alias] { get }
+    public var csvRow: SFSymbols.SystemSymbolCSVRow? { get }
+    public var defaultRenderingMode: SFSymbols.RenderingMode? { get }
+    public var functions: [Swift.String] { get }
+    public var glyphOrder: Swift.Int? { get }
+    public var key: SFSymbols.SymbolKey { get }
+    public var localeSuffix: Swift.String? { get }
+    public var mirrorForRTL: Swift.Bool { get }
+    public var name: Swift.String { get }
+    public var privateScalar: Swift.Unicode.Scalar? { get }
+    public var publicScalars: [Swift.Unicode.Scalar] { get }
+    public var tags: Swift.Set<Swift.String> { get }
+    public var useRestrictionsDescription: Swift.String? { get }
+    public var useRestrictionsLocalizedDescription: Swift.String? { get }
+
+    public func availability(for: SFSymbols.SymbolFeature) -> SFSymbols.Availability?
+    public func string(for: SFSymbols.SymbolProperty) -> Swift.String?
+}
+
+public enum SymbolKey: Swift.Hashable, Swift.Equatable {
+    case systemPrivateScalar(Swift.Unicode.Scalar)
+    case customUUID(Foundation.UUID)
+}
+
+public struct SymbolFeature: Swift.RawRepresentable, Swift.Hashable, Swift.Equatable {
+    public let rawValue: Swift.String
+
+    static var hierarchical: SFSymbols.SymbolFeature { get }
+    static var monochrome: SFSymbols.SymbolFeature { get }
+    static var multicolor: SFSymbols.SymbolFeature { get }
+    static var name: SFSymbols.SymbolFeature { get }
+}
+
+public struct SymbolProperty: Swift.RawRepresentable, Swift.Hashable, Swift.Equatable {
+    public let rawValue: Swift.String
+}
+
+public struct CustomSymbol {
+    public let uuid: Foundation.UUID
+    public var name: Swift.String
+
+    public init(uuid: Foundation.UUID, name: Swift.String)
 }

--- a/SFSymbols/2024/Sources/Modules/SFSymbols.swiftmodule/template.swiftinterface
+++ b/SFSymbols/2024/Sources/Modules/SFSymbols.swiftmodule/template.swiftinterface
@@ -13,13 +13,67 @@ public var private_nofill_to_fill: [String : String] { get }
 public var private_symbol_order: [String] { get }
 public var private_name_aliases: [String : String] { get }
 
+public struct Availability {
+    public enum Platform: RawRepresentable {
+        case sfSymbols
+        case macOS
+        case macCatalyst
+        case iOS
+        case watchOS
+        case tvOS
+        case visionOS
+
+        public init?(rawValue: Swift.String)
+
+        public var rawValue: Swift.String {
+            get
+        }
+    }
+    let earliestYear: SFSymbols.Version
+    let platformLookup: [SFSymbols.Version : [SFSymbols.Availability.Platform : SFSymbols.Version]]
+
+    public func earliestSupportedRelease(for: SFSymbols.Availability.Platform) -> SFSymbols.Version?
+}
+
+public struct Version: Codable, Hashable, Equatable, Comparable {
+    public enum DecodingError: Error {
+        case invalidVersionString(Swift.String)
+    }
+    
+    public let major: Swift.Int
+    public let minor: Swift.Int
+    public let patch: Swift.Int
+
+    public init(from: Swift.Decoder) throws
+    public init(major: Swift.Int, minor: Swift.Int, patch: Swift.Int)
+    public init?(string: Swift.String)
+
+    public var hashValue: Swift.Int {
+        get
+    }
+    public var description: Swift.String {
+        get
+    }
+
+    public func hash(into: inout Swift.Hasher)
+    public func encode(to: Swift.Encoder) throws
+
+    static public var sfSymbolsHost: SFSymbols.Version {
+        get
+    }
+
+    static public func < (_: SFSymbols.Version, _: SFSymbols.Version) -> Swift.Bool
+    static public func == (_: SFSymbols.Version, _: SFSymbols.Version) -> Swift.Bool
+}
 
 public struct SymbolMetadataStore {
     static public var system: SymbolMetadataStore { get set }
 
     public var localizationOverrideBundle : Foundation.Bundle? { get set }
     public var localizationOverrideTableName : Swift.String? { get set }
+    
     public func modernSystemName(forAlias: Swift.String) -> Swift.String?
+    public func availability(forSystemName: Swift.String) -> SFSymbols.Availability?
 }
 
 public struct SystemSymbolCSVRow: Swift.Equatable {

--- a/SFSymbols/2024/Sources/Modules/SFSymbols.swiftmodule/template.swiftinterface
+++ b/SFSymbols/2024/Sources/Modules/SFSymbols.swiftmodule/template.swiftinterface
@@ -14,7 +14,7 @@ public var private_symbol_order: [String] { get }
 public var private_name_aliases: [String : String] { get }
 
 public struct Availability {
-    public enum Platform: RawRepresentable {
+    public enum Platform: Swift.RawRepresentable, Swift.Hashable, Swift.Equatable {
         case sfSymbols
         case macOS
         case macCatalyst
@@ -29,13 +29,11 @@ public struct Availability {
             get
         }
     }
-    let earliestYear: SFSymbols.Version
-    let platformLookup: [SFSymbols.Version : [SFSymbols.Availability.Platform : SFSymbols.Version]]
 
     public func earliestSupportedRelease(for: SFSymbols.Availability.Platform) -> SFSymbols.Version?
 }
 
-public struct Version: Codable, Hashable, Equatable, Comparable {
+public struct Version: Swift.Codable, Swift.Hashable, Swift.Equatable, Swift.Comparable, Swift.CustomStringConvertible {
     public enum DecodingError: Error {
         case invalidVersionString(Swift.String)
     }
@@ -48,19 +46,13 @@ public struct Version: Codable, Hashable, Equatable, Comparable {
     public init(major: Swift.Int, minor: Swift.Int, patch: Swift.Int)
     public init?(string: Swift.String)
 
-    public var hashValue: Swift.Int {
-        get
-    }
-    public var description: Swift.String {
-        get
-    }
+    public var hashValue: Swift.Int { get }
+    public var description: Swift.String { get }
 
     public func hash(into: inout Swift.Hasher)
     public func encode(to: Swift.Encoder) throws
 
-    static public var sfSymbolsHost: SFSymbols.Version {
-        get
-    }
+    static public var sfSymbolsHost: SFSymbols.Version { get }
 
     static public func < (_: SFSymbols.Version, _: SFSymbols.Version) -> Swift.Bool
     static public func == (_: SFSymbols.Version, _: SFSymbols.Version) -> Swift.Bool
@@ -68,12 +60,33 @@ public struct Version: Codable, Hashable, Equatable, Comparable {
 
 public struct SymbolMetadataStore {
     static public var system: SymbolMetadataStore { get set }
-
+    
+    public init()
+    
+    public var customSymbols: [SFSymbols.CustomSymbol]
+    
+    public var categories: [SFSymbols.SymbolCategory] { get }
     public var localizationOverrideBundle : Foundation.Bundle? { get set }
     public var localizationOverrideTableName : Swift.String? { get set }
     
     public func modernSystemName(forAlias: Swift.String) -> Swift.String?
     public func availability(forSystemName: Swift.String) -> SFSymbols.Availability?
+    public func symbolMetadata(forSystemName: Swift.String) -> SFSymbols.SymbolMetadata?
+    public func symbolMetadata(for: SFSymbols.SymbolKey) -> SFSymbols.SymbolMetadata?
+    
+    public func load(from: Foundation.URL, decryptor: @escaping (_: Foundation.Data) throws -> Foundation.Data) throws
+    public func load(from: Foundation.URL) throws
+}
+
+public struct SymbolCategory {
+    public struct Key: Swift.Hashable, Swift.RawRepresentable {
+        public let rawValue: Swift.String
+
+        static public var all: SFSymbols.SymbolCategory.Key { get }
+    }
+    public let key: SFSymbols.SymbolCategory.Key
+    public let iconName: Swift.String
+    public let localizedTitle: Swift.String
 }
 
 public struct SystemSymbolCSVRow: Swift.Equatable {
@@ -117,4 +130,56 @@ public enum RenderingMode: Swift.Hashable, Swift.Equatable, Swift.RawRepresentab
 public struct Crypton {
     static public func decryptObfuscatedFontTable(tableTag: Swift.UInt32, from: CoreText.CTFont) -> Foundation.Data?
     static public func encryptObfuscateFontTable(tableTag: Swift.UInt32, from: CoreText.CTFont) -> Foundation.Data?
+}
+
+public struct Alias {
+    public let name: Swift.String
+    public let availability: SFSymbols.Availability?
+}
+
+public struct SymbolMetadata {
+    public var accessLevel: SFSymbols.AccessLevel { get }
+    public var additionalCSVColumns: [Swift.String : Swift.String] { get }
+    public var aliases: [SFSymbols.Alias] { get }
+    public var csvRow: SFSymbols.SystemSymbolCSVRow? { get }
+    public var defaultRenderingMode: SFSymbols.RenderingMode? { get }
+    public var functions: [Swift.String] { get }
+    public var glyphOrder: Swift.Int? { get }
+    public var key: SFSymbols.SymbolKey { get }
+    public var localeSuffix: Swift.String? { get }
+    public var mirrorForRTL: Swift.Bool { get }
+    public var name: Swift.String { get }
+    public var privateScalar: Swift.Unicode.Scalar? { get }
+    public var publicScalars: [Swift.Unicode.Scalar] { get }
+    public var tags: Swift.Set<Swift.String> { get }
+    public var useRestrictionsDescription: Swift.String? { get }
+    public var useRestrictionsLocalizedDescription: Swift.String? { get }
+
+    public func availability(for: SFSymbols.SymbolFeature) -> SFSymbols.Availability?
+    public func string(for: SFSymbols.SymbolProperty) -> Swift.String?
+}
+
+public enum SymbolKey: Swift.Hashable, Swift.Equatable {
+    case systemPrivateScalar(Swift.Unicode.Scalar)
+    case customUUID(Foundation.UUID)
+}
+
+public struct SymbolFeature: Swift.RawRepresentable, Swift.Hashable, Swift.Equatable {
+    public let rawValue: Swift.String
+
+    static var hierarchical: SFSymbols.SymbolFeature { get }
+    static var monochrome: SFSymbols.SymbolFeature { get }
+    static var multicolor: SFSymbols.SymbolFeature { get }
+    static var name: SFSymbols.SymbolFeature { get }
+}
+
+public struct SymbolProperty: Swift.RawRepresentable, Swift.Hashable, Swift.Equatable {
+    public let rawValue: Swift.String
+}
+
+public struct CustomSymbol {
+    public let uuid: Foundation.UUID
+    public var name: Swift.String
+
+    public init(uuid: Foundation.UUID, name: Swift.String)
 }


### PR DESCRIPTION
### What's included

- SFSymbol availability
- SFSymbol metadata
- Refactored SFSymbols example app

### Screenshots

<img width="49%" src="https://github.com/user-attachments/assets/df84f3c7-d85f-4062-9e7a-9abe5a8a0885" />
<img width="49%" src="https://github.com/user-attachments/assets/1442e23a-261a-4de6-b8e7-23f92981a445" />

### Check list

- [x] Example project compiled
- [x] `.swiftinterface` updated