### PR TITLE
Update to Swift 6.3.3 and Xcode 26.6

### DIFF
--- a/.github/actions/build-example/action.yml
+++ b/.github/actions/build-example/action.yml
@@ -11,7 +11,7 @@ inputs:
   xcode-version:
     description: Xcode version to use
     required: false
-    default: "26.3"
+    default: "26.6"
 
 runs:
   using: composite

--- a/.github/actions/build-example/action.yml
+++ b/.github/actions/build-example/action.yml
@@ -32,7 +32,12 @@ runs:
         tuist generate --no-open
     - name: Install xcbeautify
       shell: bash
-      run: brew install xcbeautify
+      run: |
+        if command -v xcbeautify >/dev/null 2>&1; then
+          echo "xcbeautify is already installed"
+        else
+          brew install xcbeautify
+        fi
     - name: Build
       shell: bash
       run: |

--- a/.github/workflows/ag_example.yml
+++ b/.github/workflows/ag_example.yml
@@ -48,4 +48,4 @@ jobs:
         with:
           scheme: AGExample
           destination: ${{ matrix.destination }}
-          xcode-version: "26.3"
+          xcode-version: "26.6"

--- a/.github/workflows/ag_example.yml
+++ b/.github/workflows/ag_example.yml
@@ -41,7 +41,9 @@ jobs:
             destination: "generic/platform=iOS Simulator"
           - platform: macOS
             destination: "platform=macOS"
-    runs-on: macos-15
+    runs-on:
+      - macos-15
+      - xcode-26.6
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/build-example

--- a/.github/workflows/bls_example.yml
+++ b/.github/workflows/bls_example.yml
@@ -39,7 +39,9 @@ jobs:
             destination: "generic/platform=iOS"
           - platform: iOS Simulator
             destination: "generic/platform=iOS Simulator"
-    runs-on: macos-15
+    runs-on:
+      - macos-15
+      - xcode-26.6
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/build-example

--- a/.github/workflows/bls_example.yml
+++ b/.github/workflows/bls_example.yml
@@ -46,4 +46,4 @@ jobs:
         with:
           scheme: BLSExample
           destination: ${{ matrix.destination }}
-          xcode-version: "26.3"
+          xcode-version: "26.6"

--- a/.github/workflows/coresvg_example.yml
+++ b/.github/workflows/coresvg_example.yml
@@ -48,4 +48,4 @@ jobs:
         with:
           scheme: CoreSVGExample
           destination: ${{ matrix.destination }}
-          xcode-version: "26.3"
+          xcode-version: "26.6"

--- a/.github/workflows/coresvg_example.yml
+++ b/.github/workflows/coresvg_example.yml
@@ -41,7 +41,9 @@ jobs:
             destination: "generic/platform=iOS Simulator"
           - platform: macOS
             destination: "platform=macOS"
-    runs-on: macos-15
+    runs-on:
+      - macos-15
+      - xcode-26.6
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/build-example

--- a/.github/workflows/coreui_example.yml
+++ b/.github/workflows/coreui_example.yml
@@ -41,7 +41,9 @@ jobs:
             destination: "generic/platform=iOS Simulator"
           - platform: macOS
             destination: "platform=macOS"
-    runs-on: macos-15
+    runs-on:
+      - macos-15
+      - xcode-26.6
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/build-example

--- a/.github/workflows/coreui_example.yml
+++ b/.github/workflows/coreui_example.yml
@@ -48,4 +48,4 @@ jobs:
         with:
           scheme: CoreUIExample
           destination: ${{ matrix.destination }}
-          xcode-version: "26.3"
+          xcode-version: "26.6"

--- a/.github/workflows/gf_example.yml
+++ b/.github/workflows/gf_example.yml
@@ -48,4 +48,4 @@ jobs:
         with:
           scheme: GFExample
           destination: ${{ matrix.destination }}
-          xcode-version: "26.3"
+          xcode-version: "26.6"

--- a/.github/workflows/rb_example.yml
+++ b/.github/workflows/rb_example.yml
@@ -41,7 +41,9 @@ jobs:
             destination: "generic/platform=iOS Simulator"
           - platform: macOS
             destination: "platform=macOS"
-    runs-on: macos-15
+    runs-on:
+      - macos-15
+      - xcode-26.6
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/build-example

--- a/.github/workflows/rb_example.yml
+++ b/.github/workflows/rb_example.yml
@@ -48,4 +48,4 @@ jobs:
         with:
           scheme: RBExample
           destination: ${{ matrix.destination }}
-          xcode-version: "26.3"
+          xcode-version: "26.6"

--- a/.github/workflows/sfsymbols_example.yml
+++ b/.github/workflows/sfsymbols_example.yml
@@ -48,4 +48,4 @@ jobs:
         with:
           scheme: SFSymbolsExample
           destination: ${{ matrix.destination }}
-          xcode-version: "26.3"
+          xcode-version: "26.6"

--- a/.github/workflows/sfsymbols_example.yml
+++ b/.github/workflows/sfsymbols_example.yml
@@ -41,7 +41,9 @@ jobs:
             destination: "generic/platform=iOS Simulator"
           - platform: macOS
             destination: "platform=macOS"
-    runs-on: macos-15
+    runs-on:
+      - macos-15
+      - xcode-26.6
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/build-example

--- a/AG/2021/AttributeGraph.xcframework/ios-arm64-x86_64-simulator/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/arm64-apple-ios-simulator.swiftinterface
+++ b/AG/2021/AttributeGraph.xcframework/ios-arm64-x86_64-simulator/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/arm64-apple-ios-simulator.swiftinterface
@@ -1,7 +1,7 @@
 // swift-interface-format-version: 1.0
-// swift-compiler-version: Apple Swift version 6.2 effective-5.10 (swiftlang-6.2.0.16.112 clang-1800.1.29)
+// swift-compiler-version: Apple Swift version 6.3.3 effective-5.10 (swiftlang-6.3.3.1.3 clang-2100.1.1.101)
 // swift-module-flags: -target arm64-apple-ios15.0-simulator -enable-objc-interop -enable-library-evolution -swift-version 5 -Osize -enable-upcoming-feature InternalImportsByDefault -enable-experimental-feature Extern -module-name AttributeGraph
-// swift-module-flags-ignorable: -interface-compiler-version 6.2
+// swift-module-flags-ignorable: -interface-compiler-version 6.3.3
 @_exported public import AttributeGraph
 public import Swift
 public import _Concurrency
@@ -38,10 +38,8 @@ extension AttributeGraph.Graph {
   }
 }
 extension AttributeGraph.Graph {
-  #if compiler(>=5.3) && $NonescapableTypes
   @_silgen_name("AGGraphGetOutputValue")
   @inline(__always) @inlinable public static func outputValue<Value>() -> Swift.UnsafePointer<Value>?
-  #endif
   @_silgen_name("AGGraphSetOutputValue")
   @inline(__always) @inlinable public static func setOutputValue<Value>(_ value: Swift.UnsafePointer<Value>)
 }
@@ -51,9 +49,7 @@ extension AttributeGraph.Graph {
     }
 }
 extension AttributeGraph.Graph {
-  #if compiler(>=5.3) && $NonescapableTypes
   public func archiveJSON(name: Swift.String?)
-  #endif
 }
 extension AttributeGraph.Subgraph {
   public typealias Flags = AttributeGraph.AnyAttribute.Flags
@@ -211,16 +207,12 @@ public func withUnsafeMutablePointerToEnumCase<T>(of value: Swift.UnsafeMutableP
   public subscript<V>(attribute: AttributeGraph.Attribute<V>) -> V {
     unsafeAddress
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(weakAttribute: AttributeGraph.WeakAttribute<V>) -> V? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(optionalAttribute: AttributeGraph.OptionalAttribute<V>) -> V? {
     get
   }
-  #endif
   public func valueAndFlags<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, flags: AttributeGraph.AGChangedValueFlags)
   public func changedValue<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, changed: Swift.Bool)
   public func update(body: () -> Swift.Void)
@@ -233,16 +225,12 @@ public func withUnsafeMutablePointerToEnumCase<T>(of value: Swift.UnsafeMutableP
   public subscript<V>(attribute: AttributeGraph.Attribute<V>) -> V {
     unsafeAddress
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(weakAttribute: AttributeGraph.WeakAttribute<V>) -> V? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(optionalAttribute: AttributeGraph.OptionalAttribute<V>) -> V? {
     get
   }
-  #endif
   public var value: Value {
     unsafeAddress
     nonmutating set
@@ -264,40 +252,26 @@ public func withUnsafeMutablePointerToEnumCase<T>(of value: Swift.UnsafeMutableP
   public init(base: AttributeGraph.AnyWeakAttribute)
   public init()
   public init(_ attribute: AttributeGraph.Attribute<Value>)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.Attribute<Value>?)
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var wrappedValue: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var projectedValue: AttributeGraph.Attribute<Value>? {
     get
     set
     _modify
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.Attribute<Value>? {
     get
     set
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var value: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
-  #endif
 }
 extension AttributeGraph.WeakAttribute : Swift.Hashable {
   public static func == (a: AttributeGraph.WeakAttribute<Value>, b: AttributeGraph.WeakAttribute<Value>) -> Swift.Bool
@@ -312,17 +286,13 @@ extension AttributeGraph.WeakAttribute : Swift.CustomStringConvertible {
   }
 }
 extension AttributeGraph.AnyWeakAttribute {
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.AnyAttribute?)
-  #endif
   public init<Value>(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.WeakAttribute<Value>
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.AnyAttribute? {
     get
     set
   }
-  #endif
 }
 extension AttributeGraph.AnyWeakAttribute : Swift.Hashable {
   public static func == (lhs: AttributeGraph.AnyWeakAttribute, rhs: AttributeGraph.AnyWeakAttribute) -> Swift.Bool
@@ -399,17 +369,13 @@ public protocol AttributeBodyVisitor {
 }
 public protocol StatefulRule : AttributeGraph._AttributeBody {
   associatedtype Value
-  #if compiler(>=5.3) && $NonescapableTypes
   static var initialValue: Self.Value? { get }
-  #endif
   mutating func updateValue()
 }
 extension AttributeGraph.StatefulRule {
-  #if compiler(>=5.3) && $NonescapableTypes
   public static var initialValue: Self.Value? {
     get
   }
-  #endif
   public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AttributeGraph.AnyAttribute)
   public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
 }
@@ -430,17 +396,13 @@ extension AttributeGraph.StatefulRule {
 }
 public protocol Rule : AttributeGraph._AttributeBody {
   associatedtype Value
-  #if compiler(>=5.3) && $NonescapableTypes
   static var initialValue: Self.Value? { get }
-  #endif
   var value: Self.Value { get }
 }
 extension AttributeGraph.Rule {
-  #if compiler(>=5.3) && $NonescapableTypes
   public static var initialValue: Self.Value? {
     get
   }
-  #endif
   public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AttributeGraph.AnyAttribute)
   public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
 }
@@ -453,15 +415,9 @@ extension AttributeGraph.Rule {
   }
 }
 extension AttributeGraph.Rule where Self : Swift.Hashable {
-  #if compiler(>=5.3) && $NonescapableTypes
   public func cachedValue(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?) -> Self.Value
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func cachedValueIfExists(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?) -> Self.Value?
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public static func _cachedValue(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?, hashValue: Swift.Int, bodyPtr: Swift.UnsafeRawPointer, update: () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void) -> Swift.UnsafePointer<Self.Value>
-  #endif
 }
 @frozen @propertyWrapper @dynamicMemberLookup public struct Attribute<Value> {
   public var identifier: AttributeGraph.AnyAttribute
@@ -469,9 +425,7 @@ extension AttributeGraph.Rule where Self : Swift.Hashable {
   public init(_ attribute: AttributeGraph.Attribute<Value>)
   public init(value: Value)
   public init(type _: Value.Type)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init<Body>(body: Swift.UnsafePointer<Body>, value: Swift.UnsafePointer<Value>?, flags: AttributeGraph._AttributeType.Flags = [], update: () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void) where Body : AttributeGraph._AttributeBody
-  #endif
   public var wrappedValue: Value {
     unsafeAddress
     nonmutating set
@@ -543,10 +497,8 @@ extension AttributeGraph.Attribute {
   public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.Rule
   public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.StatefulRule
 }
-#if compiler(>=5.3) && $NonescapableTypes
 @_silgen_name("AGGraphCreateAttribute")
 @inline(__always) @inlinable internal func AGGraphCreateAttribute(index: Swift.Int, body: Swift.UnsafeRawPointer, value: Swift.UnsafeRawPointer?) -> AttributeGraph.AnyAttribute
-#endif
 @_silgen_name("AGGraphGetValue")
 @inline(__always) @inlinable internal func AGGraphGetValue<Value>(_ attribute: AttributeGraph.AnyAttribute, options: AttributeGraph.AGValueOptions = [], type: Value.Type = Value.self) -> AttributeGraph.AGValue
 @_silgen_name("AGGraphSetValue")
@@ -599,11 +551,9 @@ extension Swift.UnsafeMutablePointer {
 extension AttributeGraph.AnyAttribute {
   public init<Value>(_ attribute: AttributeGraph.Attribute<Value>)
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.Attribute<Value>
-  #if compiler(>=5.3) && $NonescapableTypes
   public static var current: AttributeGraph.AnyAttribute? {
     get
   }
-  #endif
   public func unsafeOffset(at offset: Swift.Int) -> AttributeGraph.AnyAttribute
   public func setFlags(_ newFlags: AttributeGraph.AnyAttribute.Flags, mask: AttributeGraph.AnyAttribute.Flags)
   public func addInput(_ attribute: AttributeGraph.AnyAttribute, options: AttributeGraph.AGInputOptions = [], token: Swift.Int)
@@ -620,12 +570,10 @@ extension AttributeGraph.AnyAttribute {
   public var valueType: any Any.Type {
     get
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public var indirectDependency: AttributeGraph.AnyAttribute? {
     get
     nonmutating set
   }
-  #endif
 }
 extension AttributeGraph.AnyAttribute : Swift.CustomStringConvertible {
   @inlinable public var description: Swift.String {
@@ -640,12 +588,10 @@ public typealias AttributeUpdateBlock = () -> (Swift.UnsafeMutableRawPointer, At
     get
     nonmutating set
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public var dependency: AttributeGraph.AnyAttribute? {
     get
     nonmutating set
   }
-  #endif
   public var value: Value {
     get
     nonmutating set
@@ -675,22 +621,16 @@ extension AttributeGraph.IndirectAttribute : Swift.Hashable {
   public var identifier: AttributeGraph.AnyAttribute
   public init()
   public init(_ attribute: AttributeGraph.AnyAttribute)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.AnyAttribute?)
-  #endif
   public init<Value>(_ attribute: AttributeGraph.OptionalAttribute<Value>)
   public static var current: AttributeGraph.AnyOptionalAttribute {
     get
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.AnyAttribute? {
     get
     set
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func map<Value>(_ body: (AttributeGraph.AnyAttribute) -> Value) -> Value?
-  #endif
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.OptionalAttribute<Value>
 }
 extension AttributeGraph.AnyOptionalAttribute : Swift.Hashable {
@@ -710,44 +650,28 @@ extension AttributeGraph.AnyOptionalAttribute : Swift.CustomStringConvertible {
   public init()
   public init(base: AttributeGraph.AnyOptionalAttribute)
   public init(_ attribute: AttributeGraph.Attribute<Value>)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.Attribute<Value>?)
-  #endif
   public init(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.Attribute<Value>? {
     get
     set
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var value: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func map<V>(_ body: (AttributeGraph.Attribute<Value>) -> V) -> V?
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var wrappedValue: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var projectedValue: AttributeGraph.Attribute<Value>? {
     get
     set
     _modify
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
     get
   }
-  #endif
 }
 extension AttributeGraph.OptionalAttribute : Swift.Hashable {
   public static func == (a: AttributeGraph.OptionalAttribute<Value>, b: AttributeGraph.OptionalAttribute<Value>) -> Swift.Bool

--- a/AG/2021/AttributeGraph.xcframework/ios-arm64-x86_64-simulator/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/x86_64-apple-ios-simulator.swiftinterface
+++ b/AG/2021/AttributeGraph.xcframework/ios-arm64-x86_64-simulator/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/x86_64-apple-ios-simulator.swiftinterface
@@ -1,7 +1,7 @@
 // swift-interface-format-version: 1.0
-// swift-compiler-version: Apple Swift version 6.2 effective-5.10 (swiftlang-6.2.0.16.112 clang-1800.1.29)
+// swift-compiler-version: Apple Swift version 6.3.3 effective-5.10 (swiftlang-6.3.3.1.3 clang-2100.1.1.101)
 // swift-module-flags: -target x86_64-apple-ios15.0-simulator -enable-objc-interop -enable-library-evolution -swift-version 5 -Osize -enable-upcoming-feature InternalImportsByDefault -enable-experimental-feature Extern -module-name AttributeGraph
-// swift-module-flags-ignorable: -interface-compiler-version 6.2
+// swift-module-flags-ignorable: -interface-compiler-version 6.3.3
 @_exported public import AttributeGraph
 public import Swift
 public import _Concurrency
@@ -38,10 +38,8 @@ extension AttributeGraph.Graph {
   }
 }
 extension AttributeGraph.Graph {
-  #if compiler(>=5.3) && $NonescapableTypes
   @_silgen_name("AGGraphGetOutputValue")
   @inline(__always) @inlinable public static func outputValue<Value>() -> Swift.UnsafePointer<Value>?
-  #endif
   @_silgen_name("AGGraphSetOutputValue")
   @inline(__always) @inlinable public static func setOutputValue<Value>(_ value: Swift.UnsafePointer<Value>)
 }
@@ -51,9 +49,7 @@ extension AttributeGraph.Graph {
     }
 }
 extension AttributeGraph.Graph {
-  #if compiler(>=5.3) && $NonescapableTypes
   public func archiveJSON(name: Swift.String?)
-  #endif
 }
 extension AttributeGraph.Subgraph {
   public typealias Flags = AttributeGraph.AnyAttribute.Flags
@@ -211,16 +207,12 @@ public func withUnsafeMutablePointerToEnumCase<T>(of value: Swift.UnsafeMutableP
   public subscript<V>(attribute: AttributeGraph.Attribute<V>) -> V {
     unsafeAddress
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(weakAttribute: AttributeGraph.WeakAttribute<V>) -> V? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(optionalAttribute: AttributeGraph.OptionalAttribute<V>) -> V? {
     get
   }
-  #endif
   public func valueAndFlags<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, flags: AttributeGraph.AGChangedValueFlags)
   public func changedValue<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, changed: Swift.Bool)
   public func update(body: () -> Swift.Void)
@@ -233,16 +225,12 @@ public func withUnsafeMutablePointerToEnumCase<T>(of value: Swift.UnsafeMutableP
   public subscript<V>(attribute: AttributeGraph.Attribute<V>) -> V {
     unsafeAddress
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(weakAttribute: AttributeGraph.WeakAttribute<V>) -> V? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(optionalAttribute: AttributeGraph.OptionalAttribute<V>) -> V? {
     get
   }
-  #endif
   public var value: Value {
     unsafeAddress
     nonmutating set
@@ -264,40 +252,26 @@ public func withUnsafeMutablePointerToEnumCase<T>(of value: Swift.UnsafeMutableP
   public init(base: AttributeGraph.AnyWeakAttribute)
   public init()
   public init(_ attribute: AttributeGraph.Attribute<Value>)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.Attribute<Value>?)
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var wrappedValue: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var projectedValue: AttributeGraph.Attribute<Value>? {
     get
     set
     _modify
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.Attribute<Value>? {
     get
     set
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var value: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
-  #endif
 }
 extension AttributeGraph.WeakAttribute : Swift.Hashable {
   public static func == (a: AttributeGraph.WeakAttribute<Value>, b: AttributeGraph.WeakAttribute<Value>) -> Swift.Bool
@@ -312,17 +286,13 @@ extension AttributeGraph.WeakAttribute : Swift.CustomStringConvertible {
   }
 }
 extension AttributeGraph.AnyWeakAttribute {
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.AnyAttribute?)
-  #endif
   public init<Value>(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.WeakAttribute<Value>
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.AnyAttribute? {
     get
     set
   }
-  #endif
 }
 extension AttributeGraph.AnyWeakAttribute : Swift.Hashable {
   public static func == (lhs: AttributeGraph.AnyWeakAttribute, rhs: AttributeGraph.AnyWeakAttribute) -> Swift.Bool
@@ -399,17 +369,13 @@ public protocol AttributeBodyVisitor {
 }
 public protocol StatefulRule : AttributeGraph._AttributeBody {
   associatedtype Value
-  #if compiler(>=5.3) && $NonescapableTypes
   static var initialValue: Self.Value? { get }
-  #endif
   mutating func updateValue()
 }
 extension AttributeGraph.StatefulRule {
-  #if compiler(>=5.3) && $NonescapableTypes
   public static var initialValue: Self.Value? {
     get
   }
-  #endif
   public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AttributeGraph.AnyAttribute)
   public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
 }
@@ -430,17 +396,13 @@ extension AttributeGraph.StatefulRule {
 }
 public protocol Rule : AttributeGraph._AttributeBody {
   associatedtype Value
-  #if compiler(>=5.3) && $NonescapableTypes
   static var initialValue: Self.Value? { get }
-  #endif
   var value: Self.Value { get }
 }
 extension AttributeGraph.Rule {
-  #if compiler(>=5.3) && $NonescapableTypes
   public static var initialValue: Self.Value? {
     get
   }
-  #endif
   public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AttributeGraph.AnyAttribute)
   public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
 }
@@ -453,15 +415,9 @@ extension AttributeGraph.Rule {
   }
 }
 extension AttributeGraph.Rule where Self : Swift.Hashable {
-  #if compiler(>=5.3) && $NonescapableTypes
   public func cachedValue(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?) -> Self.Value
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func cachedValueIfExists(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?) -> Self.Value?
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public static func _cachedValue(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?, hashValue: Swift.Int, bodyPtr: Swift.UnsafeRawPointer, update: () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void) -> Swift.UnsafePointer<Self.Value>
-  #endif
 }
 @frozen @propertyWrapper @dynamicMemberLookup public struct Attribute<Value> {
   public var identifier: AttributeGraph.AnyAttribute
@@ -469,9 +425,7 @@ extension AttributeGraph.Rule where Self : Swift.Hashable {
   public init(_ attribute: AttributeGraph.Attribute<Value>)
   public init(value: Value)
   public init(type _: Value.Type)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init<Body>(body: Swift.UnsafePointer<Body>, value: Swift.UnsafePointer<Value>?, flags: AttributeGraph._AttributeType.Flags = [], update: () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void) where Body : AttributeGraph._AttributeBody
-  #endif
   public var wrappedValue: Value {
     unsafeAddress
     nonmutating set
@@ -543,10 +497,8 @@ extension AttributeGraph.Attribute {
   public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.Rule
   public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.StatefulRule
 }
-#if compiler(>=5.3) && $NonescapableTypes
 @_silgen_name("AGGraphCreateAttribute")
 @inline(__always) @inlinable internal func AGGraphCreateAttribute(index: Swift.Int, body: Swift.UnsafeRawPointer, value: Swift.UnsafeRawPointer?) -> AttributeGraph.AnyAttribute
-#endif
 @_silgen_name("AGGraphGetValue")
 @inline(__always) @inlinable internal func AGGraphGetValue<Value>(_ attribute: AttributeGraph.AnyAttribute, options: AttributeGraph.AGValueOptions = [], type: Value.Type = Value.self) -> AttributeGraph.AGValue
 @_silgen_name("AGGraphSetValue")
@@ -599,11 +551,9 @@ extension Swift.UnsafeMutablePointer {
 extension AttributeGraph.AnyAttribute {
   public init<Value>(_ attribute: AttributeGraph.Attribute<Value>)
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.Attribute<Value>
-  #if compiler(>=5.3) && $NonescapableTypes
   public static var current: AttributeGraph.AnyAttribute? {
     get
   }
-  #endif
   public func unsafeOffset(at offset: Swift.Int) -> AttributeGraph.AnyAttribute
   public func setFlags(_ newFlags: AttributeGraph.AnyAttribute.Flags, mask: AttributeGraph.AnyAttribute.Flags)
   public func addInput(_ attribute: AttributeGraph.AnyAttribute, options: AttributeGraph.AGInputOptions = [], token: Swift.Int)
@@ -620,12 +570,10 @@ extension AttributeGraph.AnyAttribute {
   public var valueType: any Any.Type {
     get
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public var indirectDependency: AttributeGraph.AnyAttribute? {
     get
     nonmutating set
   }
-  #endif
 }
 extension AttributeGraph.AnyAttribute : Swift.CustomStringConvertible {
   @inlinable public var description: Swift.String {
@@ -640,12 +588,10 @@ public typealias AttributeUpdateBlock = () -> (Swift.UnsafeMutableRawPointer, At
     get
     nonmutating set
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public var dependency: AttributeGraph.AnyAttribute? {
     get
     nonmutating set
   }
-  #endif
   public var value: Value {
     get
     nonmutating set
@@ -675,22 +621,16 @@ extension AttributeGraph.IndirectAttribute : Swift.Hashable {
   public var identifier: AttributeGraph.AnyAttribute
   public init()
   public init(_ attribute: AttributeGraph.AnyAttribute)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.AnyAttribute?)
-  #endif
   public init<Value>(_ attribute: AttributeGraph.OptionalAttribute<Value>)
   public static var current: AttributeGraph.AnyOptionalAttribute {
     get
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.AnyAttribute? {
     get
     set
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func map<Value>(_ body: (AttributeGraph.AnyAttribute) -> Value) -> Value?
-  #endif
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.OptionalAttribute<Value>
 }
 extension AttributeGraph.AnyOptionalAttribute : Swift.Hashable {
@@ -710,44 +650,28 @@ extension AttributeGraph.AnyOptionalAttribute : Swift.CustomStringConvertible {
   public init()
   public init(base: AttributeGraph.AnyOptionalAttribute)
   public init(_ attribute: AttributeGraph.Attribute<Value>)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.Attribute<Value>?)
-  #endif
   public init(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.Attribute<Value>? {
     get
     set
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var value: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func map<V>(_ body: (AttributeGraph.Attribute<Value>) -> V) -> V?
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var wrappedValue: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var projectedValue: AttributeGraph.Attribute<Value>? {
     get
     set
     _modify
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
     get
   }
-  #endif
 }
 extension AttributeGraph.OptionalAttribute : Swift.Hashable {
   public static func == (a: AttributeGraph.OptionalAttribute<Value>, b: AttributeGraph.OptionalAttribute<Value>) -> Swift.Bool

--- a/AG/2021/AttributeGraph.xcframework/macos-arm64e-arm64-x86_64/AttributeGraph.framework/Versions/A/Modules/AttributeGraph.swiftmodule/arm64-apple-macos.swiftinterface
+++ b/AG/2021/AttributeGraph.xcframework/macos-arm64e-arm64-x86_64/AttributeGraph.framework/Versions/A/Modules/AttributeGraph.swiftmodule/arm64-apple-macos.swiftinterface
@@ -1,7 +1,7 @@
 // swift-interface-format-version: 1.0
-// swift-compiler-version: Apple Swift version 6.2 effective-5.10 (swiftlang-6.2.0.16.112 clang-1800.1.29)
+// swift-compiler-version: Apple Swift version 6.3.3 effective-5.10 (swiftlang-6.3.3.1.3 clang-2100.1.1.101)
 // swift-module-flags: -target arm64-apple-macos12.0 -enable-objc-interop -enable-library-evolution -swift-version 5 -Osize -enable-upcoming-feature InternalImportsByDefault -enable-experimental-feature Extern -module-name AttributeGraph
-// swift-module-flags-ignorable: -interface-compiler-version 6.2
+// swift-module-flags-ignorable: -interface-compiler-version 6.3.3
 @_exported public import AttributeGraph
 public import Swift
 public import _Concurrency
@@ -38,10 +38,8 @@ extension AttributeGraph.Graph {
   }
 }
 extension AttributeGraph.Graph {
-  #if compiler(>=5.3) && $NonescapableTypes
   @_silgen_name("AGGraphGetOutputValue")
   @inline(__always) @inlinable public static func outputValue<Value>() -> Swift.UnsafePointer<Value>?
-  #endif
   @_silgen_name("AGGraphSetOutputValue")
   @inline(__always) @inlinable public static func setOutputValue<Value>(_ value: Swift.UnsafePointer<Value>)
 }
@@ -51,9 +49,7 @@ extension AttributeGraph.Graph {
     }
 }
 extension AttributeGraph.Graph {
-  #if compiler(>=5.3) && $NonescapableTypes
   public func archiveJSON(name: Swift.String?)
-  #endif
 }
 extension AttributeGraph.Subgraph {
   public typealias Flags = AttributeGraph.AnyAttribute.Flags
@@ -211,16 +207,12 @@ public func withUnsafeMutablePointerToEnumCase<T>(of value: Swift.UnsafeMutableP
   public subscript<V>(attribute: AttributeGraph.Attribute<V>) -> V {
     unsafeAddress
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(weakAttribute: AttributeGraph.WeakAttribute<V>) -> V? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(optionalAttribute: AttributeGraph.OptionalAttribute<V>) -> V? {
     get
   }
-  #endif
   public func valueAndFlags<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, flags: AttributeGraph.AGChangedValueFlags)
   public func changedValue<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, changed: Swift.Bool)
   public func update(body: () -> Swift.Void)
@@ -233,16 +225,12 @@ public func withUnsafeMutablePointerToEnumCase<T>(of value: Swift.UnsafeMutableP
   public subscript<V>(attribute: AttributeGraph.Attribute<V>) -> V {
     unsafeAddress
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(weakAttribute: AttributeGraph.WeakAttribute<V>) -> V? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(optionalAttribute: AttributeGraph.OptionalAttribute<V>) -> V? {
     get
   }
-  #endif
   public var value: Value {
     unsafeAddress
     nonmutating set
@@ -264,40 +252,26 @@ public func withUnsafeMutablePointerToEnumCase<T>(of value: Swift.UnsafeMutableP
   public init(base: AttributeGraph.AnyWeakAttribute)
   public init()
   public init(_ attribute: AttributeGraph.Attribute<Value>)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.Attribute<Value>?)
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var wrappedValue: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var projectedValue: AttributeGraph.Attribute<Value>? {
     get
     set
     _modify
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.Attribute<Value>? {
     get
     set
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var value: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
-  #endif
 }
 extension AttributeGraph.WeakAttribute : Swift.Hashable {
   public static func == (a: AttributeGraph.WeakAttribute<Value>, b: AttributeGraph.WeakAttribute<Value>) -> Swift.Bool
@@ -312,17 +286,13 @@ extension AttributeGraph.WeakAttribute : Swift.CustomStringConvertible {
   }
 }
 extension AttributeGraph.AnyWeakAttribute {
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.AnyAttribute?)
-  #endif
   public init<Value>(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.WeakAttribute<Value>
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.AnyAttribute? {
     get
     set
   }
-  #endif
 }
 extension AttributeGraph.AnyWeakAttribute : Swift.Hashable {
   public static func == (lhs: AttributeGraph.AnyWeakAttribute, rhs: AttributeGraph.AnyWeakAttribute) -> Swift.Bool
@@ -399,17 +369,13 @@ public protocol AttributeBodyVisitor {
 }
 public protocol StatefulRule : AttributeGraph._AttributeBody {
   associatedtype Value
-  #if compiler(>=5.3) && $NonescapableTypes
   static var initialValue: Self.Value? { get }
-  #endif
   mutating func updateValue()
 }
 extension AttributeGraph.StatefulRule {
-  #if compiler(>=5.3) && $NonescapableTypes
   public static var initialValue: Self.Value? {
     get
   }
-  #endif
   public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AttributeGraph.AnyAttribute)
   public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
 }
@@ -430,17 +396,13 @@ extension AttributeGraph.StatefulRule {
 }
 public protocol Rule : AttributeGraph._AttributeBody {
   associatedtype Value
-  #if compiler(>=5.3) && $NonescapableTypes
   static var initialValue: Self.Value? { get }
-  #endif
   var value: Self.Value { get }
 }
 extension AttributeGraph.Rule {
-  #if compiler(>=5.3) && $NonescapableTypes
   public static var initialValue: Self.Value? {
     get
   }
-  #endif
   public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AttributeGraph.AnyAttribute)
   public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
 }
@@ -453,15 +415,9 @@ extension AttributeGraph.Rule {
   }
 }
 extension AttributeGraph.Rule where Self : Swift.Hashable {
-  #if compiler(>=5.3) && $NonescapableTypes
   public func cachedValue(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?) -> Self.Value
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func cachedValueIfExists(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?) -> Self.Value?
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public static func _cachedValue(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?, hashValue: Swift.Int, bodyPtr: Swift.UnsafeRawPointer, update: () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void) -> Swift.UnsafePointer<Self.Value>
-  #endif
 }
 @frozen @propertyWrapper @dynamicMemberLookup public struct Attribute<Value> {
   public var identifier: AttributeGraph.AnyAttribute
@@ -469,9 +425,7 @@ extension AttributeGraph.Rule where Self : Swift.Hashable {
   public init(_ attribute: AttributeGraph.Attribute<Value>)
   public init(value: Value)
   public init(type _: Value.Type)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init<Body>(body: Swift.UnsafePointer<Body>, value: Swift.UnsafePointer<Value>?, flags: AttributeGraph._AttributeType.Flags = [], update: () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void) where Body : AttributeGraph._AttributeBody
-  #endif
   public var wrappedValue: Value {
     unsafeAddress
     nonmutating set
@@ -543,10 +497,8 @@ extension AttributeGraph.Attribute {
   public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.Rule
   public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.StatefulRule
 }
-#if compiler(>=5.3) && $NonescapableTypes
 @_silgen_name("AGGraphCreateAttribute")
 @inline(__always) @inlinable internal func AGGraphCreateAttribute(index: Swift.Int, body: Swift.UnsafeRawPointer, value: Swift.UnsafeRawPointer?) -> AttributeGraph.AnyAttribute
-#endif
 @_silgen_name("AGGraphGetValue")
 @inline(__always) @inlinable internal func AGGraphGetValue<Value>(_ attribute: AttributeGraph.AnyAttribute, options: AttributeGraph.AGValueOptions = [], type: Value.Type = Value.self) -> AttributeGraph.AGValue
 @_silgen_name("AGGraphSetValue")
@@ -599,11 +551,9 @@ extension Swift.UnsafeMutablePointer {
 extension AttributeGraph.AnyAttribute {
   public init<Value>(_ attribute: AttributeGraph.Attribute<Value>)
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.Attribute<Value>
-  #if compiler(>=5.3) && $NonescapableTypes
   public static var current: AttributeGraph.AnyAttribute? {
     get
   }
-  #endif
   public func unsafeOffset(at offset: Swift.Int) -> AttributeGraph.AnyAttribute
   public func setFlags(_ newFlags: AttributeGraph.AnyAttribute.Flags, mask: AttributeGraph.AnyAttribute.Flags)
   public func addInput(_ attribute: AttributeGraph.AnyAttribute, options: AttributeGraph.AGInputOptions = [], token: Swift.Int)
@@ -620,12 +570,10 @@ extension AttributeGraph.AnyAttribute {
   public var valueType: any Any.Type {
     get
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public var indirectDependency: AttributeGraph.AnyAttribute? {
     get
     nonmutating set
   }
-  #endif
 }
 extension AttributeGraph.AnyAttribute : Swift.CustomStringConvertible {
   @inlinable public var description: Swift.String {
@@ -640,12 +588,10 @@ public typealias AttributeUpdateBlock = () -> (Swift.UnsafeMutableRawPointer, At
     get
     nonmutating set
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public var dependency: AttributeGraph.AnyAttribute? {
     get
     nonmutating set
   }
-  #endif
   public var value: Value {
     get
     nonmutating set
@@ -675,22 +621,16 @@ extension AttributeGraph.IndirectAttribute : Swift.Hashable {
   public var identifier: AttributeGraph.AnyAttribute
   public init()
   public init(_ attribute: AttributeGraph.AnyAttribute)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.AnyAttribute?)
-  #endif
   public init<Value>(_ attribute: AttributeGraph.OptionalAttribute<Value>)
   public static var current: AttributeGraph.AnyOptionalAttribute {
     get
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.AnyAttribute? {
     get
     set
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func map<Value>(_ body: (AttributeGraph.AnyAttribute) -> Value) -> Value?
-  #endif
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.OptionalAttribute<Value>
 }
 extension AttributeGraph.AnyOptionalAttribute : Swift.Hashable {
@@ -710,44 +650,28 @@ extension AttributeGraph.AnyOptionalAttribute : Swift.CustomStringConvertible {
   public init()
   public init(base: AttributeGraph.AnyOptionalAttribute)
   public init(_ attribute: AttributeGraph.Attribute<Value>)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.Attribute<Value>?)
-  #endif
   public init(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.Attribute<Value>? {
     get
     set
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var value: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func map<V>(_ body: (AttributeGraph.Attribute<Value>) -> V) -> V?
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var wrappedValue: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var projectedValue: AttributeGraph.Attribute<Value>? {
     get
     set
     _modify
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
     get
   }
-  #endif
 }
 extension AttributeGraph.OptionalAttribute : Swift.Hashable {
   public static func == (a: AttributeGraph.OptionalAttribute<Value>, b: AttributeGraph.OptionalAttribute<Value>) -> Swift.Bool

--- a/AG/2021/AttributeGraph.xcframework/macos-arm64e-arm64-x86_64/AttributeGraph.framework/Versions/A/Modules/AttributeGraph.swiftmodule/arm64e-apple-macos.swiftinterface
+++ b/AG/2021/AttributeGraph.xcframework/macos-arm64e-arm64-x86_64/AttributeGraph.framework/Versions/A/Modules/AttributeGraph.swiftmodule/arm64e-apple-macos.swiftinterface
@@ -1,7 +1,7 @@
 // swift-interface-format-version: 1.0
-// swift-compiler-version: Apple Swift version 6.2 effective-5.10 (swiftlang-6.2.0.16.112 clang-1800.1.29)
+// swift-compiler-version: Apple Swift version 6.3.3 effective-5.10 (swiftlang-6.3.3.1.3 clang-2100.1.1.101)
 // swift-module-flags: -target arm64e-apple-macos12.0 -enable-objc-interop -enable-library-evolution -swift-version 5 -Osize -enable-upcoming-feature InternalImportsByDefault -enable-experimental-feature Extern -module-name AttributeGraph
-// swift-module-flags-ignorable: -interface-compiler-version 6.2
+// swift-module-flags-ignorable: -interface-compiler-version 6.3.3
 @_exported public import AttributeGraph
 public import Swift
 public import _Concurrency
@@ -38,10 +38,8 @@ extension AttributeGraph.Graph {
   }
 }
 extension AttributeGraph.Graph {
-  #if compiler(>=5.3) && $NonescapableTypes
   @_silgen_name("AGGraphGetOutputValue")
   @inline(__always) @inlinable public static func outputValue<Value>() -> Swift.UnsafePointer<Value>?
-  #endif
   @_silgen_name("AGGraphSetOutputValue")
   @inline(__always) @inlinable public static func setOutputValue<Value>(_ value: Swift.UnsafePointer<Value>)
 }
@@ -51,9 +49,7 @@ extension AttributeGraph.Graph {
     }
 }
 extension AttributeGraph.Graph {
-  #if compiler(>=5.3) && $NonescapableTypes
   public func archiveJSON(name: Swift.String?)
-  #endif
 }
 extension AttributeGraph.Subgraph {
   public typealias Flags = AttributeGraph.AnyAttribute.Flags
@@ -211,16 +207,12 @@ public func withUnsafeMutablePointerToEnumCase<T>(of value: Swift.UnsafeMutableP
   public subscript<V>(attribute: AttributeGraph.Attribute<V>) -> V {
     unsafeAddress
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(weakAttribute: AttributeGraph.WeakAttribute<V>) -> V? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(optionalAttribute: AttributeGraph.OptionalAttribute<V>) -> V? {
     get
   }
-  #endif
   public func valueAndFlags<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, flags: AttributeGraph.AGChangedValueFlags)
   public func changedValue<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, changed: Swift.Bool)
   public func update(body: () -> Swift.Void)
@@ -233,16 +225,12 @@ public func withUnsafeMutablePointerToEnumCase<T>(of value: Swift.UnsafeMutableP
   public subscript<V>(attribute: AttributeGraph.Attribute<V>) -> V {
     unsafeAddress
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(weakAttribute: AttributeGraph.WeakAttribute<V>) -> V? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(optionalAttribute: AttributeGraph.OptionalAttribute<V>) -> V? {
     get
   }
-  #endif
   public var value: Value {
     unsafeAddress
     nonmutating set
@@ -264,40 +252,26 @@ public func withUnsafeMutablePointerToEnumCase<T>(of value: Swift.UnsafeMutableP
   public init(base: AttributeGraph.AnyWeakAttribute)
   public init()
   public init(_ attribute: AttributeGraph.Attribute<Value>)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.Attribute<Value>?)
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var wrappedValue: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var projectedValue: AttributeGraph.Attribute<Value>? {
     get
     set
     _modify
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.Attribute<Value>? {
     get
     set
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var value: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
-  #endif
 }
 extension AttributeGraph.WeakAttribute : Swift.Hashable {
   public static func == (a: AttributeGraph.WeakAttribute<Value>, b: AttributeGraph.WeakAttribute<Value>) -> Swift.Bool
@@ -312,17 +286,13 @@ extension AttributeGraph.WeakAttribute : Swift.CustomStringConvertible {
   }
 }
 extension AttributeGraph.AnyWeakAttribute {
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.AnyAttribute?)
-  #endif
   public init<Value>(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.WeakAttribute<Value>
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.AnyAttribute? {
     get
     set
   }
-  #endif
 }
 extension AttributeGraph.AnyWeakAttribute : Swift.Hashable {
   public static func == (lhs: AttributeGraph.AnyWeakAttribute, rhs: AttributeGraph.AnyWeakAttribute) -> Swift.Bool
@@ -399,17 +369,13 @@ public protocol AttributeBodyVisitor {
 }
 public protocol StatefulRule : AttributeGraph._AttributeBody {
   associatedtype Value
-  #if compiler(>=5.3) && $NonescapableTypes
   static var initialValue: Self.Value? { get }
-  #endif
   mutating func updateValue()
 }
 extension AttributeGraph.StatefulRule {
-  #if compiler(>=5.3) && $NonescapableTypes
   public static var initialValue: Self.Value? {
     get
   }
-  #endif
   public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AttributeGraph.AnyAttribute)
   public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
 }
@@ -430,17 +396,13 @@ extension AttributeGraph.StatefulRule {
 }
 public protocol Rule : AttributeGraph._AttributeBody {
   associatedtype Value
-  #if compiler(>=5.3) && $NonescapableTypes
   static var initialValue: Self.Value? { get }
-  #endif
   var value: Self.Value { get }
 }
 extension AttributeGraph.Rule {
-  #if compiler(>=5.3) && $NonescapableTypes
   public static var initialValue: Self.Value? {
     get
   }
-  #endif
   public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AttributeGraph.AnyAttribute)
   public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
 }
@@ -453,15 +415,9 @@ extension AttributeGraph.Rule {
   }
 }
 extension AttributeGraph.Rule where Self : Swift.Hashable {
-  #if compiler(>=5.3) && $NonescapableTypes
   public func cachedValue(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?) -> Self.Value
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func cachedValueIfExists(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?) -> Self.Value?
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public static func _cachedValue(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?, hashValue: Swift.Int, bodyPtr: Swift.UnsafeRawPointer, update: () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void) -> Swift.UnsafePointer<Self.Value>
-  #endif
 }
 @frozen @propertyWrapper @dynamicMemberLookup public struct Attribute<Value> {
   public var identifier: AttributeGraph.AnyAttribute
@@ -469,9 +425,7 @@ extension AttributeGraph.Rule where Self : Swift.Hashable {
   public init(_ attribute: AttributeGraph.Attribute<Value>)
   public init(value: Value)
   public init(type _: Value.Type)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init<Body>(body: Swift.UnsafePointer<Body>, value: Swift.UnsafePointer<Value>?, flags: AttributeGraph._AttributeType.Flags = [], update: () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void) where Body : AttributeGraph._AttributeBody
-  #endif
   public var wrappedValue: Value {
     unsafeAddress
     nonmutating set
@@ -543,10 +497,8 @@ extension AttributeGraph.Attribute {
   public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.Rule
   public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.StatefulRule
 }
-#if compiler(>=5.3) && $NonescapableTypes
 @_silgen_name("AGGraphCreateAttribute")
 @inline(__always) @inlinable internal func AGGraphCreateAttribute(index: Swift.Int, body: Swift.UnsafeRawPointer, value: Swift.UnsafeRawPointer?) -> AttributeGraph.AnyAttribute
-#endif
 @_silgen_name("AGGraphGetValue")
 @inline(__always) @inlinable internal func AGGraphGetValue<Value>(_ attribute: AttributeGraph.AnyAttribute, options: AttributeGraph.AGValueOptions = [], type: Value.Type = Value.self) -> AttributeGraph.AGValue
 @_silgen_name("AGGraphSetValue")
@@ -599,11 +551,9 @@ extension Swift.UnsafeMutablePointer {
 extension AttributeGraph.AnyAttribute {
   public init<Value>(_ attribute: AttributeGraph.Attribute<Value>)
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.Attribute<Value>
-  #if compiler(>=5.3) && $NonescapableTypes
   public static var current: AttributeGraph.AnyAttribute? {
     get
   }
-  #endif
   public func unsafeOffset(at offset: Swift.Int) -> AttributeGraph.AnyAttribute
   public func setFlags(_ newFlags: AttributeGraph.AnyAttribute.Flags, mask: AttributeGraph.AnyAttribute.Flags)
   public func addInput(_ attribute: AttributeGraph.AnyAttribute, options: AttributeGraph.AGInputOptions = [], token: Swift.Int)
@@ -620,12 +570,10 @@ extension AttributeGraph.AnyAttribute {
   public var valueType: any Any.Type {
     get
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public var indirectDependency: AttributeGraph.AnyAttribute? {
     get
     nonmutating set
   }
-  #endif
 }
 extension AttributeGraph.AnyAttribute : Swift.CustomStringConvertible {
   @inlinable public var description: Swift.String {
@@ -640,12 +588,10 @@ public typealias AttributeUpdateBlock = () -> (Swift.UnsafeMutableRawPointer, At
     get
     nonmutating set
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public var dependency: AttributeGraph.AnyAttribute? {
     get
     nonmutating set
   }
-  #endif
   public var value: Value {
     get
     nonmutating set
@@ -675,22 +621,16 @@ extension AttributeGraph.IndirectAttribute : Swift.Hashable {
   public var identifier: AttributeGraph.AnyAttribute
   public init()
   public init(_ attribute: AttributeGraph.AnyAttribute)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.AnyAttribute?)
-  #endif
   public init<Value>(_ attribute: AttributeGraph.OptionalAttribute<Value>)
   public static var current: AttributeGraph.AnyOptionalAttribute {
     get
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.AnyAttribute? {
     get
     set
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func map<Value>(_ body: (AttributeGraph.AnyAttribute) -> Value) -> Value?
-  #endif
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.OptionalAttribute<Value>
 }
 extension AttributeGraph.AnyOptionalAttribute : Swift.Hashable {
@@ -710,44 +650,28 @@ extension AttributeGraph.AnyOptionalAttribute : Swift.CustomStringConvertible {
   public init()
   public init(base: AttributeGraph.AnyOptionalAttribute)
   public init(_ attribute: AttributeGraph.Attribute<Value>)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.Attribute<Value>?)
-  #endif
   public init(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.Attribute<Value>? {
     get
     set
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var value: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func map<V>(_ body: (AttributeGraph.Attribute<Value>) -> V) -> V?
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var wrappedValue: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var projectedValue: AttributeGraph.Attribute<Value>? {
     get
     set
     _modify
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
     get
   }
-  #endif
 }
 extension AttributeGraph.OptionalAttribute : Swift.Hashable {
   public static func == (a: AttributeGraph.OptionalAttribute<Value>, b: AttributeGraph.OptionalAttribute<Value>) -> Swift.Bool

--- a/AG/2021/AttributeGraph.xcframework/macos-arm64e-arm64-x86_64/AttributeGraph.framework/Versions/A/Modules/AttributeGraph.swiftmodule/x86_64-apple-macos.swiftinterface
+++ b/AG/2021/AttributeGraph.xcframework/macos-arm64e-arm64-x86_64/AttributeGraph.framework/Versions/A/Modules/AttributeGraph.swiftmodule/x86_64-apple-macos.swiftinterface
@@ -1,7 +1,7 @@
 // swift-interface-format-version: 1.0
-// swift-compiler-version: Apple Swift version 6.2 effective-5.10 (swiftlang-6.2.0.16.112 clang-1800.1.29)
+// swift-compiler-version: Apple Swift version 6.3.3 effective-5.10 (swiftlang-6.3.3.1.3 clang-2100.1.1.101)
 // swift-module-flags: -target x86_64-apple-macos12.0 -enable-objc-interop -enable-library-evolution -swift-version 5 -Osize -enable-upcoming-feature InternalImportsByDefault -enable-experimental-feature Extern -module-name AttributeGraph
-// swift-module-flags-ignorable: -interface-compiler-version 6.2
+// swift-module-flags-ignorable: -interface-compiler-version 6.3.3
 @_exported public import AttributeGraph
 public import Swift
 public import _Concurrency
@@ -38,10 +38,8 @@ extension AttributeGraph.Graph {
   }
 }
 extension AttributeGraph.Graph {
-  #if compiler(>=5.3) && $NonescapableTypes
   @_silgen_name("AGGraphGetOutputValue")
   @inline(__always) @inlinable public static func outputValue<Value>() -> Swift.UnsafePointer<Value>?
-  #endif
   @_silgen_name("AGGraphSetOutputValue")
   @inline(__always) @inlinable public static func setOutputValue<Value>(_ value: Swift.UnsafePointer<Value>)
 }
@@ -51,9 +49,7 @@ extension AttributeGraph.Graph {
     }
 }
 extension AttributeGraph.Graph {
-  #if compiler(>=5.3) && $NonescapableTypes
   public func archiveJSON(name: Swift.String?)
-  #endif
 }
 extension AttributeGraph.Subgraph {
   public typealias Flags = AttributeGraph.AnyAttribute.Flags
@@ -211,16 +207,12 @@ public func withUnsafeMutablePointerToEnumCase<T>(of value: Swift.UnsafeMutableP
   public subscript<V>(attribute: AttributeGraph.Attribute<V>) -> V {
     unsafeAddress
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(weakAttribute: AttributeGraph.WeakAttribute<V>) -> V? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(optionalAttribute: AttributeGraph.OptionalAttribute<V>) -> V? {
     get
   }
-  #endif
   public func valueAndFlags<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, flags: AttributeGraph.AGChangedValueFlags)
   public func changedValue<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, changed: Swift.Bool)
   public func update(body: () -> Swift.Void)
@@ -233,16 +225,12 @@ public func withUnsafeMutablePointerToEnumCase<T>(of value: Swift.UnsafeMutableP
   public subscript<V>(attribute: AttributeGraph.Attribute<V>) -> V {
     unsafeAddress
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(weakAttribute: AttributeGraph.WeakAttribute<V>) -> V? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(optionalAttribute: AttributeGraph.OptionalAttribute<V>) -> V? {
     get
   }
-  #endif
   public var value: Value {
     unsafeAddress
     nonmutating set
@@ -264,40 +252,26 @@ public func withUnsafeMutablePointerToEnumCase<T>(of value: Swift.UnsafeMutableP
   public init(base: AttributeGraph.AnyWeakAttribute)
   public init()
   public init(_ attribute: AttributeGraph.Attribute<Value>)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.Attribute<Value>?)
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var wrappedValue: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var projectedValue: AttributeGraph.Attribute<Value>? {
     get
     set
     _modify
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.Attribute<Value>? {
     get
     set
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var value: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
-  #endif
 }
 extension AttributeGraph.WeakAttribute : Swift.Hashable {
   public static func == (a: AttributeGraph.WeakAttribute<Value>, b: AttributeGraph.WeakAttribute<Value>) -> Swift.Bool
@@ -312,17 +286,13 @@ extension AttributeGraph.WeakAttribute : Swift.CustomStringConvertible {
   }
 }
 extension AttributeGraph.AnyWeakAttribute {
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.AnyAttribute?)
-  #endif
   public init<Value>(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.WeakAttribute<Value>
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.AnyAttribute? {
     get
     set
   }
-  #endif
 }
 extension AttributeGraph.AnyWeakAttribute : Swift.Hashable {
   public static func == (lhs: AttributeGraph.AnyWeakAttribute, rhs: AttributeGraph.AnyWeakAttribute) -> Swift.Bool
@@ -399,17 +369,13 @@ public protocol AttributeBodyVisitor {
 }
 public protocol StatefulRule : AttributeGraph._AttributeBody {
   associatedtype Value
-  #if compiler(>=5.3) && $NonescapableTypes
   static var initialValue: Self.Value? { get }
-  #endif
   mutating func updateValue()
 }
 extension AttributeGraph.StatefulRule {
-  #if compiler(>=5.3) && $NonescapableTypes
   public static var initialValue: Self.Value? {
     get
   }
-  #endif
   public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AttributeGraph.AnyAttribute)
   public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
 }
@@ -430,17 +396,13 @@ extension AttributeGraph.StatefulRule {
 }
 public protocol Rule : AttributeGraph._AttributeBody {
   associatedtype Value
-  #if compiler(>=5.3) && $NonescapableTypes
   static var initialValue: Self.Value? { get }
-  #endif
   var value: Self.Value { get }
 }
 extension AttributeGraph.Rule {
-  #if compiler(>=5.3) && $NonescapableTypes
   public static var initialValue: Self.Value? {
     get
   }
-  #endif
   public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AttributeGraph.AnyAttribute)
   public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
 }
@@ -453,15 +415,9 @@ extension AttributeGraph.Rule {
   }
 }
 extension AttributeGraph.Rule where Self : Swift.Hashable {
-  #if compiler(>=5.3) && $NonescapableTypes
   public func cachedValue(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?) -> Self.Value
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func cachedValueIfExists(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?) -> Self.Value?
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public static func _cachedValue(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?, hashValue: Swift.Int, bodyPtr: Swift.UnsafeRawPointer, update: () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void) -> Swift.UnsafePointer<Self.Value>
-  #endif
 }
 @frozen @propertyWrapper @dynamicMemberLookup public struct Attribute<Value> {
   public var identifier: AttributeGraph.AnyAttribute
@@ -469,9 +425,7 @@ extension AttributeGraph.Rule where Self : Swift.Hashable {
   public init(_ attribute: AttributeGraph.Attribute<Value>)
   public init(value: Value)
   public init(type _: Value.Type)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init<Body>(body: Swift.UnsafePointer<Body>, value: Swift.UnsafePointer<Value>?, flags: AttributeGraph._AttributeType.Flags = [], update: () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void) where Body : AttributeGraph._AttributeBody
-  #endif
   public var wrappedValue: Value {
     unsafeAddress
     nonmutating set
@@ -543,10 +497,8 @@ extension AttributeGraph.Attribute {
   public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.Rule
   public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.StatefulRule
 }
-#if compiler(>=5.3) && $NonescapableTypes
 @_silgen_name("AGGraphCreateAttribute")
 @inline(__always) @inlinable internal func AGGraphCreateAttribute(index: Swift.Int, body: Swift.UnsafeRawPointer, value: Swift.UnsafeRawPointer?) -> AttributeGraph.AnyAttribute
-#endif
 @_silgen_name("AGGraphGetValue")
 @inline(__always) @inlinable internal func AGGraphGetValue<Value>(_ attribute: AttributeGraph.AnyAttribute, options: AttributeGraph.AGValueOptions = [], type: Value.Type = Value.self) -> AttributeGraph.AGValue
 @_silgen_name("AGGraphSetValue")
@@ -599,11 +551,9 @@ extension Swift.UnsafeMutablePointer {
 extension AttributeGraph.AnyAttribute {
   public init<Value>(_ attribute: AttributeGraph.Attribute<Value>)
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.Attribute<Value>
-  #if compiler(>=5.3) && $NonescapableTypes
   public static var current: AttributeGraph.AnyAttribute? {
     get
   }
-  #endif
   public func unsafeOffset(at offset: Swift.Int) -> AttributeGraph.AnyAttribute
   public func setFlags(_ newFlags: AttributeGraph.AnyAttribute.Flags, mask: AttributeGraph.AnyAttribute.Flags)
   public func addInput(_ attribute: AttributeGraph.AnyAttribute, options: AttributeGraph.AGInputOptions = [], token: Swift.Int)
@@ -620,12 +570,10 @@ extension AttributeGraph.AnyAttribute {
   public var valueType: any Any.Type {
     get
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public var indirectDependency: AttributeGraph.AnyAttribute? {
     get
     nonmutating set
   }
-  #endif
 }
 extension AttributeGraph.AnyAttribute : Swift.CustomStringConvertible {
   @inlinable public var description: Swift.String {
@@ -640,12 +588,10 @@ public typealias AttributeUpdateBlock = () -> (Swift.UnsafeMutableRawPointer, At
     get
     nonmutating set
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public var dependency: AttributeGraph.AnyAttribute? {
     get
     nonmutating set
   }
-  #endif
   public var value: Value {
     get
     nonmutating set
@@ -675,22 +621,16 @@ extension AttributeGraph.IndirectAttribute : Swift.Hashable {
   public var identifier: AttributeGraph.AnyAttribute
   public init()
   public init(_ attribute: AttributeGraph.AnyAttribute)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.AnyAttribute?)
-  #endif
   public init<Value>(_ attribute: AttributeGraph.OptionalAttribute<Value>)
   public static var current: AttributeGraph.AnyOptionalAttribute {
     get
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.AnyAttribute? {
     get
     set
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func map<Value>(_ body: (AttributeGraph.AnyAttribute) -> Value) -> Value?
-  #endif
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.OptionalAttribute<Value>
 }
 extension AttributeGraph.AnyOptionalAttribute : Swift.Hashable {
@@ -710,44 +650,28 @@ extension AttributeGraph.AnyOptionalAttribute : Swift.CustomStringConvertible {
   public init()
   public init(base: AttributeGraph.AnyOptionalAttribute)
   public init(_ attribute: AttributeGraph.Attribute<Value>)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.Attribute<Value>?)
-  #endif
   public init(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.Attribute<Value>? {
     get
     set
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var value: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func map<V>(_ body: (AttributeGraph.Attribute<Value>) -> V) -> V?
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var wrappedValue: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var projectedValue: AttributeGraph.Attribute<Value>? {
     get
     set
     _modify
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
     get
   }
-  #endif
 }
 extension AttributeGraph.OptionalAttribute : Swift.Hashable {
   public static func == (a: AttributeGraph.OptionalAttribute<Value>, b: AttributeGraph.OptionalAttribute<Value>) -> Swift.Bool

--- a/AG/2024/AttributeGraph.xcframework/ios-arm64-x86_64-simulator/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/arm64-apple-ios-simulator.swiftinterface
+++ b/AG/2024/AttributeGraph.xcframework/ios-arm64-x86_64-simulator/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/arm64-apple-ios-simulator.swiftinterface
@@ -1,7 +1,7 @@
 // swift-interface-format-version: 1.0
-// swift-compiler-version: Apple Swift version 6.2 effective-5.10 (swiftlang-6.2.0.16.112 clang-1800.1.29)
+// swift-compiler-version: Apple Swift version 6.3.3 effective-5.10 (swiftlang-6.3.3.1.3 clang-2100.1.1.101)
 // swift-module-flags: -target arm64-apple-ios18.0-simulator -enable-objc-interop -enable-library-evolution -swift-version 5 -Osize -enable-upcoming-feature InternalImportsByDefault -enable-experimental-feature Extern -module-name AttributeGraph
-// swift-module-flags-ignorable: -interface-compiler-version 6.2
+// swift-module-flags-ignorable: -interface-compiler-version 6.3.3
 @_exported public import AttributeGraph
 public import Swift
 public import _Concurrency
@@ -38,10 +38,8 @@ extension AttributeGraph.Graph {
   }
 }
 extension AttributeGraph.Graph {
-  #if compiler(>=5.3) && $NonescapableTypes
   @_silgen_name("AGGraphGetOutputValue")
   @inline(__always) @inlinable public static func outputValue<Value>() -> Swift.UnsafePointer<Value>?
-  #endif
   @_silgen_name("AGGraphSetOutputValue")
   @inline(__always) @inlinable public static func setOutputValue<Value>(_ value: Swift.UnsafePointer<Value>)
 }
@@ -51,9 +49,7 @@ extension AttributeGraph.Graph {
     }
 }
 extension AttributeGraph.Graph {
-  #if compiler(>=5.3) && $NonescapableTypes
   public func archiveJSON(name: Swift.String?)
-  #endif
 }
 extension AttributeGraph.Subgraph {
   public typealias Flags = AttributeGraph.AnyAttribute.Flags
@@ -214,16 +210,12 @@ public func withUnsafeMutablePointerToEnumCase<T>(of value: Swift.UnsafeMutableP
   public subscript<V>(attribute: AttributeGraph.Attribute<V>) -> V {
     unsafeAddress
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(weakAttribute: AttributeGraph.WeakAttribute<V>) -> V? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(optionalAttribute: AttributeGraph.OptionalAttribute<V>) -> V? {
     get
   }
-  #endif
   public func valueAndFlags<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, flags: AttributeGraph.AGChangedValueFlags)
   public func changedValue<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, changed: Swift.Bool)
   public func update(body: () -> Swift.Void)
@@ -236,16 +228,12 @@ public func withUnsafeMutablePointerToEnumCase<T>(of value: Swift.UnsafeMutableP
   public subscript<V>(attribute: AttributeGraph.Attribute<V>) -> V {
     unsafeAddress
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(weakAttribute: AttributeGraph.WeakAttribute<V>) -> V? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(optionalAttribute: AttributeGraph.OptionalAttribute<V>) -> V? {
     get
   }
-  #endif
   public var value: Value {
     unsafeAddress
     nonmutating set
@@ -267,40 +255,26 @@ public func withUnsafeMutablePointerToEnumCase<T>(of value: Swift.UnsafeMutableP
   public init(base: AttributeGraph.AnyWeakAttribute)
   public init()
   public init(_ attribute: AttributeGraph.Attribute<Value>)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.Attribute<Value>?)
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var wrappedValue: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var projectedValue: AttributeGraph.Attribute<Value>? {
     get
     set
     _modify
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.Attribute<Value>? {
     get
     set
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var value: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
-  #endif
 }
 extension AttributeGraph.WeakAttribute : Swift.Hashable {
   public static func == (a: AttributeGraph.WeakAttribute<Value>, b: AttributeGraph.WeakAttribute<Value>) -> Swift.Bool
@@ -315,17 +289,13 @@ extension AttributeGraph.WeakAttribute : Swift.CustomStringConvertible {
   }
 }
 extension AttributeGraph.AnyWeakAttribute {
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.AnyAttribute?)
-  #endif
   public init<Value>(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.WeakAttribute<Value>
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.AnyAttribute? {
     get
     set
   }
-  #endif
 }
 extension AttributeGraph.AnyWeakAttribute : Swift.Hashable {
   public static func == (lhs: AttributeGraph.AnyWeakAttribute, rhs: AttributeGraph.AnyWeakAttribute) -> Swift.Bool
@@ -402,17 +372,13 @@ public protocol AttributeBodyVisitor {
 }
 public protocol StatefulRule : AttributeGraph._AttributeBody {
   associatedtype Value
-  #if compiler(>=5.3) && $NonescapableTypes
   static var initialValue: Self.Value? { get }
-  #endif
   mutating func updateValue()
 }
 extension AttributeGraph.StatefulRule {
-  #if compiler(>=5.3) && $NonescapableTypes
   public static var initialValue: Self.Value? {
     get
   }
-  #endif
   public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AttributeGraph.AnyAttribute)
   public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
 }
@@ -433,17 +399,13 @@ extension AttributeGraph.StatefulRule {
 }
 public protocol Rule : AttributeGraph._AttributeBody {
   associatedtype Value
-  #if compiler(>=5.3) && $NonescapableTypes
   static var initialValue: Self.Value? { get }
-  #endif
   var value: Self.Value { get }
 }
 extension AttributeGraph.Rule {
-  #if compiler(>=5.3) && $NonescapableTypes
   public static var initialValue: Self.Value? {
     get
   }
-  #endif
   public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AttributeGraph.AnyAttribute)
   public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
 }
@@ -456,15 +418,9 @@ extension AttributeGraph.Rule {
   }
 }
 extension AttributeGraph.Rule where Self : Swift.Hashable {
-  #if compiler(>=5.3) && $NonescapableTypes
   public func cachedValue(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?) -> Self.Value
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func cachedValueIfExists(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?) -> Self.Value?
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public static func _cachedValue(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?, hashValue: Swift.Int, bodyPtr: Swift.UnsafeRawPointer, update: () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void) -> Swift.UnsafePointer<Self.Value>
-  #endif
 }
 @frozen @propertyWrapper @dynamicMemberLookup public struct Attribute<Value> {
   public var identifier: AttributeGraph.AnyAttribute
@@ -472,9 +428,7 @@ extension AttributeGraph.Rule where Self : Swift.Hashable {
   public init(_ attribute: AttributeGraph.Attribute<Value>)
   public init(value: Value)
   public init(type _: Value.Type)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init<Body>(body: Swift.UnsafePointer<Body>, value: Swift.UnsafePointer<Value>?, flags: AttributeGraph._AttributeType.Flags = [], update: () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void) where Body : AttributeGraph._AttributeBody
-  #endif
   public var wrappedValue: Value {
     unsafeAddress
     nonmutating set
@@ -546,10 +500,8 @@ extension AttributeGraph.Attribute {
   public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.Rule
   public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.StatefulRule
 }
-#if compiler(>=5.3) && $NonescapableTypes
 @_silgen_name("AGGraphCreateAttribute")
 @inline(__always) @inlinable internal func AGGraphCreateAttribute(index: Swift.Int, body: Swift.UnsafeRawPointer, value: Swift.UnsafeRawPointer?) -> AttributeGraph.AnyAttribute
-#endif
 @_silgen_name("AGGraphGetValue")
 @inline(__always) @inlinable internal func AGGraphGetValue<Value>(_ attribute: AttributeGraph.AnyAttribute, options: AttributeGraph.AGValueOptions = [], type: Value.Type = Value.self) -> AttributeGraph.AGValue
 @_silgen_name("AGGraphSetValue")
@@ -602,11 +554,9 @@ extension Swift.UnsafeMutablePointer {
 extension AttributeGraph.AnyAttribute {
   public init<Value>(_ attribute: AttributeGraph.Attribute<Value>)
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.Attribute<Value>
-  #if compiler(>=5.3) && $NonescapableTypes
   public static var current: AttributeGraph.AnyAttribute? {
     get
   }
-  #endif
   public func unsafeOffset(at offset: Swift.Int) -> AttributeGraph.AnyAttribute
   public func setFlags(_ newFlags: AttributeGraph.AnyAttribute.Flags, mask: AttributeGraph.AnyAttribute.Flags)
   public func addInput(_ attribute: AttributeGraph.AnyAttribute, options: AttributeGraph.AGInputOptions = [], token: Swift.Int)
@@ -623,12 +573,10 @@ extension AttributeGraph.AnyAttribute {
   public var valueType: any Any.Type {
     get
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public var indirectDependency: AttributeGraph.AnyAttribute? {
     get
     nonmutating set
   }
-  #endif
 }
 extension AttributeGraph.AnyAttribute : Swift.CustomStringConvertible {
   @inlinable public var description: Swift.String {
@@ -643,12 +591,10 @@ public typealias AttributeUpdateBlock = () -> (Swift.UnsafeMutableRawPointer, At
     get
     nonmutating set
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public var dependency: AttributeGraph.AnyAttribute? {
     get
     nonmutating set
   }
-  #endif
   public var value: Value {
     get
     nonmutating set
@@ -678,22 +624,16 @@ extension AttributeGraph.IndirectAttribute : Swift.Hashable {
   public var identifier: AttributeGraph.AnyAttribute
   public init()
   public init(_ attribute: AttributeGraph.AnyAttribute)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.AnyAttribute?)
-  #endif
   public init<Value>(_ attribute: AttributeGraph.OptionalAttribute<Value>)
   public static var current: AttributeGraph.AnyOptionalAttribute {
     get
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.AnyAttribute? {
     get
     set
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func map<Value>(_ body: (AttributeGraph.AnyAttribute) -> Value) -> Value?
-  #endif
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.OptionalAttribute<Value>
 }
 extension AttributeGraph.AnyOptionalAttribute : Swift.Hashable {
@@ -713,44 +653,28 @@ extension AttributeGraph.AnyOptionalAttribute : Swift.CustomStringConvertible {
   public init()
   public init(base: AttributeGraph.AnyOptionalAttribute)
   public init(_ attribute: AttributeGraph.Attribute<Value>)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.Attribute<Value>?)
-  #endif
   public init(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.Attribute<Value>? {
     get
     set
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var value: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func map<V>(_ body: (AttributeGraph.Attribute<Value>) -> V) -> V?
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var wrappedValue: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var projectedValue: AttributeGraph.Attribute<Value>? {
     get
     set
     _modify
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
     get
   }
-  #endif
 }
 extension AttributeGraph.OptionalAttribute : Swift.Hashable {
   public static func == (a: AttributeGraph.OptionalAttribute<Value>, b: AttributeGraph.OptionalAttribute<Value>) -> Swift.Bool

--- a/AG/2024/AttributeGraph.xcframework/ios-arm64-x86_64-simulator/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/x86_64-apple-ios-simulator.swiftinterface
+++ b/AG/2024/AttributeGraph.xcframework/ios-arm64-x86_64-simulator/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/x86_64-apple-ios-simulator.swiftinterface
@@ -1,7 +1,7 @@
 // swift-interface-format-version: 1.0
-// swift-compiler-version: Apple Swift version 6.2 effective-5.10 (swiftlang-6.2.0.16.112 clang-1800.1.29)
+// swift-compiler-version: Apple Swift version 6.3.3 effective-5.10 (swiftlang-6.3.3.1.3 clang-2100.1.1.101)
 // swift-module-flags: -target x86_64-apple-ios18.0-simulator -enable-objc-interop -enable-library-evolution -swift-version 5 -Osize -enable-upcoming-feature InternalImportsByDefault -enable-experimental-feature Extern -module-name AttributeGraph
-// swift-module-flags-ignorable: -interface-compiler-version 6.2
+// swift-module-flags-ignorable: -interface-compiler-version 6.3.3
 @_exported public import AttributeGraph
 public import Swift
 public import _Concurrency
@@ -38,10 +38,8 @@ extension AttributeGraph.Graph {
   }
 }
 extension AttributeGraph.Graph {
-  #if compiler(>=5.3) && $NonescapableTypes
   @_silgen_name("AGGraphGetOutputValue")
   @inline(__always) @inlinable public static func outputValue<Value>() -> Swift.UnsafePointer<Value>?
-  #endif
   @_silgen_name("AGGraphSetOutputValue")
   @inline(__always) @inlinable public static func setOutputValue<Value>(_ value: Swift.UnsafePointer<Value>)
 }
@@ -51,9 +49,7 @@ extension AttributeGraph.Graph {
     }
 }
 extension AttributeGraph.Graph {
-  #if compiler(>=5.3) && $NonescapableTypes
   public func archiveJSON(name: Swift.String?)
-  #endif
 }
 extension AttributeGraph.Subgraph {
   public typealias Flags = AttributeGraph.AnyAttribute.Flags
@@ -214,16 +210,12 @@ public func withUnsafeMutablePointerToEnumCase<T>(of value: Swift.UnsafeMutableP
   public subscript<V>(attribute: AttributeGraph.Attribute<V>) -> V {
     unsafeAddress
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(weakAttribute: AttributeGraph.WeakAttribute<V>) -> V? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(optionalAttribute: AttributeGraph.OptionalAttribute<V>) -> V? {
     get
   }
-  #endif
   public func valueAndFlags<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, flags: AttributeGraph.AGChangedValueFlags)
   public func changedValue<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, changed: Swift.Bool)
   public func update(body: () -> Swift.Void)
@@ -236,16 +228,12 @@ public func withUnsafeMutablePointerToEnumCase<T>(of value: Swift.UnsafeMutableP
   public subscript<V>(attribute: AttributeGraph.Attribute<V>) -> V {
     unsafeAddress
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(weakAttribute: AttributeGraph.WeakAttribute<V>) -> V? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(optionalAttribute: AttributeGraph.OptionalAttribute<V>) -> V? {
     get
   }
-  #endif
   public var value: Value {
     unsafeAddress
     nonmutating set
@@ -267,40 +255,26 @@ public func withUnsafeMutablePointerToEnumCase<T>(of value: Swift.UnsafeMutableP
   public init(base: AttributeGraph.AnyWeakAttribute)
   public init()
   public init(_ attribute: AttributeGraph.Attribute<Value>)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.Attribute<Value>?)
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var wrappedValue: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var projectedValue: AttributeGraph.Attribute<Value>? {
     get
     set
     _modify
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.Attribute<Value>? {
     get
     set
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var value: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
-  #endif
 }
 extension AttributeGraph.WeakAttribute : Swift.Hashable {
   public static func == (a: AttributeGraph.WeakAttribute<Value>, b: AttributeGraph.WeakAttribute<Value>) -> Swift.Bool
@@ -315,17 +289,13 @@ extension AttributeGraph.WeakAttribute : Swift.CustomStringConvertible {
   }
 }
 extension AttributeGraph.AnyWeakAttribute {
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.AnyAttribute?)
-  #endif
   public init<Value>(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.WeakAttribute<Value>
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.AnyAttribute? {
     get
     set
   }
-  #endif
 }
 extension AttributeGraph.AnyWeakAttribute : Swift.Hashable {
   public static func == (lhs: AttributeGraph.AnyWeakAttribute, rhs: AttributeGraph.AnyWeakAttribute) -> Swift.Bool
@@ -402,17 +372,13 @@ public protocol AttributeBodyVisitor {
 }
 public protocol StatefulRule : AttributeGraph._AttributeBody {
   associatedtype Value
-  #if compiler(>=5.3) && $NonescapableTypes
   static var initialValue: Self.Value? { get }
-  #endif
   mutating func updateValue()
 }
 extension AttributeGraph.StatefulRule {
-  #if compiler(>=5.3) && $NonescapableTypes
   public static var initialValue: Self.Value? {
     get
   }
-  #endif
   public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AttributeGraph.AnyAttribute)
   public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
 }
@@ -433,17 +399,13 @@ extension AttributeGraph.StatefulRule {
 }
 public protocol Rule : AttributeGraph._AttributeBody {
   associatedtype Value
-  #if compiler(>=5.3) && $NonescapableTypes
   static var initialValue: Self.Value? { get }
-  #endif
   var value: Self.Value { get }
 }
 extension AttributeGraph.Rule {
-  #if compiler(>=5.3) && $NonescapableTypes
   public static var initialValue: Self.Value? {
     get
   }
-  #endif
   public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AttributeGraph.AnyAttribute)
   public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
 }
@@ -456,15 +418,9 @@ extension AttributeGraph.Rule {
   }
 }
 extension AttributeGraph.Rule where Self : Swift.Hashable {
-  #if compiler(>=5.3) && $NonescapableTypes
   public func cachedValue(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?) -> Self.Value
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func cachedValueIfExists(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?) -> Self.Value?
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public static func _cachedValue(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?, hashValue: Swift.Int, bodyPtr: Swift.UnsafeRawPointer, update: () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void) -> Swift.UnsafePointer<Self.Value>
-  #endif
 }
 @frozen @propertyWrapper @dynamicMemberLookup public struct Attribute<Value> {
   public var identifier: AttributeGraph.AnyAttribute
@@ -472,9 +428,7 @@ extension AttributeGraph.Rule where Self : Swift.Hashable {
   public init(_ attribute: AttributeGraph.Attribute<Value>)
   public init(value: Value)
   public init(type _: Value.Type)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init<Body>(body: Swift.UnsafePointer<Body>, value: Swift.UnsafePointer<Value>?, flags: AttributeGraph._AttributeType.Flags = [], update: () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void) where Body : AttributeGraph._AttributeBody
-  #endif
   public var wrappedValue: Value {
     unsafeAddress
     nonmutating set
@@ -546,10 +500,8 @@ extension AttributeGraph.Attribute {
   public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.Rule
   public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.StatefulRule
 }
-#if compiler(>=5.3) && $NonescapableTypes
 @_silgen_name("AGGraphCreateAttribute")
 @inline(__always) @inlinable internal func AGGraphCreateAttribute(index: Swift.Int, body: Swift.UnsafeRawPointer, value: Swift.UnsafeRawPointer?) -> AttributeGraph.AnyAttribute
-#endif
 @_silgen_name("AGGraphGetValue")
 @inline(__always) @inlinable internal func AGGraphGetValue<Value>(_ attribute: AttributeGraph.AnyAttribute, options: AttributeGraph.AGValueOptions = [], type: Value.Type = Value.self) -> AttributeGraph.AGValue
 @_silgen_name("AGGraphSetValue")
@@ -602,11 +554,9 @@ extension Swift.UnsafeMutablePointer {
 extension AttributeGraph.AnyAttribute {
   public init<Value>(_ attribute: AttributeGraph.Attribute<Value>)
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.Attribute<Value>
-  #if compiler(>=5.3) && $NonescapableTypes
   public static var current: AttributeGraph.AnyAttribute? {
     get
   }
-  #endif
   public func unsafeOffset(at offset: Swift.Int) -> AttributeGraph.AnyAttribute
   public func setFlags(_ newFlags: AttributeGraph.AnyAttribute.Flags, mask: AttributeGraph.AnyAttribute.Flags)
   public func addInput(_ attribute: AttributeGraph.AnyAttribute, options: AttributeGraph.AGInputOptions = [], token: Swift.Int)
@@ -623,12 +573,10 @@ extension AttributeGraph.AnyAttribute {
   public var valueType: any Any.Type {
     get
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public var indirectDependency: AttributeGraph.AnyAttribute? {
     get
     nonmutating set
   }
-  #endif
 }
 extension AttributeGraph.AnyAttribute : Swift.CustomStringConvertible {
   @inlinable public var description: Swift.String {
@@ -643,12 +591,10 @@ public typealias AttributeUpdateBlock = () -> (Swift.UnsafeMutableRawPointer, At
     get
     nonmutating set
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public var dependency: AttributeGraph.AnyAttribute? {
     get
     nonmutating set
   }
-  #endif
   public var value: Value {
     get
     nonmutating set
@@ -678,22 +624,16 @@ extension AttributeGraph.IndirectAttribute : Swift.Hashable {
   public var identifier: AttributeGraph.AnyAttribute
   public init()
   public init(_ attribute: AttributeGraph.AnyAttribute)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.AnyAttribute?)
-  #endif
   public init<Value>(_ attribute: AttributeGraph.OptionalAttribute<Value>)
   public static var current: AttributeGraph.AnyOptionalAttribute {
     get
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.AnyAttribute? {
     get
     set
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func map<Value>(_ body: (AttributeGraph.AnyAttribute) -> Value) -> Value?
-  #endif
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.OptionalAttribute<Value>
 }
 extension AttributeGraph.AnyOptionalAttribute : Swift.Hashable {
@@ -713,44 +653,28 @@ extension AttributeGraph.AnyOptionalAttribute : Swift.CustomStringConvertible {
   public init()
   public init(base: AttributeGraph.AnyOptionalAttribute)
   public init(_ attribute: AttributeGraph.Attribute<Value>)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.Attribute<Value>?)
-  #endif
   public init(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.Attribute<Value>? {
     get
     set
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var value: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func map<V>(_ body: (AttributeGraph.Attribute<Value>) -> V) -> V?
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var wrappedValue: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var projectedValue: AttributeGraph.Attribute<Value>? {
     get
     set
     _modify
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
     get
   }
-  #endif
 }
 extension AttributeGraph.OptionalAttribute : Swift.Hashable {
   public static func == (a: AttributeGraph.OptionalAttribute<Value>, b: AttributeGraph.OptionalAttribute<Value>) -> Swift.Bool

--- a/AG/2024/AttributeGraph.xcframework/macos-arm64e-arm64-x86_64/AttributeGraph.framework/Versions/A/Modules/AttributeGraph.swiftmodule/arm64-apple-macos.swiftinterface
+++ b/AG/2024/AttributeGraph.xcframework/macos-arm64e-arm64-x86_64/AttributeGraph.framework/Versions/A/Modules/AttributeGraph.swiftmodule/arm64-apple-macos.swiftinterface
@@ -1,7 +1,7 @@
 // swift-interface-format-version: 1.0
-// swift-compiler-version: Apple Swift version 6.2 effective-5.10 (swiftlang-6.2.0.16.112 clang-1800.1.29)
+// swift-compiler-version: Apple Swift version 6.3.3 effective-5.10 (swiftlang-6.3.3.1.3 clang-2100.1.1.101)
 // swift-module-flags: -target arm64-apple-macos15.0 -enable-objc-interop -enable-library-evolution -swift-version 5 -Osize -enable-upcoming-feature InternalImportsByDefault -enable-experimental-feature Extern -module-name AttributeGraph
-// swift-module-flags-ignorable: -interface-compiler-version 6.2
+// swift-module-flags-ignorable: -interface-compiler-version 6.3.3
 @_exported public import AttributeGraph
 public import Swift
 public import _Concurrency
@@ -38,10 +38,8 @@ extension AttributeGraph.Graph {
   }
 }
 extension AttributeGraph.Graph {
-  #if compiler(>=5.3) && $NonescapableTypes
   @_silgen_name("AGGraphGetOutputValue")
   @inline(__always) @inlinable public static func outputValue<Value>() -> Swift.UnsafePointer<Value>?
-  #endif
   @_silgen_name("AGGraphSetOutputValue")
   @inline(__always) @inlinable public static func setOutputValue<Value>(_ value: Swift.UnsafePointer<Value>)
 }
@@ -51,9 +49,7 @@ extension AttributeGraph.Graph {
     }
 }
 extension AttributeGraph.Graph {
-  #if compiler(>=5.3) && $NonescapableTypes
   public func archiveJSON(name: Swift.String?)
-  #endif
 }
 extension AttributeGraph.Subgraph {
   public typealias Flags = AttributeGraph.AnyAttribute.Flags
@@ -214,16 +210,12 @@ public func withUnsafeMutablePointerToEnumCase<T>(of value: Swift.UnsafeMutableP
   public subscript<V>(attribute: AttributeGraph.Attribute<V>) -> V {
     unsafeAddress
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(weakAttribute: AttributeGraph.WeakAttribute<V>) -> V? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(optionalAttribute: AttributeGraph.OptionalAttribute<V>) -> V? {
     get
   }
-  #endif
   public func valueAndFlags<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, flags: AttributeGraph.AGChangedValueFlags)
   public func changedValue<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, changed: Swift.Bool)
   public func update(body: () -> Swift.Void)
@@ -236,16 +228,12 @@ public func withUnsafeMutablePointerToEnumCase<T>(of value: Swift.UnsafeMutableP
   public subscript<V>(attribute: AttributeGraph.Attribute<V>) -> V {
     unsafeAddress
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(weakAttribute: AttributeGraph.WeakAttribute<V>) -> V? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(optionalAttribute: AttributeGraph.OptionalAttribute<V>) -> V? {
     get
   }
-  #endif
   public var value: Value {
     unsafeAddress
     nonmutating set
@@ -267,40 +255,26 @@ public func withUnsafeMutablePointerToEnumCase<T>(of value: Swift.UnsafeMutableP
   public init(base: AttributeGraph.AnyWeakAttribute)
   public init()
   public init(_ attribute: AttributeGraph.Attribute<Value>)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.Attribute<Value>?)
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var wrappedValue: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var projectedValue: AttributeGraph.Attribute<Value>? {
     get
     set
     _modify
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.Attribute<Value>? {
     get
     set
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var value: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
-  #endif
 }
 extension AttributeGraph.WeakAttribute : Swift.Hashable {
   public static func == (a: AttributeGraph.WeakAttribute<Value>, b: AttributeGraph.WeakAttribute<Value>) -> Swift.Bool
@@ -315,17 +289,13 @@ extension AttributeGraph.WeakAttribute : Swift.CustomStringConvertible {
   }
 }
 extension AttributeGraph.AnyWeakAttribute {
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.AnyAttribute?)
-  #endif
   public init<Value>(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.WeakAttribute<Value>
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.AnyAttribute? {
     get
     set
   }
-  #endif
 }
 extension AttributeGraph.AnyWeakAttribute : Swift.Hashable {
   public static func == (lhs: AttributeGraph.AnyWeakAttribute, rhs: AttributeGraph.AnyWeakAttribute) -> Swift.Bool
@@ -402,17 +372,13 @@ public protocol AttributeBodyVisitor {
 }
 public protocol StatefulRule : AttributeGraph._AttributeBody {
   associatedtype Value
-  #if compiler(>=5.3) && $NonescapableTypes
   static var initialValue: Self.Value? { get }
-  #endif
   mutating func updateValue()
 }
 extension AttributeGraph.StatefulRule {
-  #if compiler(>=5.3) && $NonescapableTypes
   public static var initialValue: Self.Value? {
     get
   }
-  #endif
   public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AttributeGraph.AnyAttribute)
   public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
 }
@@ -433,17 +399,13 @@ extension AttributeGraph.StatefulRule {
 }
 public protocol Rule : AttributeGraph._AttributeBody {
   associatedtype Value
-  #if compiler(>=5.3) && $NonescapableTypes
   static var initialValue: Self.Value? { get }
-  #endif
   var value: Self.Value { get }
 }
 extension AttributeGraph.Rule {
-  #if compiler(>=5.3) && $NonescapableTypes
   public static var initialValue: Self.Value? {
     get
   }
-  #endif
   public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AttributeGraph.AnyAttribute)
   public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
 }
@@ -456,15 +418,9 @@ extension AttributeGraph.Rule {
   }
 }
 extension AttributeGraph.Rule where Self : Swift.Hashable {
-  #if compiler(>=5.3) && $NonescapableTypes
   public func cachedValue(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?) -> Self.Value
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func cachedValueIfExists(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?) -> Self.Value?
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public static func _cachedValue(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?, hashValue: Swift.Int, bodyPtr: Swift.UnsafeRawPointer, update: () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void) -> Swift.UnsafePointer<Self.Value>
-  #endif
 }
 @frozen @propertyWrapper @dynamicMemberLookup public struct Attribute<Value> {
   public var identifier: AttributeGraph.AnyAttribute
@@ -472,9 +428,7 @@ extension AttributeGraph.Rule where Self : Swift.Hashable {
   public init(_ attribute: AttributeGraph.Attribute<Value>)
   public init(value: Value)
   public init(type _: Value.Type)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init<Body>(body: Swift.UnsafePointer<Body>, value: Swift.UnsafePointer<Value>?, flags: AttributeGraph._AttributeType.Flags = [], update: () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void) where Body : AttributeGraph._AttributeBody
-  #endif
   public var wrappedValue: Value {
     unsafeAddress
     nonmutating set
@@ -546,10 +500,8 @@ extension AttributeGraph.Attribute {
   public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.Rule
   public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.StatefulRule
 }
-#if compiler(>=5.3) && $NonescapableTypes
 @_silgen_name("AGGraphCreateAttribute")
 @inline(__always) @inlinable internal func AGGraphCreateAttribute(index: Swift.Int, body: Swift.UnsafeRawPointer, value: Swift.UnsafeRawPointer?) -> AttributeGraph.AnyAttribute
-#endif
 @_silgen_name("AGGraphGetValue")
 @inline(__always) @inlinable internal func AGGraphGetValue<Value>(_ attribute: AttributeGraph.AnyAttribute, options: AttributeGraph.AGValueOptions = [], type: Value.Type = Value.self) -> AttributeGraph.AGValue
 @_silgen_name("AGGraphSetValue")
@@ -602,11 +554,9 @@ extension Swift.UnsafeMutablePointer {
 extension AttributeGraph.AnyAttribute {
   public init<Value>(_ attribute: AttributeGraph.Attribute<Value>)
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.Attribute<Value>
-  #if compiler(>=5.3) && $NonescapableTypes
   public static var current: AttributeGraph.AnyAttribute? {
     get
   }
-  #endif
   public func unsafeOffset(at offset: Swift.Int) -> AttributeGraph.AnyAttribute
   public func setFlags(_ newFlags: AttributeGraph.AnyAttribute.Flags, mask: AttributeGraph.AnyAttribute.Flags)
   public func addInput(_ attribute: AttributeGraph.AnyAttribute, options: AttributeGraph.AGInputOptions = [], token: Swift.Int)
@@ -623,12 +573,10 @@ extension AttributeGraph.AnyAttribute {
   public var valueType: any Any.Type {
     get
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public var indirectDependency: AttributeGraph.AnyAttribute? {
     get
     nonmutating set
   }
-  #endif
 }
 extension AttributeGraph.AnyAttribute : Swift.CustomStringConvertible {
   @inlinable public var description: Swift.String {
@@ -643,12 +591,10 @@ public typealias AttributeUpdateBlock = () -> (Swift.UnsafeMutableRawPointer, At
     get
     nonmutating set
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public var dependency: AttributeGraph.AnyAttribute? {
     get
     nonmutating set
   }
-  #endif
   public var value: Value {
     get
     nonmutating set
@@ -678,22 +624,16 @@ extension AttributeGraph.IndirectAttribute : Swift.Hashable {
   public var identifier: AttributeGraph.AnyAttribute
   public init()
   public init(_ attribute: AttributeGraph.AnyAttribute)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.AnyAttribute?)
-  #endif
   public init<Value>(_ attribute: AttributeGraph.OptionalAttribute<Value>)
   public static var current: AttributeGraph.AnyOptionalAttribute {
     get
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.AnyAttribute? {
     get
     set
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func map<Value>(_ body: (AttributeGraph.AnyAttribute) -> Value) -> Value?
-  #endif
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.OptionalAttribute<Value>
 }
 extension AttributeGraph.AnyOptionalAttribute : Swift.Hashable {
@@ -713,44 +653,28 @@ extension AttributeGraph.AnyOptionalAttribute : Swift.CustomStringConvertible {
   public init()
   public init(base: AttributeGraph.AnyOptionalAttribute)
   public init(_ attribute: AttributeGraph.Attribute<Value>)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.Attribute<Value>?)
-  #endif
   public init(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.Attribute<Value>? {
     get
     set
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var value: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func map<V>(_ body: (AttributeGraph.Attribute<Value>) -> V) -> V?
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var wrappedValue: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var projectedValue: AttributeGraph.Attribute<Value>? {
     get
     set
     _modify
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
     get
   }
-  #endif
 }
 extension AttributeGraph.OptionalAttribute : Swift.Hashable {
   public static func == (a: AttributeGraph.OptionalAttribute<Value>, b: AttributeGraph.OptionalAttribute<Value>) -> Swift.Bool

--- a/AG/2024/AttributeGraph.xcframework/macos-arm64e-arm64-x86_64/AttributeGraph.framework/Versions/A/Modules/AttributeGraph.swiftmodule/arm64e-apple-macos.swiftinterface
+++ b/AG/2024/AttributeGraph.xcframework/macos-arm64e-arm64-x86_64/AttributeGraph.framework/Versions/A/Modules/AttributeGraph.swiftmodule/arm64e-apple-macos.swiftinterface
@@ -1,7 +1,7 @@
 // swift-interface-format-version: 1.0
-// swift-compiler-version: Apple Swift version 6.2 effective-5.10 (swiftlang-6.2.0.16.112 clang-1800.1.29)
+// swift-compiler-version: Apple Swift version 6.3.3 effective-5.10 (swiftlang-6.3.3.1.3 clang-2100.1.1.101)
 // swift-module-flags: -target arm64e-apple-macos15.0 -enable-objc-interop -enable-library-evolution -swift-version 5 -Osize -enable-upcoming-feature InternalImportsByDefault -enable-experimental-feature Extern -module-name AttributeGraph
-// swift-module-flags-ignorable: -interface-compiler-version 6.2
+// swift-module-flags-ignorable: -interface-compiler-version 6.3.3
 @_exported public import AttributeGraph
 public import Swift
 public import _Concurrency
@@ -38,10 +38,8 @@ extension AttributeGraph.Graph {
   }
 }
 extension AttributeGraph.Graph {
-  #if compiler(>=5.3) && $NonescapableTypes
   @_silgen_name("AGGraphGetOutputValue")
   @inline(__always) @inlinable public static func outputValue<Value>() -> Swift.UnsafePointer<Value>?
-  #endif
   @_silgen_name("AGGraphSetOutputValue")
   @inline(__always) @inlinable public static func setOutputValue<Value>(_ value: Swift.UnsafePointer<Value>)
 }
@@ -51,9 +49,7 @@ extension AttributeGraph.Graph {
     }
 }
 extension AttributeGraph.Graph {
-  #if compiler(>=5.3) && $NonescapableTypes
   public func archiveJSON(name: Swift.String?)
-  #endif
 }
 extension AttributeGraph.Subgraph {
   public typealias Flags = AttributeGraph.AnyAttribute.Flags
@@ -214,16 +210,12 @@ public func withUnsafeMutablePointerToEnumCase<T>(of value: Swift.UnsafeMutableP
   public subscript<V>(attribute: AttributeGraph.Attribute<V>) -> V {
     unsafeAddress
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(weakAttribute: AttributeGraph.WeakAttribute<V>) -> V? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(optionalAttribute: AttributeGraph.OptionalAttribute<V>) -> V? {
     get
   }
-  #endif
   public func valueAndFlags<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, flags: AttributeGraph.AGChangedValueFlags)
   public func changedValue<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, changed: Swift.Bool)
   public func update(body: () -> Swift.Void)
@@ -236,16 +228,12 @@ public func withUnsafeMutablePointerToEnumCase<T>(of value: Swift.UnsafeMutableP
   public subscript<V>(attribute: AttributeGraph.Attribute<V>) -> V {
     unsafeAddress
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(weakAttribute: AttributeGraph.WeakAttribute<V>) -> V? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(optionalAttribute: AttributeGraph.OptionalAttribute<V>) -> V? {
     get
   }
-  #endif
   public var value: Value {
     unsafeAddress
     nonmutating set
@@ -267,40 +255,26 @@ public func withUnsafeMutablePointerToEnumCase<T>(of value: Swift.UnsafeMutableP
   public init(base: AttributeGraph.AnyWeakAttribute)
   public init()
   public init(_ attribute: AttributeGraph.Attribute<Value>)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.Attribute<Value>?)
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var wrappedValue: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var projectedValue: AttributeGraph.Attribute<Value>? {
     get
     set
     _modify
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.Attribute<Value>? {
     get
     set
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var value: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
-  #endif
 }
 extension AttributeGraph.WeakAttribute : Swift.Hashable {
   public static func == (a: AttributeGraph.WeakAttribute<Value>, b: AttributeGraph.WeakAttribute<Value>) -> Swift.Bool
@@ -315,17 +289,13 @@ extension AttributeGraph.WeakAttribute : Swift.CustomStringConvertible {
   }
 }
 extension AttributeGraph.AnyWeakAttribute {
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.AnyAttribute?)
-  #endif
   public init<Value>(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.WeakAttribute<Value>
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.AnyAttribute? {
     get
     set
   }
-  #endif
 }
 extension AttributeGraph.AnyWeakAttribute : Swift.Hashable {
   public static func == (lhs: AttributeGraph.AnyWeakAttribute, rhs: AttributeGraph.AnyWeakAttribute) -> Swift.Bool
@@ -402,17 +372,13 @@ public protocol AttributeBodyVisitor {
 }
 public protocol StatefulRule : AttributeGraph._AttributeBody {
   associatedtype Value
-  #if compiler(>=5.3) && $NonescapableTypes
   static var initialValue: Self.Value? { get }
-  #endif
   mutating func updateValue()
 }
 extension AttributeGraph.StatefulRule {
-  #if compiler(>=5.3) && $NonescapableTypes
   public static var initialValue: Self.Value? {
     get
   }
-  #endif
   public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AttributeGraph.AnyAttribute)
   public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
 }
@@ -433,17 +399,13 @@ extension AttributeGraph.StatefulRule {
 }
 public protocol Rule : AttributeGraph._AttributeBody {
   associatedtype Value
-  #if compiler(>=5.3) && $NonescapableTypes
   static var initialValue: Self.Value? { get }
-  #endif
   var value: Self.Value { get }
 }
 extension AttributeGraph.Rule {
-  #if compiler(>=5.3) && $NonescapableTypes
   public static var initialValue: Self.Value? {
     get
   }
-  #endif
   public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AttributeGraph.AnyAttribute)
   public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
 }
@@ -456,15 +418,9 @@ extension AttributeGraph.Rule {
   }
 }
 extension AttributeGraph.Rule where Self : Swift.Hashable {
-  #if compiler(>=5.3) && $NonescapableTypes
   public func cachedValue(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?) -> Self.Value
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func cachedValueIfExists(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?) -> Self.Value?
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public static func _cachedValue(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?, hashValue: Swift.Int, bodyPtr: Swift.UnsafeRawPointer, update: () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void) -> Swift.UnsafePointer<Self.Value>
-  #endif
 }
 @frozen @propertyWrapper @dynamicMemberLookup public struct Attribute<Value> {
   public var identifier: AttributeGraph.AnyAttribute
@@ -472,9 +428,7 @@ extension AttributeGraph.Rule where Self : Swift.Hashable {
   public init(_ attribute: AttributeGraph.Attribute<Value>)
   public init(value: Value)
   public init(type _: Value.Type)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init<Body>(body: Swift.UnsafePointer<Body>, value: Swift.UnsafePointer<Value>?, flags: AttributeGraph._AttributeType.Flags = [], update: () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void) where Body : AttributeGraph._AttributeBody
-  #endif
   public var wrappedValue: Value {
     unsafeAddress
     nonmutating set
@@ -546,10 +500,8 @@ extension AttributeGraph.Attribute {
   public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.Rule
   public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.StatefulRule
 }
-#if compiler(>=5.3) && $NonescapableTypes
 @_silgen_name("AGGraphCreateAttribute")
 @inline(__always) @inlinable internal func AGGraphCreateAttribute(index: Swift.Int, body: Swift.UnsafeRawPointer, value: Swift.UnsafeRawPointer?) -> AttributeGraph.AnyAttribute
-#endif
 @_silgen_name("AGGraphGetValue")
 @inline(__always) @inlinable internal func AGGraphGetValue<Value>(_ attribute: AttributeGraph.AnyAttribute, options: AttributeGraph.AGValueOptions = [], type: Value.Type = Value.self) -> AttributeGraph.AGValue
 @_silgen_name("AGGraphSetValue")
@@ -602,11 +554,9 @@ extension Swift.UnsafeMutablePointer {
 extension AttributeGraph.AnyAttribute {
   public init<Value>(_ attribute: AttributeGraph.Attribute<Value>)
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.Attribute<Value>
-  #if compiler(>=5.3) && $NonescapableTypes
   public static var current: AttributeGraph.AnyAttribute? {
     get
   }
-  #endif
   public func unsafeOffset(at offset: Swift.Int) -> AttributeGraph.AnyAttribute
   public func setFlags(_ newFlags: AttributeGraph.AnyAttribute.Flags, mask: AttributeGraph.AnyAttribute.Flags)
   public func addInput(_ attribute: AttributeGraph.AnyAttribute, options: AttributeGraph.AGInputOptions = [], token: Swift.Int)
@@ -623,12 +573,10 @@ extension AttributeGraph.AnyAttribute {
   public var valueType: any Any.Type {
     get
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public var indirectDependency: AttributeGraph.AnyAttribute? {
     get
     nonmutating set
   }
-  #endif
 }
 extension AttributeGraph.AnyAttribute : Swift.CustomStringConvertible {
   @inlinable public var description: Swift.String {
@@ -643,12 +591,10 @@ public typealias AttributeUpdateBlock = () -> (Swift.UnsafeMutableRawPointer, At
     get
     nonmutating set
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public var dependency: AttributeGraph.AnyAttribute? {
     get
     nonmutating set
   }
-  #endif
   public var value: Value {
     get
     nonmutating set
@@ -678,22 +624,16 @@ extension AttributeGraph.IndirectAttribute : Swift.Hashable {
   public var identifier: AttributeGraph.AnyAttribute
   public init()
   public init(_ attribute: AttributeGraph.AnyAttribute)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.AnyAttribute?)
-  #endif
   public init<Value>(_ attribute: AttributeGraph.OptionalAttribute<Value>)
   public static var current: AttributeGraph.AnyOptionalAttribute {
     get
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.AnyAttribute? {
     get
     set
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func map<Value>(_ body: (AttributeGraph.AnyAttribute) -> Value) -> Value?
-  #endif
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.OptionalAttribute<Value>
 }
 extension AttributeGraph.AnyOptionalAttribute : Swift.Hashable {
@@ -713,44 +653,28 @@ extension AttributeGraph.AnyOptionalAttribute : Swift.CustomStringConvertible {
   public init()
   public init(base: AttributeGraph.AnyOptionalAttribute)
   public init(_ attribute: AttributeGraph.Attribute<Value>)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.Attribute<Value>?)
-  #endif
   public init(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.Attribute<Value>? {
     get
     set
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var value: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func map<V>(_ body: (AttributeGraph.Attribute<Value>) -> V) -> V?
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var wrappedValue: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var projectedValue: AttributeGraph.Attribute<Value>? {
     get
     set
     _modify
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
     get
   }
-  #endif
 }
 extension AttributeGraph.OptionalAttribute : Swift.Hashable {
   public static func == (a: AttributeGraph.OptionalAttribute<Value>, b: AttributeGraph.OptionalAttribute<Value>) -> Swift.Bool

--- a/AG/2024/AttributeGraph.xcframework/macos-arm64e-arm64-x86_64/AttributeGraph.framework/Versions/A/Modules/AttributeGraph.swiftmodule/x86_64-apple-macos.swiftinterface
+++ b/AG/2024/AttributeGraph.xcframework/macos-arm64e-arm64-x86_64/AttributeGraph.framework/Versions/A/Modules/AttributeGraph.swiftmodule/x86_64-apple-macos.swiftinterface
@@ -1,7 +1,7 @@
 // swift-interface-format-version: 1.0
-// swift-compiler-version: Apple Swift version 6.2 effective-5.10 (swiftlang-6.2.0.16.112 clang-1800.1.29)
+// swift-compiler-version: Apple Swift version 6.3.3 effective-5.10 (swiftlang-6.3.3.1.3 clang-2100.1.1.101)
 // swift-module-flags: -target x86_64-apple-macos15.0 -enable-objc-interop -enable-library-evolution -swift-version 5 -Osize -enable-upcoming-feature InternalImportsByDefault -enable-experimental-feature Extern -module-name AttributeGraph
-// swift-module-flags-ignorable: -interface-compiler-version 6.2
+// swift-module-flags-ignorable: -interface-compiler-version 6.3.3
 @_exported public import AttributeGraph
 public import Swift
 public import _Concurrency
@@ -38,10 +38,8 @@ extension AttributeGraph.Graph {
   }
 }
 extension AttributeGraph.Graph {
-  #if compiler(>=5.3) && $NonescapableTypes
   @_silgen_name("AGGraphGetOutputValue")
   @inline(__always) @inlinable public static func outputValue<Value>() -> Swift.UnsafePointer<Value>?
-  #endif
   @_silgen_name("AGGraphSetOutputValue")
   @inline(__always) @inlinable public static func setOutputValue<Value>(_ value: Swift.UnsafePointer<Value>)
 }
@@ -51,9 +49,7 @@ extension AttributeGraph.Graph {
     }
 }
 extension AttributeGraph.Graph {
-  #if compiler(>=5.3) && $NonescapableTypes
   public func archiveJSON(name: Swift.String?)
-  #endif
 }
 extension AttributeGraph.Subgraph {
   public typealias Flags = AttributeGraph.AnyAttribute.Flags
@@ -214,16 +210,12 @@ public func withUnsafeMutablePointerToEnumCase<T>(of value: Swift.UnsafeMutableP
   public subscript<V>(attribute: AttributeGraph.Attribute<V>) -> V {
     unsafeAddress
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(weakAttribute: AttributeGraph.WeakAttribute<V>) -> V? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(optionalAttribute: AttributeGraph.OptionalAttribute<V>) -> V? {
     get
   }
-  #endif
   public func valueAndFlags<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, flags: AttributeGraph.AGChangedValueFlags)
   public func changedValue<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, changed: Swift.Bool)
   public func update(body: () -> Swift.Void)
@@ -236,16 +228,12 @@ public func withUnsafeMutablePointerToEnumCase<T>(of value: Swift.UnsafeMutableP
   public subscript<V>(attribute: AttributeGraph.Attribute<V>) -> V {
     unsafeAddress
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(weakAttribute: AttributeGraph.WeakAttribute<V>) -> V? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(optionalAttribute: AttributeGraph.OptionalAttribute<V>) -> V? {
     get
   }
-  #endif
   public var value: Value {
     unsafeAddress
     nonmutating set
@@ -267,40 +255,26 @@ public func withUnsafeMutablePointerToEnumCase<T>(of value: Swift.UnsafeMutableP
   public init(base: AttributeGraph.AnyWeakAttribute)
   public init()
   public init(_ attribute: AttributeGraph.Attribute<Value>)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.Attribute<Value>?)
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var wrappedValue: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var projectedValue: AttributeGraph.Attribute<Value>? {
     get
     set
     _modify
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.Attribute<Value>? {
     get
     set
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var value: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
-  #endif
 }
 extension AttributeGraph.WeakAttribute : Swift.Hashable {
   public static func == (a: AttributeGraph.WeakAttribute<Value>, b: AttributeGraph.WeakAttribute<Value>) -> Swift.Bool
@@ -315,17 +289,13 @@ extension AttributeGraph.WeakAttribute : Swift.CustomStringConvertible {
   }
 }
 extension AttributeGraph.AnyWeakAttribute {
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.AnyAttribute?)
-  #endif
   public init<Value>(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.WeakAttribute<Value>
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.AnyAttribute? {
     get
     set
   }
-  #endif
 }
 extension AttributeGraph.AnyWeakAttribute : Swift.Hashable {
   public static func == (lhs: AttributeGraph.AnyWeakAttribute, rhs: AttributeGraph.AnyWeakAttribute) -> Swift.Bool
@@ -402,17 +372,13 @@ public protocol AttributeBodyVisitor {
 }
 public protocol StatefulRule : AttributeGraph._AttributeBody {
   associatedtype Value
-  #if compiler(>=5.3) && $NonescapableTypes
   static var initialValue: Self.Value? { get }
-  #endif
   mutating func updateValue()
 }
 extension AttributeGraph.StatefulRule {
-  #if compiler(>=5.3) && $NonescapableTypes
   public static var initialValue: Self.Value? {
     get
   }
-  #endif
   public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AttributeGraph.AnyAttribute)
   public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
 }
@@ -433,17 +399,13 @@ extension AttributeGraph.StatefulRule {
 }
 public protocol Rule : AttributeGraph._AttributeBody {
   associatedtype Value
-  #if compiler(>=5.3) && $NonescapableTypes
   static var initialValue: Self.Value? { get }
-  #endif
   var value: Self.Value { get }
 }
 extension AttributeGraph.Rule {
-  #if compiler(>=5.3) && $NonescapableTypes
   public static var initialValue: Self.Value? {
     get
   }
-  #endif
   public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AttributeGraph.AnyAttribute)
   public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
 }
@@ -456,15 +418,9 @@ extension AttributeGraph.Rule {
   }
 }
 extension AttributeGraph.Rule where Self : Swift.Hashable {
-  #if compiler(>=5.3) && $NonescapableTypes
   public func cachedValue(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?) -> Self.Value
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func cachedValueIfExists(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?) -> Self.Value?
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public static func _cachedValue(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?, hashValue: Swift.Int, bodyPtr: Swift.UnsafeRawPointer, update: () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void) -> Swift.UnsafePointer<Self.Value>
-  #endif
 }
 @frozen @propertyWrapper @dynamicMemberLookup public struct Attribute<Value> {
   public var identifier: AttributeGraph.AnyAttribute
@@ -472,9 +428,7 @@ extension AttributeGraph.Rule where Self : Swift.Hashable {
   public init(_ attribute: AttributeGraph.Attribute<Value>)
   public init(value: Value)
   public init(type _: Value.Type)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init<Body>(body: Swift.UnsafePointer<Body>, value: Swift.UnsafePointer<Value>?, flags: AttributeGraph._AttributeType.Flags = [], update: () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void) where Body : AttributeGraph._AttributeBody
-  #endif
   public var wrappedValue: Value {
     unsafeAddress
     nonmutating set
@@ -546,10 +500,8 @@ extension AttributeGraph.Attribute {
   public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.Rule
   public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.StatefulRule
 }
-#if compiler(>=5.3) && $NonescapableTypes
 @_silgen_name("AGGraphCreateAttribute")
 @inline(__always) @inlinable internal func AGGraphCreateAttribute(index: Swift.Int, body: Swift.UnsafeRawPointer, value: Swift.UnsafeRawPointer?) -> AttributeGraph.AnyAttribute
-#endif
 @_silgen_name("AGGraphGetValue")
 @inline(__always) @inlinable internal func AGGraphGetValue<Value>(_ attribute: AttributeGraph.AnyAttribute, options: AttributeGraph.AGValueOptions = [], type: Value.Type = Value.self) -> AttributeGraph.AGValue
 @_silgen_name("AGGraphSetValue")
@@ -602,11 +554,9 @@ extension Swift.UnsafeMutablePointer {
 extension AttributeGraph.AnyAttribute {
   public init<Value>(_ attribute: AttributeGraph.Attribute<Value>)
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.Attribute<Value>
-  #if compiler(>=5.3) && $NonescapableTypes
   public static var current: AttributeGraph.AnyAttribute? {
     get
   }
-  #endif
   public func unsafeOffset(at offset: Swift.Int) -> AttributeGraph.AnyAttribute
   public func setFlags(_ newFlags: AttributeGraph.AnyAttribute.Flags, mask: AttributeGraph.AnyAttribute.Flags)
   public func addInput(_ attribute: AttributeGraph.AnyAttribute, options: AttributeGraph.AGInputOptions = [], token: Swift.Int)
@@ -623,12 +573,10 @@ extension AttributeGraph.AnyAttribute {
   public var valueType: any Any.Type {
     get
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public var indirectDependency: AttributeGraph.AnyAttribute? {
     get
     nonmutating set
   }
-  #endif
 }
 extension AttributeGraph.AnyAttribute : Swift.CustomStringConvertible {
   @inlinable public var description: Swift.String {
@@ -643,12 +591,10 @@ public typealias AttributeUpdateBlock = () -> (Swift.UnsafeMutableRawPointer, At
     get
     nonmutating set
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public var dependency: AttributeGraph.AnyAttribute? {
     get
     nonmutating set
   }
-  #endif
   public var value: Value {
     get
     nonmutating set
@@ -678,22 +624,16 @@ extension AttributeGraph.IndirectAttribute : Swift.Hashable {
   public var identifier: AttributeGraph.AnyAttribute
   public init()
   public init(_ attribute: AttributeGraph.AnyAttribute)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.AnyAttribute?)
-  #endif
   public init<Value>(_ attribute: AttributeGraph.OptionalAttribute<Value>)
   public static var current: AttributeGraph.AnyOptionalAttribute {
     get
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.AnyAttribute? {
     get
     set
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func map<Value>(_ body: (AttributeGraph.AnyAttribute) -> Value) -> Value?
-  #endif
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.OptionalAttribute<Value>
 }
 extension AttributeGraph.AnyOptionalAttribute : Swift.Hashable {
@@ -713,44 +653,28 @@ extension AttributeGraph.AnyOptionalAttribute : Swift.CustomStringConvertible {
   public init()
   public init(base: AttributeGraph.AnyOptionalAttribute)
   public init(_ attribute: AttributeGraph.Attribute<Value>)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.Attribute<Value>?)
-  #endif
   public init(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.Attribute<Value>? {
     get
     set
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var value: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func map<V>(_ body: (AttributeGraph.Attribute<Value>) -> V) -> V?
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var wrappedValue: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var projectedValue: AttributeGraph.Attribute<Value>? {
     get
     set
     _modify
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
     get
   }
-  #endif
 }
 extension AttributeGraph.OptionalAttribute : Swift.Hashable {
   public static func == (a: AttributeGraph.OptionalAttribute<Value>, b: AttributeGraph.OptionalAttribute<Value>) -> Swift.Bool

--- a/AG/2024/AttributeGraph.xcframework/xros-arm64-x86_64-simulator/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/arm64-apple-xros-simulator.swiftinterface
+++ b/AG/2024/AttributeGraph.xcframework/xros-arm64-x86_64-simulator/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/arm64-apple-xros-simulator.swiftinterface
@@ -1,7 +1,7 @@
 // swift-interface-format-version: 1.0
-// swift-compiler-version: Apple Swift version 6.2 effective-5.10 (swiftlang-6.2.0.16.112 clang-1800.1.29)
+// swift-compiler-version: Apple Swift version 6.3.3 effective-5.10 (swiftlang-6.3.3.1.3 clang-2100.1.1.101)
 // swift-module-flags: -target arm64-apple-xros2.0-simulator -enable-objc-interop -enable-library-evolution -swift-version 5 -Osize -enable-upcoming-feature InternalImportsByDefault -enable-experimental-feature Extern -module-name AttributeGraph
-// swift-module-flags-ignorable: -interface-compiler-version 6.2
+// swift-module-flags-ignorable: -interface-compiler-version 6.3.3
 @_exported public import AttributeGraph
 public import Swift
 public import _Concurrency
@@ -38,10 +38,8 @@ extension AttributeGraph.Graph {
   }
 }
 extension AttributeGraph.Graph {
-  #if compiler(>=5.3) && $NonescapableTypes
   @_silgen_name("AGGraphGetOutputValue")
   @inline(__always) @inlinable public static func outputValue<Value>() -> Swift.UnsafePointer<Value>?
-  #endif
   @_silgen_name("AGGraphSetOutputValue")
   @inline(__always) @inlinable public static func setOutputValue<Value>(_ value: Swift.UnsafePointer<Value>)
 }
@@ -51,9 +49,7 @@ extension AttributeGraph.Graph {
     }
 }
 extension AttributeGraph.Graph {
-  #if compiler(>=5.3) && $NonescapableTypes
   public func archiveJSON(name: Swift.String?)
-  #endif
 }
 extension AttributeGraph.Subgraph {
   public typealias Flags = AttributeGraph.AnyAttribute.Flags
@@ -214,16 +210,12 @@ public func withUnsafeMutablePointerToEnumCase<T>(of value: Swift.UnsafeMutableP
   public subscript<V>(attribute: AttributeGraph.Attribute<V>) -> V {
     unsafeAddress
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(weakAttribute: AttributeGraph.WeakAttribute<V>) -> V? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(optionalAttribute: AttributeGraph.OptionalAttribute<V>) -> V? {
     get
   }
-  #endif
   public func valueAndFlags<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, flags: AttributeGraph.AGChangedValueFlags)
   public func changedValue<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, changed: Swift.Bool)
   public func update(body: () -> Swift.Void)
@@ -236,16 +228,12 @@ public func withUnsafeMutablePointerToEnumCase<T>(of value: Swift.UnsafeMutableP
   public subscript<V>(attribute: AttributeGraph.Attribute<V>) -> V {
     unsafeAddress
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(weakAttribute: AttributeGraph.WeakAttribute<V>) -> V? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(optionalAttribute: AttributeGraph.OptionalAttribute<V>) -> V? {
     get
   }
-  #endif
   public var value: Value {
     unsafeAddress
     nonmutating set
@@ -267,40 +255,26 @@ public func withUnsafeMutablePointerToEnumCase<T>(of value: Swift.UnsafeMutableP
   public init(base: AttributeGraph.AnyWeakAttribute)
   public init()
   public init(_ attribute: AttributeGraph.Attribute<Value>)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.Attribute<Value>?)
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var wrappedValue: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var projectedValue: AttributeGraph.Attribute<Value>? {
     get
     set
     _modify
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.Attribute<Value>? {
     get
     set
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var value: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
-  #endif
 }
 extension AttributeGraph.WeakAttribute : Swift.Hashable {
   public static func == (a: AttributeGraph.WeakAttribute<Value>, b: AttributeGraph.WeakAttribute<Value>) -> Swift.Bool
@@ -315,17 +289,13 @@ extension AttributeGraph.WeakAttribute : Swift.CustomStringConvertible {
   }
 }
 extension AttributeGraph.AnyWeakAttribute {
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.AnyAttribute?)
-  #endif
   public init<Value>(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.WeakAttribute<Value>
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.AnyAttribute? {
     get
     set
   }
-  #endif
 }
 extension AttributeGraph.AnyWeakAttribute : Swift.Hashable {
   public static func == (lhs: AttributeGraph.AnyWeakAttribute, rhs: AttributeGraph.AnyWeakAttribute) -> Swift.Bool
@@ -402,17 +372,13 @@ public protocol AttributeBodyVisitor {
 }
 public protocol StatefulRule : AttributeGraph._AttributeBody {
   associatedtype Value
-  #if compiler(>=5.3) && $NonescapableTypes
   static var initialValue: Self.Value? { get }
-  #endif
   mutating func updateValue()
 }
 extension AttributeGraph.StatefulRule {
-  #if compiler(>=5.3) && $NonescapableTypes
   public static var initialValue: Self.Value? {
     get
   }
-  #endif
   public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AttributeGraph.AnyAttribute)
   public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
 }
@@ -433,17 +399,13 @@ extension AttributeGraph.StatefulRule {
 }
 public protocol Rule : AttributeGraph._AttributeBody {
   associatedtype Value
-  #if compiler(>=5.3) && $NonescapableTypes
   static var initialValue: Self.Value? { get }
-  #endif
   var value: Self.Value { get }
 }
 extension AttributeGraph.Rule {
-  #if compiler(>=5.3) && $NonescapableTypes
   public static var initialValue: Self.Value? {
     get
   }
-  #endif
   public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AttributeGraph.AnyAttribute)
   public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
 }
@@ -456,15 +418,9 @@ extension AttributeGraph.Rule {
   }
 }
 extension AttributeGraph.Rule where Self : Swift.Hashable {
-  #if compiler(>=5.3) && $NonescapableTypes
   public func cachedValue(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?) -> Self.Value
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func cachedValueIfExists(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?) -> Self.Value?
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public static func _cachedValue(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?, hashValue: Swift.Int, bodyPtr: Swift.UnsafeRawPointer, update: () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void) -> Swift.UnsafePointer<Self.Value>
-  #endif
 }
 @frozen @propertyWrapper @dynamicMemberLookup public struct Attribute<Value> {
   public var identifier: AttributeGraph.AnyAttribute
@@ -472,9 +428,7 @@ extension AttributeGraph.Rule where Self : Swift.Hashable {
   public init(_ attribute: AttributeGraph.Attribute<Value>)
   public init(value: Value)
   public init(type _: Value.Type)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init<Body>(body: Swift.UnsafePointer<Body>, value: Swift.UnsafePointer<Value>?, flags: AttributeGraph._AttributeType.Flags = [], update: () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void) where Body : AttributeGraph._AttributeBody
-  #endif
   public var wrappedValue: Value {
     unsafeAddress
     nonmutating set
@@ -546,10 +500,8 @@ extension AttributeGraph.Attribute {
   public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.Rule
   public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.StatefulRule
 }
-#if compiler(>=5.3) && $NonescapableTypes
 @_silgen_name("AGGraphCreateAttribute")
 @inline(__always) @inlinable internal func AGGraphCreateAttribute(index: Swift.Int, body: Swift.UnsafeRawPointer, value: Swift.UnsafeRawPointer?) -> AttributeGraph.AnyAttribute
-#endif
 @_silgen_name("AGGraphGetValue")
 @inline(__always) @inlinable internal func AGGraphGetValue<Value>(_ attribute: AttributeGraph.AnyAttribute, options: AttributeGraph.AGValueOptions = [], type: Value.Type = Value.self) -> AttributeGraph.AGValue
 @_silgen_name("AGGraphSetValue")
@@ -602,11 +554,9 @@ extension Swift.UnsafeMutablePointer {
 extension AttributeGraph.AnyAttribute {
   public init<Value>(_ attribute: AttributeGraph.Attribute<Value>)
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.Attribute<Value>
-  #if compiler(>=5.3) && $NonescapableTypes
   public static var current: AttributeGraph.AnyAttribute? {
     get
   }
-  #endif
   public func unsafeOffset(at offset: Swift.Int) -> AttributeGraph.AnyAttribute
   public func setFlags(_ newFlags: AttributeGraph.AnyAttribute.Flags, mask: AttributeGraph.AnyAttribute.Flags)
   public func addInput(_ attribute: AttributeGraph.AnyAttribute, options: AttributeGraph.AGInputOptions = [], token: Swift.Int)
@@ -623,12 +573,10 @@ extension AttributeGraph.AnyAttribute {
   public var valueType: any Any.Type {
     get
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public var indirectDependency: AttributeGraph.AnyAttribute? {
     get
     nonmutating set
   }
-  #endif
 }
 extension AttributeGraph.AnyAttribute : Swift.CustomStringConvertible {
   @inlinable public var description: Swift.String {
@@ -643,12 +591,10 @@ public typealias AttributeUpdateBlock = () -> (Swift.UnsafeMutableRawPointer, At
     get
     nonmutating set
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public var dependency: AttributeGraph.AnyAttribute? {
     get
     nonmutating set
   }
-  #endif
   public var value: Value {
     get
     nonmutating set
@@ -678,22 +624,16 @@ extension AttributeGraph.IndirectAttribute : Swift.Hashable {
   public var identifier: AttributeGraph.AnyAttribute
   public init()
   public init(_ attribute: AttributeGraph.AnyAttribute)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.AnyAttribute?)
-  #endif
   public init<Value>(_ attribute: AttributeGraph.OptionalAttribute<Value>)
   public static var current: AttributeGraph.AnyOptionalAttribute {
     get
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.AnyAttribute? {
     get
     set
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func map<Value>(_ body: (AttributeGraph.AnyAttribute) -> Value) -> Value?
-  #endif
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.OptionalAttribute<Value>
 }
 extension AttributeGraph.AnyOptionalAttribute : Swift.Hashable {
@@ -713,44 +653,28 @@ extension AttributeGraph.AnyOptionalAttribute : Swift.CustomStringConvertible {
   public init()
   public init(base: AttributeGraph.AnyOptionalAttribute)
   public init(_ attribute: AttributeGraph.Attribute<Value>)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.Attribute<Value>?)
-  #endif
   public init(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.Attribute<Value>? {
     get
     set
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var value: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func map<V>(_ body: (AttributeGraph.Attribute<Value>) -> V) -> V?
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var wrappedValue: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var projectedValue: AttributeGraph.Attribute<Value>? {
     get
     set
     _modify
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
     get
   }
-  #endif
 }
 extension AttributeGraph.OptionalAttribute : Swift.Hashable {
   public static func == (a: AttributeGraph.OptionalAttribute<Value>, b: AttributeGraph.OptionalAttribute<Value>) -> Swift.Bool

--- a/AG/2024/AttributeGraph.xcframework/xros-arm64-x86_64-simulator/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/x86_64-apple-xros-simulator.swiftinterface
+++ b/AG/2024/AttributeGraph.xcframework/xros-arm64-x86_64-simulator/AttributeGraph.framework/Modules/AttributeGraph.swiftmodule/x86_64-apple-xros-simulator.swiftinterface
@@ -1,7 +1,7 @@
 // swift-interface-format-version: 1.0
-// swift-compiler-version: Apple Swift version 6.2 effective-5.10 (swiftlang-6.2.0.16.112 clang-1800.1.29)
+// swift-compiler-version: Apple Swift version 6.3.3 effective-5.10 (swiftlang-6.3.3.1.3 clang-2100.1.1.101)
 // swift-module-flags: -target x86_64-apple-xros2.0-simulator -enable-objc-interop -enable-library-evolution -swift-version 5 -Osize -enable-upcoming-feature InternalImportsByDefault -enable-experimental-feature Extern -module-name AttributeGraph
-// swift-module-flags-ignorable: -interface-compiler-version 6.2
+// swift-module-flags-ignorable: -interface-compiler-version 6.3.3
 @_exported public import AttributeGraph
 public import Swift
 public import _Concurrency
@@ -38,10 +38,8 @@ extension AttributeGraph.Graph {
   }
 }
 extension AttributeGraph.Graph {
-  #if compiler(>=5.3) && $NonescapableTypes
   @_silgen_name("AGGraphGetOutputValue")
   @inline(__always) @inlinable public static func outputValue<Value>() -> Swift.UnsafePointer<Value>?
-  #endif
   @_silgen_name("AGGraphSetOutputValue")
   @inline(__always) @inlinable public static func setOutputValue<Value>(_ value: Swift.UnsafePointer<Value>)
 }
@@ -51,9 +49,7 @@ extension AttributeGraph.Graph {
     }
 }
 extension AttributeGraph.Graph {
-  #if compiler(>=5.3) && $NonescapableTypes
   public func archiveJSON(name: Swift.String?)
-  #endif
 }
 extension AttributeGraph.Subgraph {
   public typealias Flags = AttributeGraph.AnyAttribute.Flags
@@ -214,16 +210,12 @@ public func withUnsafeMutablePointerToEnumCase<T>(of value: Swift.UnsafeMutableP
   public subscript<V>(attribute: AttributeGraph.Attribute<V>) -> V {
     unsafeAddress
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(weakAttribute: AttributeGraph.WeakAttribute<V>) -> V? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(optionalAttribute: AttributeGraph.OptionalAttribute<V>) -> V? {
     get
   }
-  #endif
   public func valueAndFlags<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, flags: AttributeGraph.AGChangedValueFlags)
   public func changedValue<V>(of input: AttributeGraph.Attribute<V>, options: AttributeGraph.AGValueOptions = []) -> (value: V, changed: Swift.Bool)
   public func update(body: () -> Swift.Void)
@@ -236,16 +228,12 @@ public func withUnsafeMutablePointerToEnumCase<T>(of value: Swift.UnsafeMutableP
   public subscript<V>(attribute: AttributeGraph.Attribute<V>) -> V {
     unsafeAddress
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(weakAttribute: AttributeGraph.WeakAttribute<V>) -> V? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<V>(optionalAttribute: AttributeGraph.OptionalAttribute<V>) -> V? {
     get
   }
-  #endif
   public var value: Value {
     unsafeAddress
     nonmutating set
@@ -267,40 +255,26 @@ public func withUnsafeMutablePointerToEnumCase<T>(of value: Swift.UnsafeMutableP
   public init(base: AttributeGraph.AnyWeakAttribute)
   public init()
   public init(_ attribute: AttributeGraph.Attribute<Value>)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.Attribute<Value>?)
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var wrappedValue: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var projectedValue: AttributeGraph.Attribute<Value>? {
     get
     set
     _modify
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.Attribute<Value>? {
     get
     set
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var value: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
-  #endif
 }
 extension AttributeGraph.WeakAttribute : Swift.Hashable {
   public static func == (a: AttributeGraph.WeakAttribute<Value>, b: AttributeGraph.WeakAttribute<Value>) -> Swift.Bool
@@ -315,17 +289,13 @@ extension AttributeGraph.WeakAttribute : Swift.CustomStringConvertible {
   }
 }
 extension AttributeGraph.AnyWeakAttribute {
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.AnyAttribute?)
-  #endif
   public init<Value>(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.WeakAttribute<Value>
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.AnyAttribute? {
     get
     set
   }
-  #endif
 }
 extension AttributeGraph.AnyWeakAttribute : Swift.Hashable {
   public static func == (lhs: AttributeGraph.AnyWeakAttribute, rhs: AttributeGraph.AnyWeakAttribute) -> Swift.Bool
@@ -402,17 +372,13 @@ public protocol AttributeBodyVisitor {
 }
 public protocol StatefulRule : AttributeGraph._AttributeBody {
   associatedtype Value
-  #if compiler(>=5.3) && $NonescapableTypes
   static var initialValue: Self.Value? { get }
-  #endif
   mutating func updateValue()
 }
 extension AttributeGraph.StatefulRule {
-  #if compiler(>=5.3) && $NonescapableTypes
   public static var initialValue: Self.Value? {
     get
   }
-  #endif
   public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AttributeGraph.AnyAttribute)
   public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
 }
@@ -433,17 +399,13 @@ extension AttributeGraph.StatefulRule {
 }
 public protocol Rule : AttributeGraph._AttributeBody {
   associatedtype Value
-  #if compiler(>=5.3) && $NonescapableTypes
   static var initialValue: Self.Value? { get }
-  #endif
   var value: Self.Value { get }
 }
 extension AttributeGraph.Rule {
-  #if compiler(>=5.3) && $NonescapableTypes
   public static var initialValue: Self.Value? {
     get
   }
-  #endif
   public static func _update(_ pointer: Swift.UnsafeMutableRawPointer, attribute _: AttributeGraph.AnyAttribute)
   public static func _updateDefault(_: Swift.UnsafeMutableRawPointer)
 }
@@ -456,15 +418,9 @@ extension AttributeGraph.Rule {
   }
 }
 extension AttributeGraph.Rule where Self : Swift.Hashable {
-  #if compiler(>=5.3) && $NonescapableTypes
   public func cachedValue(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?) -> Self.Value
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func cachedValueIfExists(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?) -> Self.Value?
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public static func _cachedValue(options: AttributeGraph.AGCachedValueOptions = [], owner: AttributeGraph.AnyAttribute?, hashValue: Swift.Int, bodyPtr: Swift.UnsafeRawPointer, update: () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void) -> Swift.UnsafePointer<Self.Value>
-  #endif
 }
 @frozen @propertyWrapper @dynamicMemberLookup public struct Attribute<Value> {
   public var identifier: AttributeGraph.AnyAttribute
@@ -472,9 +428,7 @@ extension AttributeGraph.Rule where Self : Swift.Hashable {
   public init(_ attribute: AttributeGraph.Attribute<Value>)
   public init(value: Value)
   public init(type _: Value.Type)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init<Body>(body: Swift.UnsafePointer<Body>, value: Swift.UnsafePointer<Value>?, flags: AttributeGraph._AttributeType.Flags = [], update: () -> (Swift.UnsafeMutableRawPointer, AttributeGraph.AnyAttribute) -> Swift.Void) where Body : AttributeGraph._AttributeBody
-  #endif
   public var wrappedValue: Value {
     unsafeAddress
     nonmutating set
@@ -546,10 +500,8 @@ extension AttributeGraph.Attribute {
   public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.Rule
   public init<R>(_ rule: R) where Value == R.Value, R : AttributeGraph.StatefulRule
 }
-#if compiler(>=5.3) && $NonescapableTypes
 @_silgen_name("AGGraphCreateAttribute")
 @inline(__always) @inlinable internal func AGGraphCreateAttribute(index: Swift.Int, body: Swift.UnsafeRawPointer, value: Swift.UnsafeRawPointer?) -> AttributeGraph.AnyAttribute
-#endif
 @_silgen_name("AGGraphGetValue")
 @inline(__always) @inlinable internal func AGGraphGetValue<Value>(_ attribute: AttributeGraph.AnyAttribute, options: AttributeGraph.AGValueOptions = [], type: Value.Type = Value.self) -> AttributeGraph.AGValue
 @_silgen_name("AGGraphSetValue")
@@ -602,11 +554,9 @@ extension Swift.UnsafeMutablePointer {
 extension AttributeGraph.AnyAttribute {
   public init<Value>(_ attribute: AttributeGraph.Attribute<Value>)
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.Attribute<Value>
-  #if compiler(>=5.3) && $NonescapableTypes
   public static var current: AttributeGraph.AnyAttribute? {
     get
   }
-  #endif
   public func unsafeOffset(at offset: Swift.Int) -> AttributeGraph.AnyAttribute
   public func setFlags(_ newFlags: AttributeGraph.AnyAttribute.Flags, mask: AttributeGraph.AnyAttribute.Flags)
   public func addInput(_ attribute: AttributeGraph.AnyAttribute, options: AttributeGraph.AGInputOptions = [], token: Swift.Int)
@@ -623,12 +573,10 @@ extension AttributeGraph.AnyAttribute {
   public var valueType: any Any.Type {
     get
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public var indirectDependency: AttributeGraph.AnyAttribute? {
     get
     nonmutating set
   }
-  #endif
 }
 extension AttributeGraph.AnyAttribute : Swift.CustomStringConvertible {
   @inlinable public var description: Swift.String {
@@ -643,12 +591,10 @@ public typealias AttributeUpdateBlock = () -> (Swift.UnsafeMutableRawPointer, At
     get
     nonmutating set
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public var dependency: AttributeGraph.AnyAttribute? {
     get
     nonmutating set
   }
-  #endif
   public var value: Value {
     get
     nonmutating set
@@ -678,22 +624,16 @@ extension AttributeGraph.IndirectAttribute : Swift.Hashable {
   public var identifier: AttributeGraph.AnyAttribute
   public init()
   public init(_ attribute: AttributeGraph.AnyAttribute)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.AnyAttribute?)
-  #endif
   public init<Value>(_ attribute: AttributeGraph.OptionalAttribute<Value>)
   public static var current: AttributeGraph.AnyOptionalAttribute {
     get
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.AnyAttribute? {
     get
     set
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func map<Value>(_ body: (AttributeGraph.AnyAttribute) -> Value) -> Value?
-  #endif
   public func unsafeCast<Value>(to _: Value.Type) -> AttributeGraph.OptionalAttribute<Value>
 }
 extension AttributeGraph.AnyOptionalAttribute : Swift.Hashable {
@@ -713,44 +653,28 @@ extension AttributeGraph.AnyOptionalAttribute : Swift.CustomStringConvertible {
   public init()
   public init(base: AttributeGraph.AnyOptionalAttribute)
   public init(_ attribute: AttributeGraph.Attribute<Value>)
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(_ attribute: AttributeGraph.Attribute<Value>?)
-  #endif
   public init(_ weakAttribute: AttributeGraph.WeakAttribute<Value>)
-  #if compiler(>=5.3) && $NonescapableTypes
   public var attribute: AttributeGraph.Attribute<Value>? {
     get
     set
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var value: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func changedValue(options: AttributeGraph.AGValueOptions = []) -> (value: Value, changed: Swift.Bool)?
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public func map<V>(_ body: (AttributeGraph.Attribute<Value>) -> V) -> V?
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var wrappedValue: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var projectedValue: AttributeGraph.Attribute<Value>? {
     get
     set
     _modify
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public subscript<Member>(dynamicMember keyPath: Swift.KeyPath<Value, Member>) -> AttributeGraph.Attribute<Member>? {
     get
   }
-  #endif
 }
 extension AttributeGraph.OptionalAttribute : Swift.Hashable {
   public static func == (a: AttributeGraph.OptionalAttribute<Value>, b: AttributeGraph.OptionalAttribute<Value>) -> Swift.Bool

--- a/AG/generate_swiftinterface.sh
+++ b/AG/generate_swiftinterface.sh
@@ -40,7 +40,7 @@ cleanup() {
 trap cleanup EXIT
 
 # Verify Swift compiler version matches the expected version for this framework
-EXPECTED_SWIFT_VERSION="6.2"
+EXPECTED_SWIFT_VERSION="6.3"
 SWIFT_VERSION=$(xcrun swiftc --version 2>&1 | grep -o 'Swift version [0-9]*\.[0-9]*' | head -1 | awk '{print $3}')
 if [ "${SWIFT_VERSION}" != "${EXPECTED_SWIFT_VERSION}" ]; then
     echo "Error: expected Swift ${EXPECTED_SWIFT_VERSION} but found Swift ${SWIFT_VERSION}"

--- a/AG/update.sh
+++ b/AG/update.sh
@@ -33,9 +33,9 @@ generate_swiftinterface_header() {
     local target="$1"
     local result=""
     result+="// swift-interface-format-version: 1.0\n"
-    result+="// swift-compiler-version: Apple Swift version 6.2 effective-5.10 (swiftlang-6.2.0.16.112 clang-1800.1.29)\n"
+    result+="// swift-compiler-version: Apple Swift version 6.3.3 effective-5.10 (swiftlang-6.3.3.1.3 clang-2100.1.1.101)\n"
     result+="// swift-module-flags: -target $target -enable-objc-interop -enable-library-evolution -swift-version 5 -Osize -enable-upcoming-feature InternalImportsByDefault -enable-experimental-feature Extern -module-name AttributeGraph\n"
-    result+="// swift-module-flags-ignorable:  -interface-compiler-version 6.2"
+    result+="// swift-module-flags-ignorable:  -interface-compiler-version 6.3.3"
 
     echo -e $result
 }

--- a/Example/Tuist/Package.swift
+++ b/Example/Tuist/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.2
+// swift-tools-version: 6.3
 
 import PackageDescription
 

--- a/Example/mise.toml
+++ b/Example/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-tuist = "4.193.0"
+tuist = "4.203.4"
 
 [env]
 DARWINPRIVATEFRAMEWORKS_TARGET_RELEASE = "2025"

--- a/GF/2025/Gestures.xcframework/ios-arm64-x86_64-simulator/Gestures.framework/Modules/Gestures.swiftmodule/arm64-apple-ios-simulator.swiftinterface
+++ b/GF/2025/Gestures.xcframework/ios-arm64-x86_64-simulator/Gestures.framework/Modules/Gestures.swiftmodule/arm64-apple-ios-simulator.swiftinterface
@@ -1,7 +1,7 @@
 // swift-interface-format-version: 1.0
-// swift-compiler-version: Apple Swift version 6.2 effective-5.10 (swiftlang-6.2.0.16.112 clang-1800.1.29)
+// swift-compiler-version: Apple Swift version 6.3.3 effective-5.10 (swiftlang-6.3.3.1.3 clang-2100.1.1.101)
 // swift-module-flags: -target arm64-apple-ios26.0-simulator -enable-objc-interop -enable-library-evolution -swift-version 5 -Osize -enable-upcoming-feature InternalImportsByDefault -enable-experimental-feature Extern -module-name Gestures
-// swift-module-flags-ignorable: -interface-compiler-version 6.2
+// swift-module-flags-ignorable: -interface-compiler-version 6.3.3
 public import Dispatch
 @_exported public import Gestures
 public import Swift
@@ -25,12 +25,8 @@ public struct GestureTrait : Swift.Hashable, Swift.Identifiable, Swift.Sendable 
   public var id: Gestures.GestureTraitID
   public var attributes: [Gestures.GestureTrait.AttributeKey : Gestures.GestureTrait.AttributeValue]
   public init(id: Gestures.GestureTraitID, attributes: [Gestures.GestureTrait.AttributeKey : Gestures.GestureTrait.AttributeValue] = [:])
-  #if compiler(>=5.3) && $NonescapableTypes
   public static func tap(tapCount: Swift.Int? = nil, pointCount: Swift.Int? = nil) -> Gestures.GestureTrait
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public static func longPress(pointCount: Swift.Int? = nil, minimumDuration: Swift.Duration? = nil, maximumMovement: Swift.Double? = nil) -> Gestures.GestureTrait
-  #endif
   public static func pan() -> Gestures.GestureTrait
   public struct AttributeKey : Swift.Hashable, Swift.Sendable, Swift.CustomStringConvertible {
     public let rawValue: Swift.Int
@@ -171,9 +167,7 @@ public struct GestureRelation : Swift.Equatable, Swift.Sendable {
   public var direction: Gestures.GestureRelationDirection
   public var role: Gestures.GestureRelationRole?
   public var target: Gestures.GestureNodeMatcher
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(type: Gestures.GestureRelationType, direction: Gestures.GestureRelationDirection, role: Gestures.GestureRelationRole?, target: Gestures.GestureNodeMatcher)
-  #endif
   public static func == (a: Gestures.GestureRelation, b: Gestures.GestureRelation) -> Swift.Bool
 }
 extension Swift.Array where Element == Gestures.GestureRelation {
@@ -214,16 +208,12 @@ extension Gestures.GesturePhase {
   public var isRecognized: Swift.Bool {
     get
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public var value: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var failureReason: Gestures.GestureFailureReason? {
     get
   }
-  #endif
   public func mapValue<T>(_ transform: (Value) -> T) -> Gestures.GesturePhase<T> where T : Swift.Sendable
 }
 extension Gestures.GesturePhase : Swift.CustomStringConvertible {
@@ -252,11 +242,9 @@ public enum GestureOutput<Value> : Swift.Sendable where Value : Swift.Sendable {
   case finalValue(Value, metadata: Gestures.GestureOutputMetadata?)
 }
 extension Gestures.GestureOutput {
-  #if compiler(>=5.3) && $NonescapableTypes
   public var value: Value? {
     get
   }
-  #endif
   public var isEmpty: Swift.Bool {
     get
   }
@@ -277,9 +265,7 @@ public enum GestureOutputEmptyReason : Swift.Hashable, Swift.Sendable {
 public struct GestureOutputMetadata : Swift.Sendable {
 }
 public protocol GestureNodeContainer : AnyObject, Swift.Sendable {
-  #if compiler(>=5.3) && $NonescapableTypes
   func index(of node: Gestures.AnyGestureNode) -> Swift.Int?
-  #endif
   func isDescendant(of container: any Gestures.GestureNodeContainer, referenceNode: Gestures.AnyGestureNode) -> Swift.Bool
   func isDeeper(than container: any Gestures.GestureNodeContainer, referenceNode: Gestures.AnyGestureNode) -> Swift.Bool
 }
@@ -300,9 +286,7 @@ public protocol GestureNodeDelegate<Value> : AnyObject, Swift.Sendable {
   func gestureNodeShouldActivate(_ node: Gestures.GestureNode<Self.Value>) -> Swift.Bool
   func gestureNode(_ node: Gestures.GestureNode<Self.Value>, didEnqueuePhase phase: Gestures.GesturePhase<Self.Value>)
   func gestureNode(_ node: Gestures.GestureNode<Self.Value>, didUpdatePhase newPhase: Gestures.GesturePhase<Self.Value>, oldPhase: Gestures.GesturePhase<Self.Value>)
-  #if compiler(>=5.3) && $NonescapableTypes
   func gestureNode(_ node: Gestures.GestureNode<Self.Value>, roleForRelationType type: Gestures.GestureRelationType, direction: Gestures.GestureRelationDirection, relatedNode: Gestures.AnyGestureNode) -> Gestures.GestureRelationRole?
-  #endif
 }
 public struct GestureNodeOptions : Swift.OptionSet, Swift.Sendable {
   public let rawValue: Swift.Int
@@ -355,20 +339,16 @@ extension Gestures.AnyGestureNode : Swift.Comparable {
 }
 @_inheritsConvenienceInitializers public class GestureNode<Value> : Gestures.AnyGestureNode, @unchecked Swift.Sendable where Value : Swift.Sendable {
   weak public var delegate: (any Gestures.GestureNodeDelegate<Value>)?
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(traits: Gestures.GestureTraitCollection?, tag: Gestures.GestureTag?, relations: [Gestures.GestureRelation])
-  #endif
   convenience public init()
   override public var options: Gestures.GestureNodeOptions {
     get
     set
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   override public var container: (any Gestures.GestureNodeContainer)? {
     get
     set
   }
-  #endif
   public var phase: Gestures.GesturePhase<Value> {
     get
   }
@@ -391,9 +371,7 @@ public protocol GestureComponent : Swift.Sendable {
   associatedtype Value : Swift.Sendable
   mutating func update(context: Gestures.GestureComponentContext) throws -> Gestures.GestureOutput<Self.Value>
   mutating func reset()
-  #if compiler(>=5.3) && $NonescapableTypes
   mutating func traits() -> Gestures.GestureTraitCollection?
-  #endif
   mutating func capacity<E>(for eventType: E.Type) -> Swift.Int where E : Gestures.Event
 }
 extension Gestures.CompositeGestureComponent {
@@ -427,19 +405,15 @@ public protocol CompositeGestureComponent : Gestures.GestureComponent {
 }
 extension Gestures.CompositeGestureComponent {
   public mutating func reset()
-  #if compiler(>=5.3) && $NonescapableTypes
   public mutating func traits() -> Gestures.GestureTraitCollection?
-  #endif
   public mutating func capacity<E>(for eventType: E.Type) -> Swift.Int where E : Gestures.Event
 }
 @_hasMissingDesignatedInitializers final public class GestureComponentController<Component> : Gestures.AnyGestureComponentController, @unchecked Swift.Sendable where Component : Gestures.GestureComponent {
   public init(component: Component, timeScheduler: any Gestures.TimeScheduler)
   convenience public init(component: Component)
-  #if compiler(>=5.3) && $NonescapableTypes
   override final public var traits: Gestures.GestureTraitCollection? {
     get
   }
-  #endif
   override final public var timeSource: any Gestures.TimeSource {
     get
   }
@@ -450,11 +424,9 @@ extension Gestures.CompositeGestureComponent {
 }
 @_hasMissingDesignatedInitializers open class AnyGestureComponentController : @unchecked Swift.Sendable {
   weak open var node: Gestures.AnyGestureNode?
-  #if compiler(>=5.3) && $NonescapableTypes
   open var traits: Gestures.GestureTraitCollection? {
     get
   }
-  #endif
   open var timeSource: any Gestures.TimeSource {
     get
   }
@@ -498,9 +470,7 @@ public struct GestureUpdateDriverToken : Swift.Hashable, Swift.Sendable {
   }
 }
 public protocol TimeScheduler : AnyObject, Gestures.TimeSource {
-  #if compiler(>=5.3) && $NonescapableTypes
   func schedule(after duration: Swift.Duration, handler: @escaping () -> Swift.Void, cancelHandler: (() -> Swift.Void)?) -> Gestures.TimeSchedulerToken
-  #endif
   func cancel(token: Gestures.TimeSchedulerToken)
 }
 public struct TimeSchedulerToken : Swift.Hashable, Swift.Sendable {
@@ -519,9 +489,7 @@ final public class DispatchTimeScheduler : @unchecked Swift.Sendable, Gestures.T
   final public var timestamp: Gestures.Timestamp {
     get
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   final public func schedule(after duration: Swift.Duration, handler: @escaping () -> Swift.Void, cancelHandler: (() -> Swift.Void)? = nil) -> Gestures.TimeSchedulerToken
-  #endif
   final public func cancel(token: Gestures.TimeSchedulerToken)
   @objc deinit
 }
@@ -646,8 +614,6 @@ extension Gestures.GFGestureRelationRole : Swift.CustomStringConvertible {
     get
   }
 }
-extension CoreFoundation.CGPoint : Swift.Sendable {}
-extension CoreFoundation.CGVector : Swift.Sendable {}
 extension Gestures.GestureTrait : Swift.CustomStringConvertible {}
 extension Gestures.GestureTrait : Swift.CustomDebugStringConvertible {}
 extension Gestures.GestureTraitCollection : Swift.CustomStringConvertible {}

--- a/GF/2025/Gestures.xcframework/ios-arm64-x86_64-simulator/Gestures.framework/Modules/Gestures.swiftmodule/x86_64-apple-ios-simulator.swiftinterface
+++ b/GF/2025/Gestures.xcframework/ios-arm64-x86_64-simulator/Gestures.framework/Modules/Gestures.swiftmodule/x86_64-apple-ios-simulator.swiftinterface
@@ -1,7 +1,7 @@
 // swift-interface-format-version: 1.0
-// swift-compiler-version: Apple Swift version 6.2 effective-5.10 (swiftlang-6.2.0.16.112 clang-1800.1.29)
+// swift-compiler-version: Apple Swift version 6.3.3 effective-5.10 (swiftlang-6.3.3.1.3 clang-2100.1.1.101)
 // swift-module-flags: -target x86_64-apple-ios26.0-simulator -enable-objc-interop -enable-library-evolution -swift-version 5 -Osize -enable-upcoming-feature InternalImportsByDefault -enable-experimental-feature Extern -module-name Gestures
-// swift-module-flags-ignorable: -interface-compiler-version 6.2
+// swift-module-flags-ignorable: -interface-compiler-version 6.3.3
 public import Dispatch
 @_exported public import Gestures
 public import Swift
@@ -25,12 +25,8 @@ public struct GestureTrait : Swift.Hashable, Swift.Identifiable, Swift.Sendable 
   public var id: Gestures.GestureTraitID
   public var attributes: [Gestures.GestureTrait.AttributeKey : Gestures.GestureTrait.AttributeValue]
   public init(id: Gestures.GestureTraitID, attributes: [Gestures.GestureTrait.AttributeKey : Gestures.GestureTrait.AttributeValue] = [:])
-  #if compiler(>=5.3) && $NonescapableTypes
   public static func tap(tapCount: Swift.Int? = nil, pointCount: Swift.Int? = nil) -> Gestures.GestureTrait
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public static func longPress(pointCount: Swift.Int? = nil, minimumDuration: Swift.Duration? = nil, maximumMovement: Swift.Double? = nil) -> Gestures.GestureTrait
-  #endif
   public static func pan() -> Gestures.GestureTrait
   public struct AttributeKey : Swift.Hashable, Swift.Sendable, Swift.CustomStringConvertible {
     public let rawValue: Swift.Int
@@ -171,9 +167,7 @@ public struct GestureRelation : Swift.Equatable, Swift.Sendable {
   public var direction: Gestures.GestureRelationDirection
   public var role: Gestures.GestureRelationRole?
   public var target: Gestures.GestureNodeMatcher
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(type: Gestures.GestureRelationType, direction: Gestures.GestureRelationDirection, role: Gestures.GestureRelationRole?, target: Gestures.GestureNodeMatcher)
-  #endif
   public static func == (a: Gestures.GestureRelation, b: Gestures.GestureRelation) -> Swift.Bool
 }
 extension Swift.Array where Element == Gestures.GestureRelation {
@@ -214,16 +208,12 @@ extension Gestures.GesturePhase {
   public var isRecognized: Swift.Bool {
     get
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public var value: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var failureReason: Gestures.GestureFailureReason? {
     get
   }
-  #endif
   public func mapValue<T>(_ transform: (Value) -> T) -> Gestures.GesturePhase<T> where T : Swift.Sendable
 }
 extension Gestures.GesturePhase : Swift.CustomStringConvertible {
@@ -252,11 +242,9 @@ public enum GestureOutput<Value> : Swift.Sendable where Value : Swift.Sendable {
   case finalValue(Value, metadata: Gestures.GestureOutputMetadata?)
 }
 extension Gestures.GestureOutput {
-  #if compiler(>=5.3) && $NonescapableTypes
   public var value: Value? {
     get
   }
-  #endif
   public var isEmpty: Swift.Bool {
     get
   }
@@ -277,9 +265,7 @@ public enum GestureOutputEmptyReason : Swift.Hashable, Swift.Sendable {
 public struct GestureOutputMetadata : Swift.Sendable {
 }
 public protocol GestureNodeContainer : AnyObject, Swift.Sendable {
-  #if compiler(>=5.3) && $NonescapableTypes
   func index(of node: Gestures.AnyGestureNode) -> Swift.Int?
-  #endif
   func isDescendant(of container: any Gestures.GestureNodeContainer, referenceNode: Gestures.AnyGestureNode) -> Swift.Bool
   func isDeeper(than container: any Gestures.GestureNodeContainer, referenceNode: Gestures.AnyGestureNode) -> Swift.Bool
 }
@@ -300,9 +286,7 @@ public protocol GestureNodeDelegate<Value> : AnyObject, Swift.Sendable {
   func gestureNodeShouldActivate(_ node: Gestures.GestureNode<Self.Value>) -> Swift.Bool
   func gestureNode(_ node: Gestures.GestureNode<Self.Value>, didEnqueuePhase phase: Gestures.GesturePhase<Self.Value>)
   func gestureNode(_ node: Gestures.GestureNode<Self.Value>, didUpdatePhase newPhase: Gestures.GesturePhase<Self.Value>, oldPhase: Gestures.GesturePhase<Self.Value>)
-  #if compiler(>=5.3) && $NonescapableTypes
   func gestureNode(_ node: Gestures.GestureNode<Self.Value>, roleForRelationType type: Gestures.GestureRelationType, direction: Gestures.GestureRelationDirection, relatedNode: Gestures.AnyGestureNode) -> Gestures.GestureRelationRole?
-  #endif
 }
 public struct GestureNodeOptions : Swift.OptionSet, Swift.Sendable {
   public let rawValue: Swift.Int
@@ -355,20 +339,16 @@ extension Gestures.AnyGestureNode : Swift.Comparable {
 }
 @_inheritsConvenienceInitializers public class GestureNode<Value> : Gestures.AnyGestureNode, @unchecked Swift.Sendable where Value : Swift.Sendable {
   weak public var delegate: (any Gestures.GestureNodeDelegate<Value>)?
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(traits: Gestures.GestureTraitCollection?, tag: Gestures.GestureTag?, relations: [Gestures.GestureRelation])
-  #endif
   convenience public init()
   override public var options: Gestures.GestureNodeOptions {
     get
     set
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   override public var container: (any Gestures.GestureNodeContainer)? {
     get
     set
   }
-  #endif
   public var phase: Gestures.GesturePhase<Value> {
     get
   }
@@ -391,9 +371,7 @@ public protocol GestureComponent : Swift.Sendable {
   associatedtype Value : Swift.Sendable
   mutating func update(context: Gestures.GestureComponentContext) throws -> Gestures.GestureOutput<Self.Value>
   mutating func reset()
-  #if compiler(>=5.3) && $NonescapableTypes
   mutating func traits() -> Gestures.GestureTraitCollection?
-  #endif
   mutating func capacity<E>(for eventType: E.Type) -> Swift.Int where E : Gestures.Event
 }
 extension Gestures.CompositeGestureComponent {
@@ -427,19 +405,15 @@ public protocol CompositeGestureComponent : Gestures.GestureComponent {
 }
 extension Gestures.CompositeGestureComponent {
   public mutating func reset()
-  #if compiler(>=5.3) && $NonescapableTypes
   public mutating func traits() -> Gestures.GestureTraitCollection?
-  #endif
   public mutating func capacity<E>(for eventType: E.Type) -> Swift.Int where E : Gestures.Event
 }
 @_hasMissingDesignatedInitializers final public class GestureComponentController<Component> : Gestures.AnyGestureComponentController, @unchecked Swift.Sendable where Component : Gestures.GestureComponent {
   public init(component: Component, timeScheduler: any Gestures.TimeScheduler)
   convenience public init(component: Component)
-  #if compiler(>=5.3) && $NonescapableTypes
   override final public var traits: Gestures.GestureTraitCollection? {
     get
   }
-  #endif
   override final public var timeSource: any Gestures.TimeSource {
     get
   }
@@ -450,11 +424,9 @@ extension Gestures.CompositeGestureComponent {
 }
 @_hasMissingDesignatedInitializers open class AnyGestureComponentController : @unchecked Swift.Sendable {
   weak open var node: Gestures.AnyGestureNode?
-  #if compiler(>=5.3) && $NonescapableTypes
   open var traits: Gestures.GestureTraitCollection? {
     get
   }
-  #endif
   open var timeSource: any Gestures.TimeSource {
     get
   }
@@ -498,9 +470,7 @@ public struct GestureUpdateDriverToken : Swift.Hashable, Swift.Sendable {
   }
 }
 public protocol TimeScheduler : AnyObject, Gestures.TimeSource {
-  #if compiler(>=5.3) && $NonescapableTypes
   func schedule(after duration: Swift.Duration, handler: @escaping () -> Swift.Void, cancelHandler: (() -> Swift.Void)?) -> Gestures.TimeSchedulerToken
-  #endif
   func cancel(token: Gestures.TimeSchedulerToken)
 }
 public struct TimeSchedulerToken : Swift.Hashable, Swift.Sendable {
@@ -519,9 +489,7 @@ final public class DispatchTimeScheduler : @unchecked Swift.Sendable, Gestures.T
   final public var timestamp: Gestures.Timestamp {
     get
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   final public func schedule(after duration: Swift.Duration, handler: @escaping () -> Swift.Void, cancelHandler: (() -> Swift.Void)? = nil) -> Gestures.TimeSchedulerToken
-  #endif
   final public func cancel(token: Gestures.TimeSchedulerToken)
   @objc deinit
 }
@@ -646,8 +614,6 @@ extension Gestures.GFGestureRelationRole : Swift.CustomStringConvertible {
     get
   }
 }
-extension CoreFoundation.CGPoint : Swift.Sendable {}
-extension CoreFoundation.CGVector : Swift.Sendable {}
 extension Gestures.GestureTrait : Swift.CustomStringConvertible {}
 extension Gestures.GestureTrait : Swift.CustomDebugStringConvertible {}
 extension Gestures.GestureTraitCollection : Swift.CustomStringConvertible {}

--- a/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/arm64-apple-macos.swiftinterface
+++ b/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/arm64-apple-macos.swiftinterface
@@ -1,7 +1,7 @@
 // swift-interface-format-version: 1.0
-// swift-compiler-version: Apple Swift version 6.2 effective-5.10 (swiftlang-6.2.0.16.112 clang-1800.1.29)
+// swift-compiler-version: Apple Swift version 6.3.3 effective-5.10 (swiftlang-6.3.3.1.3 clang-2100.1.1.101)
 // swift-module-flags: -target arm64-apple-macos26.0 -enable-objc-interop -enable-library-evolution -swift-version 5 -Osize -enable-upcoming-feature InternalImportsByDefault -enable-experimental-feature Extern -module-name Gestures
-// swift-module-flags-ignorable: -interface-compiler-version 6.2
+// swift-module-flags-ignorable: -interface-compiler-version 6.3.3
 public import Dispatch
 @_exported public import Gestures
 public import Swift
@@ -25,12 +25,8 @@ public struct GestureTrait : Swift.Hashable, Swift.Identifiable, Swift.Sendable 
   public var id: Gestures.GestureTraitID
   public var attributes: [Gestures.GestureTrait.AttributeKey : Gestures.GestureTrait.AttributeValue]
   public init(id: Gestures.GestureTraitID, attributes: [Gestures.GestureTrait.AttributeKey : Gestures.GestureTrait.AttributeValue] = [:])
-  #if compiler(>=5.3) && $NonescapableTypes
   public static func tap(tapCount: Swift.Int? = nil, pointCount: Swift.Int? = nil) -> Gestures.GestureTrait
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public static func longPress(pointCount: Swift.Int? = nil, minimumDuration: Swift.Duration? = nil, maximumMovement: Swift.Double? = nil) -> Gestures.GestureTrait
-  #endif
   public static func pan() -> Gestures.GestureTrait
   public struct AttributeKey : Swift.Hashable, Swift.Sendable, Swift.CustomStringConvertible {
     public let rawValue: Swift.Int
@@ -171,9 +167,7 @@ public struct GestureRelation : Swift.Equatable, Swift.Sendable {
   public var direction: Gestures.GestureRelationDirection
   public var role: Gestures.GestureRelationRole?
   public var target: Gestures.GestureNodeMatcher
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(type: Gestures.GestureRelationType, direction: Gestures.GestureRelationDirection, role: Gestures.GestureRelationRole?, target: Gestures.GestureNodeMatcher)
-  #endif
   public static func == (a: Gestures.GestureRelation, b: Gestures.GestureRelation) -> Swift.Bool
 }
 extension Swift.Array where Element == Gestures.GestureRelation {
@@ -214,16 +208,12 @@ extension Gestures.GesturePhase {
   public var isRecognized: Swift.Bool {
     get
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public var value: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var failureReason: Gestures.GestureFailureReason? {
     get
   }
-  #endif
   public func mapValue<T>(_ transform: (Value) -> T) -> Gestures.GesturePhase<T> where T : Swift.Sendable
 }
 extension Gestures.GesturePhase : Swift.CustomStringConvertible {
@@ -252,11 +242,9 @@ public enum GestureOutput<Value> : Swift.Sendable where Value : Swift.Sendable {
   case finalValue(Value, metadata: Gestures.GestureOutputMetadata?)
 }
 extension Gestures.GestureOutput {
-  #if compiler(>=5.3) && $NonescapableTypes
   public var value: Value? {
     get
   }
-  #endif
   public var isEmpty: Swift.Bool {
     get
   }
@@ -277,9 +265,7 @@ public enum GestureOutputEmptyReason : Swift.Hashable, Swift.Sendable {
 public struct GestureOutputMetadata : Swift.Sendable {
 }
 public protocol GestureNodeContainer : AnyObject, Swift.Sendable {
-  #if compiler(>=5.3) && $NonescapableTypes
   func index(of node: Gestures.AnyGestureNode) -> Swift.Int?
-  #endif
   func isDescendant(of container: any Gestures.GestureNodeContainer, referenceNode: Gestures.AnyGestureNode) -> Swift.Bool
   func isDeeper(than container: any Gestures.GestureNodeContainer, referenceNode: Gestures.AnyGestureNode) -> Swift.Bool
 }
@@ -300,9 +286,7 @@ public protocol GestureNodeDelegate<Value> : AnyObject, Swift.Sendable {
   func gestureNodeShouldActivate(_ node: Gestures.GestureNode<Self.Value>) -> Swift.Bool
   func gestureNode(_ node: Gestures.GestureNode<Self.Value>, didEnqueuePhase phase: Gestures.GesturePhase<Self.Value>)
   func gestureNode(_ node: Gestures.GestureNode<Self.Value>, didUpdatePhase newPhase: Gestures.GesturePhase<Self.Value>, oldPhase: Gestures.GesturePhase<Self.Value>)
-  #if compiler(>=5.3) && $NonescapableTypes
   func gestureNode(_ node: Gestures.GestureNode<Self.Value>, roleForRelationType type: Gestures.GestureRelationType, direction: Gestures.GestureRelationDirection, relatedNode: Gestures.AnyGestureNode) -> Gestures.GestureRelationRole?
-  #endif
 }
 public struct GestureNodeOptions : Swift.OptionSet, Swift.Sendable {
   public let rawValue: Swift.Int
@@ -355,20 +339,16 @@ extension Gestures.AnyGestureNode : Swift.Comparable {
 }
 @_inheritsConvenienceInitializers public class GestureNode<Value> : Gestures.AnyGestureNode, @unchecked Swift.Sendable where Value : Swift.Sendable {
   weak public var delegate: (any Gestures.GestureNodeDelegate<Value>)?
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(traits: Gestures.GestureTraitCollection?, tag: Gestures.GestureTag?, relations: [Gestures.GestureRelation])
-  #endif
   convenience public init()
   override public var options: Gestures.GestureNodeOptions {
     get
     set
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   override public var container: (any Gestures.GestureNodeContainer)? {
     get
     set
   }
-  #endif
   public var phase: Gestures.GesturePhase<Value> {
     get
   }
@@ -391,9 +371,7 @@ public protocol GestureComponent : Swift.Sendable {
   associatedtype Value : Swift.Sendable
   mutating func update(context: Gestures.GestureComponentContext) throws -> Gestures.GestureOutput<Self.Value>
   mutating func reset()
-  #if compiler(>=5.3) && $NonescapableTypes
   mutating func traits() -> Gestures.GestureTraitCollection?
-  #endif
   mutating func capacity<E>(for eventType: E.Type) -> Swift.Int where E : Gestures.Event
 }
 extension Gestures.CompositeGestureComponent {
@@ -427,19 +405,15 @@ public protocol CompositeGestureComponent : Gestures.GestureComponent {
 }
 extension Gestures.CompositeGestureComponent {
   public mutating func reset()
-  #if compiler(>=5.3) && $NonescapableTypes
   public mutating func traits() -> Gestures.GestureTraitCollection?
-  #endif
   public mutating func capacity<E>(for eventType: E.Type) -> Swift.Int where E : Gestures.Event
 }
 @_hasMissingDesignatedInitializers final public class GestureComponentController<Component> : Gestures.AnyGestureComponentController, @unchecked Swift.Sendable where Component : Gestures.GestureComponent {
   public init(component: Component, timeScheduler: any Gestures.TimeScheduler)
   convenience public init(component: Component)
-  #if compiler(>=5.3) && $NonescapableTypes
   override final public var traits: Gestures.GestureTraitCollection? {
     get
   }
-  #endif
   override final public var timeSource: any Gestures.TimeSource {
     get
   }
@@ -450,11 +424,9 @@ extension Gestures.CompositeGestureComponent {
 }
 @_hasMissingDesignatedInitializers open class AnyGestureComponentController : @unchecked Swift.Sendable {
   weak open var node: Gestures.AnyGestureNode?
-  #if compiler(>=5.3) && $NonescapableTypes
   open var traits: Gestures.GestureTraitCollection? {
     get
   }
-  #endif
   open var timeSource: any Gestures.TimeSource {
     get
   }
@@ -498,9 +470,7 @@ public struct GestureUpdateDriverToken : Swift.Hashable, Swift.Sendable {
   }
 }
 public protocol TimeScheduler : AnyObject, Gestures.TimeSource {
-  #if compiler(>=5.3) && $NonescapableTypes
   func schedule(after duration: Swift.Duration, handler: @escaping () -> Swift.Void, cancelHandler: (() -> Swift.Void)?) -> Gestures.TimeSchedulerToken
-  #endif
   func cancel(token: Gestures.TimeSchedulerToken)
 }
 public struct TimeSchedulerToken : Swift.Hashable, Swift.Sendable {
@@ -519,9 +489,7 @@ final public class DispatchTimeScheduler : @unchecked Swift.Sendable, Gestures.T
   final public var timestamp: Gestures.Timestamp {
     get
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   final public func schedule(after duration: Swift.Duration, handler: @escaping () -> Swift.Void, cancelHandler: (() -> Swift.Void)? = nil) -> Gestures.TimeSchedulerToken
-  #endif
   final public func cancel(token: Gestures.TimeSchedulerToken)
   @objc deinit
 }
@@ -646,8 +614,6 @@ extension Gestures.GFGestureRelationRole : Swift.CustomStringConvertible {
     get
   }
 }
-extension CoreFoundation.CGPoint : Swift.Sendable {}
-extension CoreFoundation.CGVector : Swift.Sendable {}
 extension Gestures.GestureTrait : Swift.CustomStringConvertible {}
 extension Gestures.GestureTrait : Swift.CustomDebugStringConvertible {}
 extension Gestures.GestureTraitCollection : Swift.CustomStringConvertible {}

--- a/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/arm64e-apple-macos.swiftinterface
+++ b/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/arm64e-apple-macos.swiftinterface
@@ -1,7 +1,7 @@
 // swift-interface-format-version: 1.0
-// swift-compiler-version: Apple Swift version 6.2 effective-5.10 (swiftlang-6.2.0.16.112 clang-1800.1.29)
+// swift-compiler-version: Apple Swift version 6.3.3 effective-5.10 (swiftlang-6.3.3.1.3 clang-2100.1.1.101)
 // swift-module-flags: -target arm64e-apple-macos26.0 -enable-objc-interop -enable-library-evolution -swift-version 5 -Osize -enable-upcoming-feature InternalImportsByDefault -enable-experimental-feature Extern -module-name Gestures
-// swift-module-flags-ignorable: -interface-compiler-version 6.2
+// swift-module-flags-ignorable: -interface-compiler-version 6.3.3
 public import Dispatch
 @_exported public import Gestures
 public import Swift
@@ -25,12 +25,8 @@ public struct GestureTrait : Swift.Hashable, Swift.Identifiable, Swift.Sendable 
   public var id: Gestures.GestureTraitID
   public var attributes: [Gestures.GestureTrait.AttributeKey : Gestures.GestureTrait.AttributeValue]
   public init(id: Gestures.GestureTraitID, attributes: [Gestures.GestureTrait.AttributeKey : Gestures.GestureTrait.AttributeValue] = [:])
-  #if compiler(>=5.3) && $NonescapableTypes
   public static func tap(tapCount: Swift.Int? = nil, pointCount: Swift.Int? = nil) -> Gestures.GestureTrait
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public static func longPress(pointCount: Swift.Int? = nil, minimumDuration: Swift.Duration? = nil, maximumMovement: Swift.Double? = nil) -> Gestures.GestureTrait
-  #endif
   public static func pan() -> Gestures.GestureTrait
   public struct AttributeKey : Swift.Hashable, Swift.Sendable, Swift.CustomStringConvertible {
     public let rawValue: Swift.Int
@@ -171,9 +167,7 @@ public struct GestureRelation : Swift.Equatable, Swift.Sendable {
   public var direction: Gestures.GestureRelationDirection
   public var role: Gestures.GestureRelationRole?
   public var target: Gestures.GestureNodeMatcher
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(type: Gestures.GestureRelationType, direction: Gestures.GestureRelationDirection, role: Gestures.GestureRelationRole?, target: Gestures.GestureNodeMatcher)
-  #endif
   public static func == (a: Gestures.GestureRelation, b: Gestures.GestureRelation) -> Swift.Bool
 }
 extension Swift.Array where Element == Gestures.GestureRelation {
@@ -214,16 +208,12 @@ extension Gestures.GesturePhase {
   public var isRecognized: Swift.Bool {
     get
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public var value: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var failureReason: Gestures.GestureFailureReason? {
     get
   }
-  #endif
   public func mapValue<T>(_ transform: (Value) -> T) -> Gestures.GesturePhase<T> where T : Swift.Sendable
 }
 extension Gestures.GesturePhase : Swift.CustomStringConvertible {
@@ -252,11 +242,9 @@ public enum GestureOutput<Value> : Swift.Sendable where Value : Swift.Sendable {
   case finalValue(Value, metadata: Gestures.GestureOutputMetadata?)
 }
 extension Gestures.GestureOutput {
-  #if compiler(>=5.3) && $NonescapableTypes
   public var value: Value? {
     get
   }
-  #endif
   public var isEmpty: Swift.Bool {
     get
   }
@@ -277,9 +265,7 @@ public enum GestureOutputEmptyReason : Swift.Hashable, Swift.Sendable {
 public struct GestureOutputMetadata : Swift.Sendable {
 }
 public protocol GestureNodeContainer : AnyObject, Swift.Sendable {
-  #if compiler(>=5.3) && $NonescapableTypes
   func index(of node: Gestures.AnyGestureNode) -> Swift.Int?
-  #endif
   func isDescendant(of container: any Gestures.GestureNodeContainer, referenceNode: Gestures.AnyGestureNode) -> Swift.Bool
   func isDeeper(than container: any Gestures.GestureNodeContainer, referenceNode: Gestures.AnyGestureNode) -> Swift.Bool
 }
@@ -300,9 +286,7 @@ public protocol GestureNodeDelegate<Value> : AnyObject, Swift.Sendable {
   func gestureNodeShouldActivate(_ node: Gestures.GestureNode<Self.Value>) -> Swift.Bool
   func gestureNode(_ node: Gestures.GestureNode<Self.Value>, didEnqueuePhase phase: Gestures.GesturePhase<Self.Value>)
   func gestureNode(_ node: Gestures.GestureNode<Self.Value>, didUpdatePhase newPhase: Gestures.GesturePhase<Self.Value>, oldPhase: Gestures.GesturePhase<Self.Value>)
-  #if compiler(>=5.3) && $NonescapableTypes
   func gestureNode(_ node: Gestures.GestureNode<Self.Value>, roleForRelationType type: Gestures.GestureRelationType, direction: Gestures.GestureRelationDirection, relatedNode: Gestures.AnyGestureNode) -> Gestures.GestureRelationRole?
-  #endif
 }
 public struct GestureNodeOptions : Swift.OptionSet, Swift.Sendable {
   public let rawValue: Swift.Int
@@ -355,20 +339,16 @@ extension Gestures.AnyGestureNode : Swift.Comparable {
 }
 @_inheritsConvenienceInitializers public class GestureNode<Value> : Gestures.AnyGestureNode, @unchecked Swift.Sendable where Value : Swift.Sendable {
   weak public var delegate: (any Gestures.GestureNodeDelegate<Value>)?
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(traits: Gestures.GestureTraitCollection?, tag: Gestures.GestureTag?, relations: [Gestures.GestureRelation])
-  #endif
   convenience public init()
   override public var options: Gestures.GestureNodeOptions {
     get
     set
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   override public var container: (any Gestures.GestureNodeContainer)? {
     get
     set
   }
-  #endif
   public var phase: Gestures.GesturePhase<Value> {
     get
   }
@@ -391,9 +371,7 @@ public protocol GestureComponent : Swift.Sendable {
   associatedtype Value : Swift.Sendable
   mutating func update(context: Gestures.GestureComponentContext) throws -> Gestures.GestureOutput<Self.Value>
   mutating func reset()
-  #if compiler(>=5.3) && $NonescapableTypes
   mutating func traits() -> Gestures.GestureTraitCollection?
-  #endif
   mutating func capacity<E>(for eventType: E.Type) -> Swift.Int where E : Gestures.Event
 }
 extension Gestures.CompositeGestureComponent {
@@ -427,19 +405,15 @@ public protocol CompositeGestureComponent : Gestures.GestureComponent {
 }
 extension Gestures.CompositeGestureComponent {
   public mutating func reset()
-  #if compiler(>=5.3) && $NonescapableTypes
   public mutating func traits() -> Gestures.GestureTraitCollection?
-  #endif
   public mutating func capacity<E>(for eventType: E.Type) -> Swift.Int where E : Gestures.Event
 }
 @_hasMissingDesignatedInitializers final public class GestureComponentController<Component> : Gestures.AnyGestureComponentController, @unchecked Swift.Sendable where Component : Gestures.GestureComponent {
   public init(component: Component, timeScheduler: any Gestures.TimeScheduler)
   convenience public init(component: Component)
-  #if compiler(>=5.3) && $NonescapableTypes
   override final public var traits: Gestures.GestureTraitCollection? {
     get
   }
-  #endif
   override final public var timeSource: any Gestures.TimeSource {
     get
   }
@@ -450,11 +424,9 @@ extension Gestures.CompositeGestureComponent {
 }
 @_hasMissingDesignatedInitializers open class AnyGestureComponentController : @unchecked Swift.Sendable {
   weak open var node: Gestures.AnyGestureNode?
-  #if compiler(>=5.3) && $NonescapableTypes
   open var traits: Gestures.GestureTraitCollection? {
     get
   }
-  #endif
   open var timeSource: any Gestures.TimeSource {
     get
   }
@@ -498,9 +470,7 @@ public struct GestureUpdateDriverToken : Swift.Hashable, Swift.Sendable {
   }
 }
 public protocol TimeScheduler : AnyObject, Gestures.TimeSource {
-  #if compiler(>=5.3) && $NonescapableTypes
   func schedule(after duration: Swift.Duration, handler: @escaping () -> Swift.Void, cancelHandler: (() -> Swift.Void)?) -> Gestures.TimeSchedulerToken
-  #endif
   func cancel(token: Gestures.TimeSchedulerToken)
 }
 public struct TimeSchedulerToken : Swift.Hashable, Swift.Sendable {
@@ -519,9 +489,7 @@ final public class DispatchTimeScheduler : @unchecked Swift.Sendable, Gestures.T
   final public var timestamp: Gestures.Timestamp {
     get
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   final public func schedule(after duration: Swift.Duration, handler: @escaping () -> Swift.Void, cancelHandler: (() -> Swift.Void)? = nil) -> Gestures.TimeSchedulerToken
-  #endif
   final public func cancel(token: Gestures.TimeSchedulerToken)
   @objc deinit
 }
@@ -646,8 +614,6 @@ extension Gestures.GFGestureRelationRole : Swift.CustomStringConvertible {
     get
   }
 }
-extension CoreFoundation.CGPoint : Swift.Sendable {}
-extension CoreFoundation.CGVector : Swift.Sendable {}
 extension Gestures.GestureTrait : Swift.CustomStringConvertible {}
 extension Gestures.GestureTrait : Swift.CustomDebugStringConvertible {}
 extension Gestures.GestureTraitCollection : Swift.CustomStringConvertible {}

--- a/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/x86_64-apple-macos.swiftinterface
+++ b/GF/2025/Gestures.xcframework/macos-arm64e-arm64-x86_64/Gestures.framework/Versions/A/Modules/Gestures.swiftmodule/x86_64-apple-macos.swiftinterface
@@ -1,7 +1,7 @@
 // swift-interface-format-version: 1.0
-// swift-compiler-version: Apple Swift version 6.2 effective-5.10 (swiftlang-6.2.0.16.112 clang-1800.1.29)
+// swift-compiler-version: Apple Swift version 6.3.3 effective-5.10 (swiftlang-6.3.3.1.3 clang-2100.1.1.101)
 // swift-module-flags: -target x86_64-apple-macos26.0 -enable-objc-interop -enable-library-evolution -swift-version 5 -Osize -enable-upcoming-feature InternalImportsByDefault -enable-experimental-feature Extern -module-name Gestures
-// swift-module-flags-ignorable: -interface-compiler-version 6.2
+// swift-module-flags-ignorable: -interface-compiler-version 6.3.3
 public import Dispatch
 @_exported public import Gestures
 public import Swift
@@ -25,12 +25,8 @@ public struct GestureTrait : Swift.Hashable, Swift.Identifiable, Swift.Sendable 
   public var id: Gestures.GestureTraitID
   public var attributes: [Gestures.GestureTrait.AttributeKey : Gestures.GestureTrait.AttributeValue]
   public init(id: Gestures.GestureTraitID, attributes: [Gestures.GestureTrait.AttributeKey : Gestures.GestureTrait.AttributeValue] = [:])
-  #if compiler(>=5.3) && $NonescapableTypes
   public static func tap(tapCount: Swift.Int? = nil, pointCount: Swift.Int? = nil) -> Gestures.GestureTrait
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public static func longPress(pointCount: Swift.Int? = nil, minimumDuration: Swift.Duration? = nil, maximumMovement: Swift.Double? = nil) -> Gestures.GestureTrait
-  #endif
   public static func pan() -> Gestures.GestureTrait
   public struct AttributeKey : Swift.Hashable, Swift.Sendable, Swift.CustomStringConvertible {
     public let rawValue: Swift.Int
@@ -171,9 +167,7 @@ public struct GestureRelation : Swift.Equatable, Swift.Sendable {
   public var direction: Gestures.GestureRelationDirection
   public var role: Gestures.GestureRelationRole?
   public var target: Gestures.GestureNodeMatcher
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(type: Gestures.GestureRelationType, direction: Gestures.GestureRelationDirection, role: Gestures.GestureRelationRole?, target: Gestures.GestureNodeMatcher)
-  #endif
   public static func == (a: Gestures.GestureRelation, b: Gestures.GestureRelation) -> Swift.Bool
 }
 extension Swift.Array where Element == Gestures.GestureRelation {
@@ -214,16 +208,12 @@ extension Gestures.GesturePhase {
   public var isRecognized: Swift.Bool {
     get
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   public var value: Value? {
     get
   }
-  #endif
-  #if compiler(>=5.3) && $NonescapableTypes
   public var failureReason: Gestures.GestureFailureReason? {
     get
   }
-  #endif
   public func mapValue<T>(_ transform: (Value) -> T) -> Gestures.GesturePhase<T> where T : Swift.Sendable
 }
 extension Gestures.GesturePhase : Swift.CustomStringConvertible {
@@ -252,11 +242,9 @@ public enum GestureOutput<Value> : Swift.Sendable where Value : Swift.Sendable {
   case finalValue(Value, metadata: Gestures.GestureOutputMetadata?)
 }
 extension Gestures.GestureOutput {
-  #if compiler(>=5.3) && $NonescapableTypes
   public var value: Value? {
     get
   }
-  #endif
   public var isEmpty: Swift.Bool {
     get
   }
@@ -277,9 +265,7 @@ public enum GestureOutputEmptyReason : Swift.Hashable, Swift.Sendable {
 public struct GestureOutputMetadata : Swift.Sendable {
 }
 public protocol GestureNodeContainer : AnyObject, Swift.Sendable {
-  #if compiler(>=5.3) && $NonescapableTypes
   func index(of node: Gestures.AnyGestureNode) -> Swift.Int?
-  #endif
   func isDescendant(of container: any Gestures.GestureNodeContainer, referenceNode: Gestures.AnyGestureNode) -> Swift.Bool
   func isDeeper(than container: any Gestures.GestureNodeContainer, referenceNode: Gestures.AnyGestureNode) -> Swift.Bool
 }
@@ -300,9 +286,7 @@ public protocol GestureNodeDelegate<Value> : AnyObject, Swift.Sendable {
   func gestureNodeShouldActivate(_ node: Gestures.GestureNode<Self.Value>) -> Swift.Bool
   func gestureNode(_ node: Gestures.GestureNode<Self.Value>, didEnqueuePhase phase: Gestures.GesturePhase<Self.Value>)
   func gestureNode(_ node: Gestures.GestureNode<Self.Value>, didUpdatePhase newPhase: Gestures.GesturePhase<Self.Value>, oldPhase: Gestures.GesturePhase<Self.Value>)
-  #if compiler(>=5.3) && $NonescapableTypes
   func gestureNode(_ node: Gestures.GestureNode<Self.Value>, roleForRelationType type: Gestures.GestureRelationType, direction: Gestures.GestureRelationDirection, relatedNode: Gestures.AnyGestureNode) -> Gestures.GestureRelationRole?
-  #endif
 }
 public struct GestureNodeOptions : Swift.OptionSet, Swift.Sendable {
   public let rawValue: Swift.Int
@@ -355,20 +339,16 @@ extension Gestures.AnyGestureNode : Swift.Comparable {
 }
 @_inheritsConvenienceInitializers public class GestureNode<Value> : Gestures.AnyGestureNode, @unchecked Swift.Sendable where Value : Swift.Sendable {
   weak public var delegate: (any Gestures.GestureNodeDelegate<Value>)?
-  #if compiler(>=5.3) && $NonescapableTypes
   public init(traits: Gestures.GestureTraitCollection?, tag: Gestures.GestureTag?, relations: [Gestures.GestureRelation])
-  #endif
   convenience public init()
   override public var options: Gestures.GestureNodeOptions {
     get
     set
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   override public var container: (any Gestures.GestureNodeContainer)? {
     get
     set
   }
-  #endif
   public var phase: Gestures.GesturePhase<Value> {
     get
   }
@@ -391,9 +371,7 @@ public protocol GestureComponent : Swift.Sendable {
   associatedtype Value : Swift.Sendable
   mutating func update(context: Gestures.GestureComponentContext) throws -> Gestures.GestureOutput<Self.Value>
   mutating func reset()
-  #if compiler(>=5.3) && $NonescapableTypes
   mutating func traits() -> Gestures.GestureTraitCollection?
-  #endif
   mutating func capacity<E>(for eventType: E.Type) -> Swift.Int where E : Gestures.Event
 }
 extension Gestures.CompositeGestureComponent {
@@ -427,19 +405,15 @@ public protocol CompositeGestureComponent : Gestures.GestureComponent {
 }
 extension Gestures.CompositeGestureComponent {
   public mutating func reset()
-  #if compiler(>=5.3) && $NonescapableTypes
   public mutating func traits() -> Gestures.GestureTraitCollection?
-  #endif
   public mutating func capacity<E>(for eventType: E.Type) -> Swift.Int where E : Gestures.Event
 }
 @_hasMissingDesignatedInitializers final public class GestureComponentController<Component> : Gestures.AnyGestureComponentController, @unchecked Swift.Sendable where Component : Gestures.GestureComponent {
   public init(component: Component, timeScheduler: any Gestures.TimeScheduler)
   convenience public init(component: Component)
-  #if compiler(>=5.3) && $NonescapableTypes
   override final public var traits: Gestures.GestureTraitCollection? {
     get
   }
-  #endif
   override final public var timeSource: any Gestures.TimeSource {
     get
   }
@@ -450,11 +424,9 @@ extension Gestures.CompositeGestureComponent {
 }
 @_hasMissingDesignatedInitializers open class AnyGestureComponentController : @unchecked Swift.Sendable {
   weak open var node: Gestures.AnyGestureNode?
-  #if compiler(>=5.3) && $NonescapableTypes
   open var traits: Gestures.GestureTraitCollection? {
     get
   }
-  #endif
   open var timeSource: any Gestures.TimeSource {
     get
   }
@@ -498,9 +470,7 @@ public struct GestureUpdateDriverToken : Swift.Hashable, Swift.Sendable {
   }
 }
 public protocol TimeScheduler : AnyObject, Gestures.TimeSource {
-  #if compiler(>=5.3) && $NonescapableTypes
   func schedule(after duration: Swift.Duration, handler: @escaping () -> Swift.Void, cancelHandler: (() -> Swift.Void)?) -> Gestures.TimeSchedulerToken
-  #endif
   func cancel(token: Gestures.TimeSchedulerToken)
 }
 public struct TimeSchedulerToken : Swift.Hashable, Swift.Sendable {
@@ -519,9 +489,7 @@ final public class DispatchTimeScheduler : @unchecked Swift.Sendable, Gestures.T
   final public var timestamp: Gestures.Timestamp {
     get
   }
-  #if compiler(>=5.3) && $NonescapableTypes
   final public func schedule(after duration: Swift.Duration, handler: @escaping () -> Swift.Void, cancelHandler: (() -> Swift.Void)? = nil) -> Gestures.TimeSchedulerToken
-  #endif
   final public func cancel(token: Gestures.TimeSchedulerToken)
   @objc deinit
 }
@@ -646,8 +614,6 @@ extension Gestures.GFGestureRelationRole : Swift.CustomStringConvertible {
     get
   }
 }
-extension CoreFoundation.CGPoint : Swift.Sendable {}
-extension CoreFoundation.CGVector : Swift.Sendable {}
 extension Gestures.GestureTrait : Swift.CustomStringConvertible {}
 extension Gestures.GestureTrait : Swift.CustomDebugStringConvertible {}
 extension Gestures.GestureTraitCollection : Swift.CustomStringConvertible {}

--- a/GF/generate_swiftinterface.sh
+++ b/GF/generate_swiftinterface.sh
@@ -40,7 +40,7 @@ cleanup() {
 trap cleanup EXIT
 
 # Verify Swift compiler version matches the expected version for this framework
-EXPECTED_SWIFT_VERSION="6.2" # 2024 -> 6.1, 2025 -> 6.2
+EXPECTED_SWIFT_VERSION="6.3"
 SWIFT_VERSION=$(xcrun swiftc --version 2>&1 | grep -o 'Swift version [0-9]*\.[0-9]*' | head -1 | awk '{print $3}')
 if [ "${SWIFT_VERSION}" != "${EXPECTED_SWIFT_VERSION}" ]; then
     echo "Error: expected Swift ${EXPECTED_SWIFT_VERSION} but found Swift ${SWIFT_VERSION}"

--- a/GF/update.sh
+++ b/GF/update.sh
@@ -21,9 +21,9 @@ generate_swiftinterface_header() {
     local target="$1"
     local result=""
     result+="// swift-interface-format-version: 1.0\n"
-    result+="// swift-compiler-version: Apple Swift version 6.2 effective-5.10 (swiftlang-6.2.0.16.112 clang-1800.1.29)\n"
+    result+="// swift-compiler-version: Apple Swift version 6.3.3 effective-5.10 (swiftlang-6.3.3.1.3 clang-2100.1.1.101)\n"
     result+="// swift-module-flags: -target $target -enable-objc-interop -enable-library-evolution -swift-version 5 -Osize -enable-upcoming-feature InternalImportsByDefault -enable-experimental-feature Extern -module-name Gestures\n"
-    result+="// swift-module-flags-ignorable:  -interface-compiler-version 6.2"
+    result+="// swift-module-flags-ignorable:  -interface-compiler-version 6.3.3"
 
     echo -e $result
 }

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.2
+// swift-tools-version: 6.3
 
 import PackageDescription
 


### PR DESCRIPTION
## Summary

- update package manifests to Swift tools 6.3 and example workflows to Xcode 26.6
- require the `xcode-26.6` runner label for `macos-15` example jobs
- update AttributeGraph and Gestures interface generation for Swift 6.3.3
- regenerate the AttributeGraph 2021/2024 and Gestures 2025 Swift interfaces with the updated compiler

## Impact

This keeps generated interfaces and example CI aligned with Swift 6.3.3 and Xcode 26.6. It also fixes interface regeneration that still expected Swift 6.2 after selecting the newer toolchain.

## Validation

All affected interfaces were regenerated successfully with Xcode 26.6 and Swift 6.3.3. Package manifest evaluation, shell syntax checks, and diff validation also pass.